### PR TITLE
fix(ids): prefijo propio mem_ para member (antes reutilizaba org_)

### DIFF
--- a/src/app/api/settings/team/route.ts
+++ b/src/app/api/settings/team/route.ts
@@ -72,7 +72,7 @@ export const POST = withAuth(async (session, req: Request) => {
   await db
     .insert(schema.member)
     .values({
-      id: newId("organization"),
+      id: newId("member"),
       organizationId: session.organizationId,
       userId: newUserId,
       role: "member",

--- a/src/lib/db/ids.ts
+++ b/src/lib/db/ids.ts
@@ -5,6 +5,7 @@ const nano = customAlphabet(alphabet, 20);
 
 const prefixes = {
   organization: "org",
+  member: "mem",
   contact: "ct",
   conversation: "cv",
   message: "msg",

--- a/src/server/auth/on-signup.ts
+++ b/src/server/auth/on-signup.ts
@@ -37,7 +37,7 @@ export async function onUserCreated(userId: string, userName: string) {
       slug: "principal",
     });
     await tx.insert(schema.member).values({
-      id: newId("organization"),
+      id: newId("member"),
       organizationId: orgId,
       userId,
       role: "owner",


### PR DESCRIPTION
## Qué corrige

Los registros de `member` se crean con `newId("organization")` tanto en el bootstrap (`src/server/auth/on-signup.ts`) como en Configuración → Equipo (`src/app/api/settings/team/route.ts`), por lo que sus ids salen con prefijo `org_` y son indistinguibles de los de `organization` al depurar o leer la base.

## Cambio

- `src/lib/db/ids.ts`: se agrega `member: "mem"` al registro de prefijos.
- Los dos puntos de alta usan `newId("member")`.

## Por qué es seguro

- Sin migración: los ids son `text`; el cambio solo afecta filas nuevas y nada valida el prefijo en runtime.
- Gate del repo: `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm test` 90/90 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)