### PR TITLE
Núcleo genérico: identidad BSUID, API de servicio /api/bot/* y arnés E2E

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,3 +60,13 @@ META_GRAPH_API_VERSION=v25.0
 
 # Milisegundos de agrupación de mensajes antes del turno del agente (default 6000).
 # AGENT_COALESCE_MS=6000
+
+# --- Cerebro externo (opcional) -----------------------------
+# Si en vez del agente in-process prefieres tu propio bot (un microservicio en
+# el mismo servidor), habilita la API de servicio /api/bot/* con una API key:
+# el bot marca leído + "escribiendo…", descarga adjuntos y reinicia la
+# conversación de pruebas SIN que el token de WhatsApp salga del CRM.
+# Genera una larga y aleatoria (mínimo 16 caracteres); sin ella, /api/bot/*
+# responde 401 y el CRM funciona igual con su agente propio.
+#   openssl rand -base64 32
+# BOT_API_KEY=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,11 +31,25 @@ externas: el trabajo en segundo plano (agente, Laboratorio) es in-process.
 | El canal WhatsApp (Graph API) | `src/lib/meta/` (cliente único) + `src/server/whatsapp/` |
 | Campos/tablas | `src/lib/db/schema.ts` → `pnpm db:generate` → migración nueva en `drizzle/` |
 | La ingesta/envío de mensajes | `src/server/inbox/` (ingest idempotente, send con guard de sandbox, ventana 24h) |
+| Cómo se identifica a un contacto | `src/server/inbox/identity.ts` (teléfono normalizado o `bsuid:<id>`) |
+| Conectar TU propio bot en vez del agente | `src/app/api/bot/*` + `src/server/bot/auth.ts` (X-API-Key) |
 | UI | `src/components/` + `src/app/(app)/` |
 
 Los mocks del entorno de pruebas viven en `src/app/api/dev/` (wa-mock +
 ai-mock) tras un gate único (`src/lib/dev-guard.ts`): 404 incondicional en
 producción.
+
+**Identidad de contacto**: Meta está migrando de teléfono a Business-Scoped
+User IDs, así que `from` puede no venir. La llave estable es
+`contact.wa_identity` (teléfono normalizado 521→52, o `bsuid:<id>`); `phone` es
+un atributo OPCIONAL. Nunca asumas que un contacto tiene teléfono.
+
+**Cerebro externo**: `/api/bot/*` (autenticada por `BOT_API_KEY`) deja que un
+microservicio propio conduzca la conversación sin que el token de WhatsApp
+salga del CRM: marcar leído + "escribiendo…", descargar adjuntos y reiniciar la
+conversación de pruebas. Respeta `conversation.ai_enabled`/`handoff_at` igual
+que el agente in-process. Sin la key, esa superficie responde 401 y el CRM
+funciona igual.
 
 ## Reglas de la constitución (no negociables)
 
@@ -95,7 +109,11 @@ Gate técnico:
 pnpm typecheck && pnpm lint && pnpm build && pnpm test
 ```
 
-Guiones E2E por historia en `tests/e2e/*.md`.
+Guiones E2E por historia en `tests/e2e/*.md`. Parte de ellos ya están
+automatizados: con la app viva y los mocks encendidos, `pnpm test:e2e`
+(`scripts/e2e-selftest.mjs`) los conduce contra la app real y sale distinto de
+cero si algo falla. Al agregar una historia, extiende el arnés en vez de dejar
+solo el `.md`.
 
 ## Modo Objetivo — Loop SDD
 

--- a/drizzle/0001_old_sabra.sql
+++ b/drizzle/0001_old_sabra.sql
@@ -1,0 +1,70 @@
+-- 003 Identidad resiliente de contacto (BSUID).
+-- Editada a mano sobre la generada: añade backfill + dedup para instancias con
+-- datos (en una instancia fresca los pasos de backfill son no-op). Corre en una
+-- transacción (migrator de drizzle), re-ejecutable vía IF EXISTS/IF NOT EXISTS.
+
+ALTER TABLE "contact" ADD COLUMN IF NOT EXISTS "wa_identity" text;--> statement-breakpoint
+ALTER TABLE "contact" ADD COLUMN IF NOT EXISTS "wa_user_id" text;--> statement-breakpoint
+
+-- Backfill: la identidad es el teléfono NORMALIZADO (troncal MX 521→52) — la
+-- misma regla que normalizeMx() en src/lib/meta/client.ts.
+UPDATE "contact"
+SET "wa_identity" = CASE
+  WHEN "phone" ~ '^521[0-9]{10}$' THEN '52' || substring("phone" from 4)
+  ELSE "phone"
+END
+WHERE "wa_identity" IS NULL;--> statement-breakpoint
+
+-- Dedup de colisiones post-normalización (contactos 521/52 duplicados hoy):
+-- la fila más antigua es canónica; se re-apunta lo colgado y se borra la dup.
+CREATE TEMPORARY TABLE "_contact_dedup" ON COMMIT DROP AS
+SELECT id AS dup_id, keep_id FROM (
+  SELECT id,
+         first_value(id) OVER (
+           PARTITION BY organization_id, wa_identity
+           ORDER BY created_at, id
+         ) AS keep_id
+  FROM "contact"
+) ranked
+WHERE id <> keep_id;--> statement-breakpoint
+
+-- Conversaciones no-test del duplicado cuando la canónica YA tiene una:
+-- mover los mensajes a la conversación canónica y borrar la duplicada.
+UPDATE "message" m
+SET conversation_id = ck.id
+FROM "conversation" cd
+JOIN "_contact_dedup" d ON cd.contact_id = d.dup_id
+JOIN "conversation" ck ON ck.contact_id = d.keep_id AND ck.is_test = false
+WHERE m.conversation_id = cd.id AND cd.is_test = false;--> statement-breakpoint
+
+DELETE FROM "conversation" cd
+USING "_contact_dedup" d, "conversation" ck
+WHERE cd.contact_id = d.dup_id AND cd.is_test = false
+  AND ck.contact_id = d.keep_id AND ck.is_test = false;--> statement-breakpoint
+
+-- Resto de conversaciones del duplicado (canónica sin conversación, o de test):
+-- re-apuntar a la canónica.
+UPDATE "conversation" cd
+SET contact_id = d.keep_id
+FROM "_contact_dedup" d
+WHERE cd.contact_id = d.dup_id;--> statement-breakpoint
+
+-- Leads: si ambas filas tienen lead, sobrevive el de la canónica.
+DELETE FROM "lead" l
+USING "_contact_dedup" d, "lead" lk
+WHERE l.contact_id = d.dup_id AND lk.contact_id = d.keep_id;--> statement-breakpoint
+
+UPDATE "lead" l
+SET contact_id = d.keep_id
+FROM "_contact_dedup" d
+WHERE l.contact_id = d.dup_id;--> statement-breakpoint
+
+DELETE FROM "contact" c
+USING "_contact_dedup" d
+WHERE c.id = d.dup_id;--> statement-breakpoint
+
+ALTER TABLE "contact" ALTER COLUMN "wa_identity" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "contact" ALTER COLUMN "phone" DROP NOT NULL;--> statement-breakpoint
+DROP INDEX IF EXISTS "contact_org_phone_uq";--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "contact_org_wa_identity_uq" ON "contact" USING btree ("organization_id","wa_identity");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "contact_org_wa_user_id_idx" ON "contact" USING btree ("organization_id","wa_user_id");

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1944 @@
+{
+  "id": "e5ccba31-990f-496c-8012-1f2de1a5b824",
+  "prevId": "d807d54d-7d3d-43bc-9886-8e079973791d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_profile": {
+      "name": "agent_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asistente'"
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalation_rules": {
+          "name": "escalation_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_profile_org_uq": {
+          "name": "agent_profile_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_profile_organization_id_organization_id_fk": {
+          "name": "agent_profile_organization_id_organization_id_fk",
+          "tableFrom": "agent_profile",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_case": {
+      "name": "agent_test_case",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "veredicto": {
+          "name": "veredicto",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hallazgos": {
+          "name": "hallazgos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_case_run_idx": {
+          "name": "test_case_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_case_organization_id_organization_id_fk": {
+          "name": "agent_test_case_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_run_id_agent_test_run_id_fk": {
+          "name": "agent_test_case_run_id_agent_test_run_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "agent_test_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_conversation_id_conversation_id_fk": {
+          "name": "agent_test_case_conversation_id_conversation_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_run": {
+      "name": "agent_test_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "test_run_org_running_uq": {
+          "name": "test_run_org_running_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_test_run\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_run_org_idx": {
+          "name": "test_run_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_run_organization_id_organization_id_fk": {
+          "name": "agent_test_run_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact": {
+      "name": "contact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_identity": {
+          "name": "wa_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_user_id": {
+          "name": "wa_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_org_wa_identity_uq": {
+          "name": "contact_org_wa_identity_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_wa_user_id_idx": {
+          "name": "contact_org_wa_user_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_name_idx": {
+          "name": "contact_org_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_organization_id_organization_id_fk": {
+          "name": "contact_organization_id_organization_id_fk",
+          "tableFrom": "contact",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_test": {
+          "name": "is_test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ai_enabled": {
+          "name": "ai_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handoff_at": {
+          "name": "handoff_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_reason": {
+          "name": "handoff_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_inbound_at": {
+          "name": "last_inbound_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_org_contact_real_uq": {
+          "name": "conversation_org_contact_real_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation\".\"is_test\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_org_last_idx": {
+          "name": "conversation_org_last_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_organization_id_organization_id_fk": {
+          "name": "conversation_organization_id_organization_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_contact_id_contact_id_fk": {
+          "name": "conversation_contact_id_contact_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_entry": {
+      "name": "kb_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kb_org_idx": {
+          "name": "kb_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_entry_organization_id_organization_id_fk": {
+          "name": "kb_entry_organization_id_organization_id_fk",
+          "tableFrom": "kb_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead": {
+      "name": "lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lead_contact_uq": {
+          "name": "lead_contact_uq",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lead_org_stage_idx": {
+          "name": "lead_org_stage_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_organization_id_organization_id_fk": {
+          "name": "lead_organization_id_organization_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_contact_id_contact_id_fk": {
+          "name": "lead_contact_id_contact_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_message_id": {
+          "name": "wa_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated": {
+          "name": "ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "wa_timestamp": {
+          "name": "wa_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_org_conv_idx": {
+          "name": "message_org_conv_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_organization_id_organization_id_fk": {
+          "name": "message_organization_id_organization_id_fk",
+          "tableFrom": "message",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_wa_message_id_unique": {
+          "name": "message_wa_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wa_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_credentials": {
+      "name": "meta_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waba_id": {
+          "name": "waba_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number_id": {
+          "name": "phone_number_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_phone_number": {
+          "name": "display_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_name": {
+          "name": "verified_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_cipher": {
+          "name": "token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meta_credentials_org_uq": {
+          "name": "meta_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meta_credentials_phone_uq": {
+          "name": "meta_credentials_phone_uq",
+          "columns": [
+            {
+              "expression": "phone_number_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meta_credentials_organization_id_organization_id_fk": {
+          "name": "meta_credentials_organization_id_organization_id_fk",
+          "tableFrom": "meta_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_stage": {
+      "name": "pipeline_stage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stage_org_pos_idx": {
+          "name": "stage_org_pos_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_stage_organization_id_organization_id_fk": {
+          "name": "pipeline_stage_organization_id_organization_id_fk",
+          "tableFrom": "pipeline_stage",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_template_id": {
+          "name": "wa_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_org_name_lang_uq": {
+          "name": "template_org_name_lang_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_organization_id_organization_id_fk": {
+          "name": "template_organization_id_organization_id_fk",
+          "tableFrom": "template",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1783657511753,
       "tag": "0000_absurd_the_santerians",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1785464517783,
+      "tag": "0001_old_sabra",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:e2e": "node --env-file=.env scripts/e2e-selftest.mjs",
     "test:watch": "vitest",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",

--- a/scripts/e2e-selftest.mjs
+++ b/scripts/e2e-selftest.mjs
@@ -1,0 +1,308 @@
+/**
+ * Self-test E2E de comportamiento — conduce la app real en localhost con los
+ * mocks (wa-mock + ai-mock) por las superficies de usuario, en vez de darle
+ * el guion al humano. Cubre tests/e2e/us-bsuid.md y tests/e2e/us-bot-api.md.
+ *
+ * Uso:
+ *   1) app corriendo con WA_MOCK_ENABLED=true, META_GRAPH_BASE_URL → wa-mock,
+ *      BOT_API_KEY configurada y BD migrada
+ *   2) node --env-file=.env scripts/e2e-selftest.mjs
+ *
+ * Sale con código 1 si algún check falla (apto para CI o para el gate previo
+ * a declarar "Hecho").
+ */
+
+const BASE = process.env.APP_BASE_URL ?? "http://localhost:3000";
+const BOT_KEY = process.env.BOT_API_KEY;
+
+let cookie = "";
+let failures = 0;
+let checks = 0;
+
+function ok(name, cond, extra = "") {
+  checks++;
+  if (cond) {
+    console.log(`  OK  ${name}`);
+  } else {
+    failures++;
+    console.log(`  FAIL ${name}${extra ? ` — ${extra}` : ""}`);
+  }
+}
+
+async function api(path, opts = {}) {
+  const res = await fetch(`${BASE}${path}`, {
+    ...opts,
+    headers: {
+      "content-type": "application/json",
+      // Better Auth valida Origin (CSRF) en los endpoints de auth.
+      origin: BASE,
+      ...(cookie ? { cookie } : {}),
+      ...(opts.headers ?? {}),
+    },
+  });
+  const setCookie = res.headers.getSetCookie?.() ?? [];
+  if (setCookie.length) {
+    cookie = setCookie.map((c) => c.split(";")[0]).join("; ");
+  }
+  let json = null;
+  try {
+    json = await res.clone().json();
+  } catch {}
+  return { res, json };
+}
+
+function bot(path, opts = {}) {
+  return api(path, {
+    ...opts,
+    headers: { "x-api-key": BOT_KEY ?? "", ...(opts.headers ?? {}) },
+  });
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const PN = "PN-E2E-1";
+
+async function main() {
+  if (!BOT_KEY || BOT_KEY.length < 16) {
+    console.error(
+      "BOT_API_KEY ausente o corta (<16): los checks de /api/bot/* no pueden correr."
+    );
+    process.exit(1);
+  }
+
+  console.log("== Setup: registro/login + conexión WhatsApp ==");
+  const email = "e2e@vocero.test";
+  const password = "password-e2e-123";
+  let su = await api("/api/auth/sign-up/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password, name: "Operador E2E" }),
+  });
+  if (!su.res.ok) {
+    // Re-corrida: el registro se cierra tras la primera organización.
+    su = await api("/api/auth/sign-in/email", {
+      method: "POST",
+      body: JSON.stringify({ email, password }),
+    });
+  }
+  ok("registro o login del operador", su.res.ok, JSON.stringify(su.json));
+
+  const conn = await api("/api/settings/whatsapp", {
+    method: "PUT",
+    body: JSON.stringify({
+      wabaId: "WABA-E2E",
+      phoneNumberId: PN,
+      token: "tok-e2e",
+    }),
+  });
+  ok(
+    "conexión WhatsApp guardada (vía wa-mock)",
+    conn.res.ok,
+    JSON.stringify(conn.json)
+  );
+  await api("/api/dev/wa-mock/outbox", { method: "DELETE" });
+
+  console.log("\n== us-bsuid: inbound sin wa_id ==");
+  const inb1 = await api("/api/dev/wa-mock/inbound", {
+    method: "POST",
+    body: JSON.stringify({
+      phoneNumberId: PN,
+      fromUserId: "bsu_e2e_1",
+      name: "Dueña Dental",
+      text: "hola, vi su anuncio",
+      waMessageId: "wamid.e2e.bsuid.1",
+    }),
+  });
+  ok("inbound BSUID entregado", inb1.res.ok, JSON.stringify(inb1.json));
+  await sleep(1200);
+
+  let convs = (await api("/api/conversations")).json?.conversations ?? [];
+  const bsuidConv = convs.find((c) => c.contact.name === "Dueña Dental");
+  ok("conversación con nombre de perfil (no el BSUID crudo)", !!bsuidConv);
+  ok("contacto BSUID sin teléfono", bsuidConv?.contact.phone === null);
+
+  const reply = await api(`/api/conversations/${bsuidConv?.id}/messages`, {
+    method: "POST",
+    body: JSON.stringify({ text: "¡Hola! Te atendemos enseguida" }),
+  });
+  ok("respuesta a contacto BSUID enviable", reply.res.ok, JSON.stringify(reply.json));
+
+  const outbox = (await api("/api/dev/wa-mock/outbox")).json?.outbox ?? [];
+  ok(
+    "el destinatario del envío es el BSUID",
+    outbox.some((o) => o.to === "bsu_e2e_1"),
+    JSON.stringify(outbox.map((o) => o.to))
+  );
+
+  // Idempotencia: re-entrega del mismo wa_message_id
+  await api("/api/dev/wa-mock/inbound", {
+    method: "POST",
+    body: JSON.stringify({
+      phoneNumberId: PN,
+      fromUserId: "bsu_e2e_1",
+      name: "Dueña Dental",
+      text: "hola, vi su anuncio",
+      waMessageId: "wamid.e2e.bsuid.1",
+    }),
+  });
+  await sleep(800);
+  const msgs =
+    (await api(`/api/conversations/${bsuidConv?.id}/messages`)).json?.messages ??
+    [];
+  const inCount = msgs.filter((m) => m.direction === "in").length;
+  ok("webhook duplicado no duplica mensajes", inCount === 1, `in=${inCount}`);
+
+  console.log("\n== us-bsuid: reconciliación 521/52 ==");
+  await api("/api/dev/wa-mock/inbound", {
+    method: "POST",
+    body: JSON.stringify({
+      phoneNumberId: PN,
+      from: "5214621349768",
+      name: "Kevin MX",
+      text: "uno",
+    }),
+  });
+  await sleep(800);
+  await api("/api/dev/wa-mock/inbound", {
+    method: "POST",
+    body: JSON.stringify({ phoneNumberId: PN, from: "524621349768", text: "dos" }),
+  });
+  await sleep(800);
+  const contacts =
+    (await api("/api/contacts?q=Kevin%20MX")).json?.contacts ?? [];
+  ok(
+    "521 y 52 resuelven a UN solo contacto",
+    contacts.length === 1,
+    `n=${contacts.length}`
+  );
+
+  const mxConv = ((await api("/api/conversations")).json?.conversations ?? []).find(
+    (c) => c.contact.name === "Kevin MX"
+  );
+  ok("el contacto reconciliado conserva su conversación", !!mxConv);
+
+  console.log("\n== us-bot-api: autorización ==");
+  const noKey = await api("/api/bot/media/media123");
+  ok("media sin API key → 401", noKey.res.status === 401);
+  const badKey = await api("/api/bot/media/media123", {
+    headers: { "x-api-key": "x".repeat(BOT_KEY.length) },
+  });
+  ok("media con API key equivocada → 401", badKey.res.status === 401);
+  const resetNoKey = await api("/api/bot/reset", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: mxConv?.id }),
+  });
+  ok("reset sin API key → 401", resetNoKey.res.status === 401);
+
+  console.log("\n== us-bot-api: typing + leído ==");
+  const convId = mxConv?.id;
+  const outboxBeforeTyping =
+    ((await api("/api/dev/wa-mock/outbox")).json?.outbox ?? []).length;
+  const typ = await bot("/api/bot/typing", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId }),
+  });
+  ok(
+    "POST /api/bot/typing → ok:true (leído + escribiendo…)",
+    typ.res.ok && typ.json?.ok === true,
+    JSON.stringify(typ.json)
+  );
+  const outboxAfterTyping =
+    ((await api("/api/dev/wa-mock/outbox")).json?.outbox ?? []).length;
+  ok(
+    "typing NO contamina el outbox",
+    outboxAfterTyping === outboxBeforeTyping,
+    `antes=${outboxBeforeTyping} después=${outboxAfterTyping}`
+  );
+
+  const typ404 = await bot("/api/bot/typing", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: "cv_no_existe" }),
+  });
+  ok("typing con conversación inexistente → 404", typ404.res.status === 404);
+
+  console.log("\n== us-bot-api: media proxy ==");
+  const med = await bot("/api/bot/media/media123");
+  const medBytes = med.res.ok ? await med.res.arrayBuffer() : new ArrayBuffer(0);
+  ok(
+    "GET /api/bot/media/{id} → binario con content-type",
+    med.res.ok &&
+      medBytes.byteLength > 0 &&
+      (med.res.headers.get("content-type") ?? "").includes("image"),
+    `status=${med.res.status} bytes=${medBytes.byteLength}`
+  );
+  const medBad = await bot("/api/bot/media/no-es-media");
+  ok(
+    "mediaId que Graph no reconoce → error tipado, no 500",
+    medBad.res.status === 404 || medBad.res.status === 502,
+    `status=${medBad.res.status}`
+  );
+
+  console.log("\n== us-bot-api: IA pausada y reset ==");
+  const pause = await api(`/api/conversations/${convId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ aiEnabled: false }),
+  });
+  ok("IA pausada desde la bandeja", pause.res.ok, JSON.stringify(pause.json));
+
+  const typPaused = await bot("/api/bot/typing", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId }),
+  });
+  ok(
+    "typing con IA pausada → ok:false ai_paused (no toca Meta)",
+    typPaused.res.ok &&
+      typPaused.json?.ok === false &&
+      typPaused.json?.reason === "ai_paused",
+    JSON.stringify(typPaused.json)
+  );
+
+  const msgsBeforeReset =
+    ((await api(`/api/conversations/${convId}/messages`)).json?.messages ?? [])
+      .length;
+  const rst = await bot("/api/bot/reset", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId }),
+  });
+  ok(
+    "POST /api/bot/reset → ok:true",
+    rst.res.ok && rst.json?.ok === true,
+    JSON.stringify(rst.json)
+  );
+  await sleep(400);
+  convs = (await api("/api/conversations")).json?.conversations ?? [];
+  const afterReset = convs.find((c) => c.id === convId);
+  ok(
+    "reset reactiva la IA (sale del handoff)",
+    afterReset?.aiEnabled === true && !afterReset?.handoffAt,
+    JSON.stringify({
+      aiEnabled: afterReset?.aiEnabled,
+      handoffAt: afterReset?.handoffAt,
+    })
+  );
+  const msgsAfterReset =
+    ((await api(`/api/conversations/${convId}/messages`)).json?.messages ?? [])
+      .length;
+  ok(
+    "el reset conserva el historial (auditoría)",
+    msgsAfterReset === msgsBeforeReset,
+    `antes=${msgsBeforeReset} después=${msgsAfterReset}`
+  );
+
+  const stages = (await api("/api/pipeline/stages")).json?.stages ?? [];
+  const firstStage = [...stages].sort((a, b) => a.position - b.position)[0];
+  const detail = (await api(`/api/contacts/${afterReset?.contact.id}`)).json;
+  ok(
+    "reset regresa el lead a la primera etapa",
+    !detail?.lead || detail?.stage?.id === firstStage?.id,
+    `etapa=${detail?.stage?.name} esperada=${firstStage?.name}`
+  );
+
+  console.log(
+    `\n===== ${checks - failures}/${checks} checks OK, ${failures} fallos =====`
+  );
+  process.exit(failures > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("ERROR FATAL:", err);
+  process.exit(1);
+});

--- a/src/app/api/bot/media/[mediaId]/route.ts
+++ b/src/app/api/bot/media/[mediaId]/route.ts
@@ -1,0 +1,95 @@
+import { apiError } from "@/lib/api";
+import { requireBotKey, resolveInstanceOrg } from "@/server/bot/auth";
+import { getCredentialsByOrg } from "@/server/whatsapp/credentials";
+import { graphRequest, MetaApiError } from "@/lib/meta/client";
+
+export const dynamic = "force-dynamic";
+
+/** Límite de adjuntos de la Cloud API. */
+const MAX_MEDIA_BYTES = 16 * 1024 * 1024;
+
+type MediaMeta = {
+  url?: string;
+  mime_type?: string;
+  file_size?: number;
+};
+
+/**
+ * Descarga de un adjunto de Meta para un cerebro externo.
+ * GET /api/bot/media/{mediaId} → binario + content-type.
+ *
+ * El token de WhatsApp NO sale del CRM: el bot pide aquí, jamás a Meta.
+ * Flujo Graph: GET {mediaId} → url efímera → GET url con Bearer.
+ */
+export async function GET(
+  req: Request,
+  ctx: { params: Promise<{ mediaId: string }> }
+) {
+  const denied = requireBotKey(req);
+  if (denied) return denied;
+
+  const organizationId = await resolveInstanceOrg();
+  if (!organizationId) {
+    return apiError(409, "no_org", "La instancia aún no tiene organización");
+  }
+  const creds = await getCredentialsByOrg(organizationId);
+  if (!creds) {
+    return apiError(409, "no_connection", "WhatsApp no está conectado");
+  }
+
+  const { mediaId } = await ctx.params;
+  if (!/^[\w.-]{1,64}$/.test(mediaId)) {
+    return apiError(422, "invalid", "mediaId inválido");
+  }
+
+  let meta: MediaMeta;
+  try {
+    meta = await graphRequest<MediaMeta>(mediaId, { token: creds.token });
+  } catch (err) {
+    const status = err instanceof MetaApiError && err.status === 404 ? 404 : 502;
+    return apiError(
+      status,
+      "media_meta_failed",
+      "Meta no entregó la metadata del adjunto"
+    );
+  }
+  if (!meta.url) {
+    return apiError(502, "media_meta_failed", "Meta no entregó URL del adjunto");
+  }
+  if (meta.file_size && meta.file_size > MAX_MEDIA_BYTES) {
+    return apiError(413, "too_large", "El adjunto excede el límite de 16 MB");
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(meta.url, {
+      headers: { Authorization: `Bearer ${creds.token}` },
+    });
+  } catch {
+    return apiError(
+      502,
+      "media_download_failed",
+      "No se pudo descargar el adjunto"
+    );
+  }
+  if (!res.ok) {
+    return apiError(
+      502,
+      "media_download_failed",
+      `La descarga devolvió ${res.status}`
+    );
+  }
+  const buf = await res.arrayBuffer();
+  if (buf.byteLength > MAX_MEDIA_BYTES) {
+    return apiError(413, "too_large", "El adjunto excede el límite de 16 MB");
+  }
+  return new Response(buf, {
+    headers: {
+      "content-type":
+        meta.mime_type ??
+        res.headers.get("content-type") ??
+        "application/octet-stream",
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/src/app/api/bot/reset/route.ts
+++ b/src/app/api/bot/reset/route.ts
@@ -1,0 +1,91 @@
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { getDb, schema } from "@/lib/db";
+import { apiError, parseBody } from "@/lib/api";
+import { requireBotKey, resolveInstanceOrg } from "@/server/bot/auth";
+import { publish } from "@/server/events/bus";
+
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({
+  conversationId: z.string().min(1),
+});
+
+/**
+ * Reinicio de UNA conversación para la línea de pruebas del operador: IA
+ * reactivada (sale del handoff) y lead de vuelta a la primera etapa. El
+ * historial del inbox NO se borra: es auditoría. Lo invoca el cerebro externo
+ * cuando un número de su allowlist manda `/reset`.
+ */
+export async function POST(req: Request) {
+  const denied = requireBotKey(req);
+  if (denied) return denied;
+
+  const organizationId = await resolveInstanceOrg();
+  if (!organizationId) {
+    return apiError(409, "no_org", "La instancia aún no tiene organización");
+  }
+
+  const body = await parseBody(req, bodySchema);
+  if (!body.ok) return body.response;
+
+  const db = getDb();
+  const rows = await db
+    .select({
+      id: schema.conversation.id,
+      contactId: schema.conversation.contactId,
+    })
+    .from(schema.conversation)
+    .where(
+      and(
+        eq(schema.conversation.organizationId, organizationId),
+        eq(schema.conversation.id, body.data.conversationId)
+      )
+    )
+    .limit(1);
+  const conv = rows[0];
+  if (!conv) return apiError(404, "not_found", "Conversación no encontrada");
+
+  await db
+    .update(schema.conversation)
+    .set({
+      aiEnabled: true,
+      handoffAt: null,
+      handoffReason: null,
+      updatedAt: new Date(),
+    })
+    .where(eq(schema.conversation.id, conv.id));
+
+  // Etapa al inicio del funnel (best-effort: sin etapas no revienta el reset).
+  try {
+    const stages = await db
+      .select()
+      .from(schema.pipelineStage)
+      .where(eq(schema.pipelineStage.organizationId, organizationId));
+    const first = [...stages].sort((a, b) => a.position - b.position)[0];
+    const leadRows = await db
+      .select({ id: schema.lead.id })
+      .from(schema.lead)
+      .where(
+        and(
+          eq(schema.lead.organizationId, organizationId),
+          eq(schema.lead.contactId, conv.contactId)
+        )
+      )
+      .limit(1);
+    if (first && leadRows[0]) {
+      await db
+        .update(schema.lead)
+        .set({ stageId: first.id, updatedAt: new Date() })
+        .where(eq(schema.lead.id, leadRows[0].id));
+    }
+  } catch (err) {
+    console.warn(`[bot/reset] reinicio de etapa falló: ${err}`);
+  }
+
+  publish(organizationId, {
+    type: "conversation.updated",
+    data: { conversation: { id: conv.id } },
+  });
+  return Response.json({ ok: true });
+}

--- a/src/app/api/bot/typing/route.ts
+++ b/src/app/api/bot/typing/route.ts
@@ -1,0 +1,91 @@
+import { and, desc, eq, isNotNull } from "drizzle-orm";
+import { z } from "zod";
+import { getDb, schema } from "@/lib/db";
+import { apiError, parseBody } from "@/lib/api";
+import { requireBotKey, resolveInstanceOrg } from "@/server/bot/auth";
+import { getCredentialsByOrg } from "@/server/whatsapp/credentials";
+import { graphRequest } from "@/lib/meta/client";
+
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({ conversationId: z.string().min(1) });
+
+/**
+ * Indicador "escribiendo…" + marcar leído el último inbound.
+ * POST /api/bot/typing {conversationId}
+ *
+ * Best-effort por contrato: al bot JAMÁS le vale reintentar esto — si Meta
+ * falla se responde 200 {ok:false} y la conversación sigue. El indicador
+ * dura hasta ~25 s o hasta que llegue la respuesta real.
+ */
+export async function POST(req: Request) {
+  const denied = requireBotKey(req);
+  if (denied) return denied;
+
+  const organizationId = await resolveInstanceOrg();
+  if (!organizationId) {
+    return apiError(409, "no_org", "La instancia aún no tiene organización");
+  }
+  const body = await parseBody(req, bodySchema);
+  if (!body.ok) return body.response;
+
+  const db = getDb();
+  const convs = await db
+    .select()
+    .from(schema.conversation)
+    .where(
+      and(
+        eq(schema.conversation.organizationId, organizationId),
+        eq(schema.conversation.id, body.data.conversationId)
+      )
+    )
+    .limit(1);
+  const conv = convs[0];
+  if (!conv) return apiError(404, "not_found", "Conversación no encontrada");
+  if (conv.isTest) {
+    // Sandbox: jamás toca la API real (guardrail del Laboratorio).
+    return Response.json({ ok: false, reason: "sandbox" });
+  }
+  if (!conv.aiEnabled || conv.handoffAt) {
+    // Handoff/IA pausada: un humano atiende — "escribiendo…" aquí sería
+    // mentirle al cliente. Se omite sin tocar Meta.
+    return Response.json({ ok: false, reason: "ai_paused" });
+  }
+
+  const msgs = await db
+    .select({ waMessageId: schema.message.waMessageId })
+    .from(schema.message)
+    .where(
+      and(
+        eq(schema.message.organizationId, organizationId),
+        eq(schema.message.conversationId, conv.id),
+        eq(schema.message.direction, "in"),
+        isNotNull(schema.message.waMessageId)
+      )
+    )
+    .orderBy(desc(schema.message.createdAt))
+    .limit(1);
+  const wamid = msgs[0]?.waMessageId;
+  if (!wamid) return Response.json({ ok: false, reason: "no_inbound" });
+
+  const creds = await getCredentialsByOrg(organizationId);
+  if (!creds) {
+    return apiError(409, "no_connection", "WhatsApp no está conectado");
+  }
+
+  try {
+    await graphRequest(`${creds.phoneNumberId}/messages`, {
+      method: "POST",
+      token: creds.token,
+      body: {
+        messaging_product: "whatsapp",
+        status: "read",
+        message_id: wamid,
+        typing_indicator: { type: "text" },
+      },
+    });
+    return Response.json({ ok: true });
+  } catch {
+    return Response.json({ ok: false, reason: "meta_error" });
+  }
+}

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -4,6 +4,7 @@ import { apiError, parseBody, withAuth } from "@/lib/api";
 import { getDb, schema } from "@/lib/db";
 import { newId } from "@/lib/db/ids";
 import { scoped } from "@/lib/db/tenant";
+import { normalizeMx } from "@/lib/meta/client";
 import { serializeContact } from "@/server/contacts";
 
 export const dynamic = "force-dynamic";
@@ -52,17 +53,20 @@ export const POST = withAuth(async (session, req: Request) => {
   if (!body.ok) return body.response;
 
   const db = getDb();
+  // 003: la identidad WhatsApp se deriva del teléfono normalizado.
+  const phone = normalizeMx(body.data.phone);
   const inserted = await db
     .insert(schema.contact)
     .values({
       id: newId("contact"),
       organizationId: session.organizationId,
       name: body.data.name,
-      phone: body.data.phone,
+      phone,
+      waIdentity: phone,
       notes: body.data.notes ?? null,
     })
     .onConflictDoNothing({
-      target: [schema.contact.organizationId, schema.contact.phone],
+      target: [schema.contact.organizationId, schema.contact.waIdentity],
     })
     .returning();
   if (!inserted[0]) {

--- a/src/app/api/dev/wa-mock/graph/[...path]/route.ts
+++ b/src/app/api/dev/wa-mock/graph/[...path]/route.ts
@@ -60,6 +60,17 @@ export async function GET(req: Request, ctx: Params) {
     });
   }
 
+  // GET {mediaId} (ids "media...") → metadata de adjunto (media proxy del bot)
+  if (path.length === 1 && path[0]!.startsWith("media")) {
+    const origin = new URL(req.url).origin;
+    return Response.json({
+      id: path[0],
+      mime_type: path[0]!.includes("pdf") ? "application/pdf" : "image/jpeg",
+      file_size: 13,
+      url: `${origin}/api/dev/wa-mock/media-file/${path[0]}`,
+    });
+  }
+
   // GET {phoneNumberId}?fields=... → validación del wizard
   if (path.length === 1) {
     return Response.json({
@@ -80,6 +91,12 @@ export async function POST(req: Request, ctx: Params) {
   if (token.endsWith("-invalid")) return invalidTokenResponse();
 
   const body = (await req.json().catch(() => ({}))) as Record<string, unknown>;
+
+  // POST {phoneNumberId}/messages con status:"read" → typing/leído:
+  // NO es un mensaje saliente — no contamina el outbox.
+  if (path.length === 2 && path[1] === "messages" && body.status === "read") {
+    return Response.json({ success: true });
+  }
 
   // POST {phoneNumberId}/messages → registra en el outbox
   if (path.length === 2 && path[1] === "messages") {

--- a/src/app/api/dev/wa-mock/inbound/route.ts
+++ b/src/app/api/dev/wa-mock/inbound/route.ts
@@ -9,15 +9,21 @@ import {
 
 export const dynamic = "force-dynamic";
 
-const schema = z.object({
-  phoneNumberId: z.string().min(1),
-  from: z.string().min(5),
-  name: z.string().optional(),
-  type: z.string().optional(),
-  text: z.string().optional(),
-  waMessageId: z.string().optional(),
-  timestamp: z.number().optional(),
-});
+const schema = z
+  .object({
+    phoneNumberId: z.string().min(1),
+    /** Teléfono; omítelo (con fromUserId) para simular un inbound BSUID (003). */
+    from: z.string().min(5).optional(),
+    fromUserId: z.string().min(3).optional(),
+    name: z.string().optional(),
+    type: z.string().optional(),
+    text: z.string().optional(),
+    waMessageId: z.string().optional(),
+    timestamp: z.number().optional(),
+  })
+  .refine((v) => v.from || v.fromUserId, {
+    message: "Se requiere from o fromUserId",
+  });
 
 export async function POST(req: Request) {
   const guard = mockGuard();

--- a/src/app/api/dev/wa-mock/media-file/[id]/route.ts
+++ b/src/app/api/dev/wa-mock/media-file/[id]/route.ts
@@ -1,0 +1,22 @@
+import { mockGuard } from "@/lib/dev-guard";
+
+/**
+ * Binario de prueba del wa-mock (media proxy del bot). La metadata del mock de
+ * Graph apunta aquí como la "url" efímera del adjunto.
+ */
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ id: string }> }
+) {
+  const guard = mockGuard();
+  if (guard) return guard;
+  const { id } = await ctx.params;
+  const isPdf = id.includes("pdf");
+  return new Response(Buffer.from("wa-mock-media"), {
+    headers: {
+      "content-type": isPdf ? "application/pdf" : "image/jpeg",
+    },
+  });
+}

--- a/src/components/inbox/contact-panel.tsx
+++ b/src/components/inbox/contact-panel.tsx
@@ -45,8 +45,10 @@ export function ContactPanel({
   const contactId = conversation.contact.id;
 
   const agentReady = aiConfigured && agentEnabled;
-  const aiActive =
-    agentReady && conversation.aiEnabled && !conversation.handoffAt;
+  // El control es la FUENTE DE VERDAD de la conversación: el agente in-process
+  // y cualquier cerebro externo conectado por /api/bot/* respetan este flag,
+  // así que el toggle opera siempre — `agentReady` solo matiza el texto.
+  const aiActive = conversation.aiEnabled && !conversation.handoffAt;
 
   // Carga inicial (incluye notas): se re-ejecuta al cambiar de contacto.
   const refetch = useCallback(async () => {
@@ -163,7 +165,6 @@ export function ContactPanel({
                 size="sm"
                 variant="outline"
                 className="mt-2 w-full"
-                disabled={!agentReady}
                 onClick={() => void onPatchConversation({ reactivate: true })}
               >
                 Reactivar IA
@@ -176,30 +177,27 @@ export function ContactPanel({
               <div className="min-w-0">
                 <p className="text-[13px] font-medium">IA en esta conversación</p>
                 <p className="text-[11px] text-text-3">
-                  {!agentReady
-                    ? "Agente sin activar"
-                    : conversation.handoffAt
-                      ? "En pausa · atención humana"
-                      : conversation.aiEnabled
+                  {conversation.handoffAt
+                    ? "En pausa · atención humana"
+                    : !conversation.aiEnabled
+                      ? "En pausa"
+                      : agentReady
                         ? "Respondiendo"
-                        : "En pausa"}
+                        : "Activada"}
                 </p>
               </div>
               <button
                 role="switch"
                 aria-checked={aiActive}
                 aria-label="IA en esta conversación"
-                disabled={!agentReady}
                 onClick={() => {
-                  if (!agentReady) return;
                   void onPatchConversation({
                     aiEnabled: !conversation.aiEnabled,
                   });
                 }}
                 className={cn(
                   "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full px-0.5 transition-colors",
-                  aiActive ? "bg-brand" : "bg-border-strong",
-                  !agentReady && "cursor-not-allowed opacity-60"
+                  aiActive ? "bg-brand" : "bg-border-strong"
                 )}
               >
                 <span
@@ -219,8 +217,8 @@ export function ContactPanel({
                 />
                 <p className="text-[11px] leading-relaxed text-[#8a6d3b]">
                   {aiConfigured
-                    ? "La IA todavía no responde por su cuenta. Configura lo básico del agente y enciéndelo."
-                    : "Falta la clave de IA de la instancia (OPENROUTER_API_TOKEN) para que el agente pueda responder."}
+                    ? "El agente de Vocero no responde por su cuenta. Configura lo básico y enciéndelo (o conecta tu propio bot por la API)."
+                    : "Falta la clave de IA de la instancia (OPENROUTER_API_TOKEN) para que el agente responda, o conecta tu propio bot por la API."}
                   {aiConfigured && (
                     <Link
                       href="/agent"

--- a/src/components/inbox/conversation-list.tsx
+++ b/src/components/inbox/conversation-list.tsx
@@ -73,7 +73,7 @@ export function ConversationList({
     ? conversations.filter(
         (c) =>
           c.contact.name.toLowerCase().includes(q) ||
-          c.contact.phone.includes(q) ||
+          (c.contact.phone ?? "").includes(q) ||
           (c.preview ?? "").toLowerCase().includes(q)
       )
     : conversations;

--- a/src/components/inbox/inbox-client.tsx
+++ b/src/components/inbox/inbox-client.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { PanelRight } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { cn, formatPhone } from "@/lib/utils";
 import { ContactAvatar } from "@/components/avatar";
 import type { ConversationDto, MessageDto } from "@/lib/types";
 import { useEvents } from "@/components/use-events";
@@ -190,7 +190,7 @@ export function InboxClient() {
                   >
                     {selected.windowOpen
                       ? "ventana abierta"
-                      : `+${selected.contact.phone}`}
+                      : formatPhone(selected.contact.phone)}
                   </p>
                 </div>
               </div>

--- a/src/components/pipeline/pipeline-client.tsx
+++ b/src/components/pipeline/pipeline-client.tsx
@@ -26,7 +26,7 @@ export type BoardLead = {
   stageId: string;
   position: number;
   lastActivityAt: string | null;
-  contact: { id: string; name: string; phone: string };
+  contact: { id: string; name: string; phone: string | null };
   conversationId: string | null;
 };
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -111,7 +111,15 @@ export const contact = pgTable(
     organizationId: text("organization_id")
       .notNull()
       .references(() => organization.id, { onDelete: "cascade" }),
-    phone: text("phone").notNull(),
+    /**
+     * Llave de resolución WhatsApp (003): teléfono normalizado (521→52) o
+     * `bsuid:<id>` cuando Meta no manda wa_id. Estable de por vida.
+     */
+    waIdentity: text("wa_identity").notNull(),
+    /** Teléfono como ATRIBUTO opcional (003): falta en contactos BSUID. */
+    phone: text("phone"),
+    /** Business-Scoped User ID si se conoce (003). */
+    waUserId: text("wa_user_id"),
     name: text("name").notNull(),
     notes: text("notes"),
     archivedAt: timestamp("archived_at"),
@@ -119,7 +127,8 @@ export const contact = pgTable(
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
   },
   (t) => [
-    uniqueIndex("contact_org_phone_uq").on(t.organizationId, t.phone),
+    uniqueIndex("contact_org_wa_identity_uq").on(t.organizationId, t.waIdentity),
+    index("contact_org_wa_user_id_idx").on(t.organizationId, t.waUserId),
     index("contact_org_name_idx").on(t.organizationId, t.name),
   ]
 );

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -29,6 +29,9 @@ const envSchema = z.object({
   ALLOW_SIGNUP: z.string().optional(),
   AGENT_COALESCE_MS: z.coerce.number().int().min(0).default(6000),
   WA_MOCK_ENABLED: z.string().optional(),
+  // API key de un cerebro externo que conduzca la conversación por /api/bot/*.
+  // Sin ella, toda esa superficie responde 401.
+  BOT_API_KEY: z.string().optional(),
   NODE_ENV: z.string().default("development"),
 });
 

--- a/src/lib/meta/client.ts
+++ b/src/lib/meta/client.ts
@@ -83,14 +83,20 @@ export async function graphRequest<T>(
 }
 
 /**
- * Normaliza el destinatario para el envío. Números móviles de México llegan
+ * Normaliza un número al formato canónico. Números móviles de México llegan
  * de Meta como `521` + 10 dígitos (13 en total); enviar con ese `1` extra
- * produce el error 131030 — se envía como `52` + 10 dígitos.
- * El wa_id almacenado NO se modifica; esto aplica solo al enviar.
+ * produce el error 131030 — se usa `52` + 10 dígitos.
+ *
+ * Desde la identidad resiliente (003) esta normalización es SIMÉTRICA: se
+ * aplica también al escribir la identidad del contacto en la ingesta
+ * (`wa_identity`), para que `521...` y `52...` resuelvan al mismo contacto.
  */
-export function normalizeRecipient(waId: string): string {
-  if (/^521\d{10}$/.test(waId)) {
-    return `52${waId.slice(3)}`;
+export function normalizeMx(phone: string): string {
+  if (/^521\d{10}$/.test(phone)) {
+    return `52${phone.slice(3)}`;
   }
-  return waId;
+  return phone;
 }
+
+/** Alias histórico (envío). */
+export const normalizeRecipient = normalizeMx;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,7 +2,7 @@
 
 export type ConversationDto = {
   id: string;
-  contact: { id: string; name: string; phone: string };
+  contact: { id: string; name: string; phone: string | null };
   stageName: string | null;
   aiEnabled: boolean;
   handoffAt: string | null;
@@ -46,7 +46,8 @@ export type StageDto = {
 export type ContactDto = {
   id: string;
   name: string;
-  phone: string;
+  /** null en contactos que llegaron solo con BSUID (003). */
+  phone: string | null;
   notes: string | null;
   archivedAt: string | null;
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -35,6 +35,7 @@ export function avatarColor(seed: string): string {
   return AVATAR_COLORS[hash % AVATAR_COLORS.length] ?? AVATAR_COLORS[0];
 }
 
-export function formatPhone(phone: string): string {
-  return `+${phone}`;
+export function formatPhone(phone: string | null | undefined): string {
+  // 003: contactos BSUID pueden no tener teléfono.
+  return phone ? `+${phone}` : "Sin teléfono";
 }

--- a/src/server/bot/auth.ts
+++ b/src/server/bot/auth.ts
@@ -1,0 +1,53 @@
+import { timingSafeEqual } from "node:crypto";
+import { getDb, schema } from "@/lib/db";
+import { apiError } from "@/lib/api";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+/**
+ * Autenticación de la API de servicio `/api/bot/*`.
+ *
+ * Esta superficie NO la consume el navegador: la consume un cerebro externo
+ * (un microservicio propio del operador, en su mismo servidor) que quiere
+ * conducir la conversación sin que el token de WhatsApp salga del CRM.
+ * Header `X-API-Key` contra `BOT_API_KEY` (env), comparación en tiempo
+ * constante. Sin `BOT_API_KEY` configurada, toda la superficie responde 401.
+ */
+
+export function requireBotKey(req: Request): Response | null {
+  const rl = checkRateLimit("bot-api", { windowMs: 60_000, max: 600 });
+  if (!rl.allowed) return apiError(429, "rate_limited", "Demasiadas solicitudes");
+
+  const expected = process.env.BOT_API_KEY;
+  const provided = req.headers.get("x-api-key");
+  if (!expected || expected.length < 16 || !provided) {
+    return apiError(401, "unauthorized", "No autorizado");
+  }
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    return apiError(401, "unauthorized", "No autorizado");
+  }
+  return null;
+}
+
+/**
+ * Organización única de la instancia (self-hosted, un negocio). Cacheada en
+ * memoria: la instancia jamás cambia de organización en runtime.
+ */
+let cachedOrgId: string | null = null;
+
+export async function resolveInstanceOrg(): Promise<string | null> {
+  if (cachedOrgId) return cachedOrgId;
+  const db = getDb();
+  const rows = await db
+    .select({ id: schema.organization.id })
+    .from(schema.organization)
+    .limit(1);
+  cachedOrgId = rows[0]?.id ?? null;
+  return cachedOrgId;
+}
+
+/** Solo para tests. */
+export function resetInstanceOrgCache(): void {
+  cachedOrgId = null;
+}

--- a/src/server/dev/wa-mock-inbound.ts
+++ b/src/server/dev/wa-mock-inbound.ts
@@ -29,7 +29,10 @@ export async function deliverToWebhook(payload: unknown): Promise<Response> {
 export function buildInboundPayload(input: {
   wabaId: string;
   phoneNumberId: string;
-  from: string;
+  /** Teléfono del remitente. Omite y usa `fromUserId` para simular BSUID (003). */
+  from?: string;
+  /** BSUID del remitente — puede venir solo o junto a `from`. */
+  fromUserId?: string;
   name?: string;
   type?: string;
   text?: string;
@@ -38,12 +41,19 @@ export function buildInboundPayload(input: {
 }) {
   const type = input.type ?? "text";
   const message: Record<string, unknown> = {
-    from: input.from,
     id: input.waMessageId ?? `wamid.mock.in.${nextN()}`,
     timestamp: String(input.timestamp ?? Math.floor(Date.now() / 1000)),
     type,
   };
+  if (input.from) message.from = input.from;
+  if (input.fromUserId) message.from_user_id = input.fromUserId;
   if (type === "text") message.text = { body: input.text ?? "hola" };
+
+  const contactEntry: Record<string, unknown> = {
+    profile: { name: input.name ?? "Cliente" },
+  };
+  if (input.from) contactEntry.wa_id = input.from;
+  if (input.fromUserId) contactEntry.user_id = input.fromUserId;
 
   return {
     object: "whatsapp_business_account",
@@ -59,12 +69,7 @@ export function buildInboundPayload(input: {
                 display_phone_number: "5215500000000",
                 phone_number_id: input.phoneNumberId,
               },
-              contacts: [
-                {
-                  profile: { name: input.name ?? "Cliente" },
-                  wa_id: input.from,
-                },
-              ],
+              contacts: [contactEntry],
               messages: [message],
             },
           },

--- a/src/server/inbox/identity.ts
+++ b/src/server/inbox/identity.ts
@@ -1,0 +1,151 @@
+import { and, eq, or } from "drizzle-orm";
+import { getDb, schema } from "@/lib/db";
+import { newId } from "@/lib/db/ids";
+import { normalizeMx } from "@/lib/meta/client";
+import type { WebhookMessage, WebhookValue } from "@/server/inbox/webhook";
+
+/**
+ * Identidad resiliente de contacto (003).
+ *
+ * Meta está migrando la identidad de WhatsApp de teléfono a Business-Scoped
+ * User IDs (BSUID): `wa_id`/`from` pasan a ser opcionales y aparecen
+ * `from_user_id` (mensaje) y `user_id` (contacts[]). Este módulo resuelve la
+ * identidad del remitente sin asumir teléfono, y reconcilia para que un mismo
+ * humano no genere dos contactos.
+ */
+
+export const BSUID_PREFIX = "bsuid:";
+
+export type ResolvedIdentity = {
+  /** Llave estable de resolución: teléfono normalizado o `bsuid:<id>`. */
+  identity: string;
+  phone: string | null;
+  waUserId: string | null;
+  profileName: string | null;
+};
+
+/**
+ * Extrae la identidad utilizable de un mensaje del webhook.
+ * Devuelve null si el mensaje no trae NINGUNA identidad (se descarta con log,
+ * jamás se revienta el webhook).
+ */
+export function resolveIdentity(
+  msg: WebhookMessage,
+  contacts: WebhookValue["contacts"]
+): ResolvedIdentity | null {
+  const waUserId =
+    msg.from_user_id ??
+    contacts?.find((c) => c.wa_id != null && c.wa_id === msg.from)?.user_id ??
+    contacts?.find((c) => c.user_id != null)?.user_id ??
+    null;
+
+  const profileName =
+    contacts?.find((c) => c.wa_id != null && c.wa_id === msg.from)?.profile
+      ?.name ??
+    (waUserId
+      ? contacts?.find((c) => c.user_id === waUserId)?.profile?.name
+      : undefined) ??
+    null;
+
+  if (msg.from) {
+    const phone = normalizeMx(msg.from);
+    return { identity: phone, phone, waUserId, profileName };
+  }
+  if (waUserId) {
+    return {
+      identity: `${BSUID_PREFIX}${waUserId}`,
+      phone: null,
+      waUserId,
+      profileName,
+    };
+  }
+  return null;
+}
+
+/**
+ * Resuelve o crea el contacto para una identidad, reconciliando:
+ * - Si llegan teléfono Y BSUID, encuentra al contacto por cualquiera de los
+ *   dos y adquiere la señal que le faltaba (el `wa_identity` NO cambia:
+ *   es estable de por vida).
+ * - Reactiva contactos archivados (el nombre editado por el operador se
+ *   respeta).
+ */
+export async function getOrCreateContactByIdentity(
+  organizationId: string,
+  resolved: ResolvedIdentity
+) {
+  const db = getDb();
+
+  const matchers = [eq(schema.contact.waIdentity, resolved.identity)];
+  if (resolved.waUserId) {
+    matchers.push(eq(schema.contact.waUserId, resolved.waUserId));
+    matchers.push(
+      eq(schema.contact.waIdentity, `${BSUID_PREFIX}${resolved.waUserId}`)
+    );
+  }
+  if (resolved.phone) {
+    matchers.push(eq(schema.contact.phone, resolved.phone));
+  }
+
+  const rows = await db
+    .select()
+    .from(schema.contact)
+    .where(and(eq(schema.contact.organizationId, organizationId), or(...matchers)))
+    .orderBy(schema.contact.createdAt)
+    .limit(1);
+
+  const existing = rows[0];
+  if (existing) {
+    const patch: Partial<typeof schema.contact.$inferInsert> = {};
+    if (resolved.waUserId && !existing.waUserId)
+      patch.waUserId = resolved.waUserId;
+    if (resolved.phone && !existing.phone) patch.phone = resolved.phone;
+    if (existing.archivedAt) patch.archivedAt = null;
+    if (Object.keys(patch).length > 0) {
+      patch.updatedAt = new Date();
+      await db
+        .update(schema.contact)
+        .set(patch)
+        .where(eq(schema.contact.id, existing.id));
+      Object.assign(existing, patch);
+    }
+    return { contact: existing, isNew: false };
+  }
+
+  const inserted = await db
+    .insert(schema.contact)
+    .values({
+      id: newId("contact"),
+      organizationId,
+      waIdentity: resolved.identity,
+      phone: resolved.phone,
+      waUserId: resolved.waUserId,
+      name: resolved.profileName?.trim() || displayFallback(resolved),
+    })
+    .onConflictDoNothing({
+      target: [schema.contact.organizationId, schema.contact.waIdentity],
+    })
+    .returning();
+  if (inserted[0]) return { contact: inserted[0], isNew: true };
+
+  // Carrera: otro request lo creó entre el SELECT y el INSERT.
+  const raced = await db
+    .select()
+    .from(schema.contact)
+    .where(
+      and(
+        eq(schema.contact.organizationId, organizationId),
+        eq(schema.contact.waIdentity, resolved.identity)
+      )
+    )
+    .limit(1);
+  const contact = raced[0];
+  if (!contact) throw new Error("contacto no encontrado tras upsert");
+  return { contact, isNew: false };
+}
+
+/** Nombre de respaldo cuando no hay nombre de perfil: nunca el BSUID crudo. */
+function displayFallback(resolved: ResolvedIdentity): string {
+  if (resolved.phone) return resolved.phone;
+  return "Contacto de WhatsApp";
+}

--- a/src/server/inbox/ingest.ts
+++ b/src/server/inbox/ingest.ts
@@ -1,9 +1,15 @@
 import { and, eq, sql } from "drizzle-orm";
 import { getDb, schema } from "@/lib/db";
 import { newId } from "@/lib/db/ids";
+import { normalizeMx } from "@/lib/meta/client";
 import { publish } from "@/server/events/bus";
 import { getCredentialsByPhoneNumberId } from "@/server/whatsapp/credentials";
 import type { WebhookValue } from "@/server/inbox/webhook";
+import {
+  getOrCreateContactByIdentity,
+  resolveIdentity,
+  type ResolvedIdentity,
+} from "@/server/inbox/identity";
 import { applyStatusUpdate } from "@/server/inbox/status";
 import { onLeadActivity } from "@/server/inbox/lead-activity";
 import { maybeRunAgentTurn } from "@/server/ai/trigger";
@@ -20,48 +26,23 @@ const SUPPORTED_TYPES = new Set([
   "contacts",
 ]);
 
+/**
+ * Alta/resolución de contacto por teléfono (alta manual / seeds). La ingesta
+ * del webhook usa `getOrCreateContactByIdentity` (003) — este helper deriva la
+ * identidad del teléfono normalizado y delega ahí.
+ */
 export async function getOrCreateContact(
   organizationId: string,
   phone: string,
   name?: string | null
 ) {
-  const db = getDb();
-  const inserted = await db
-    .insert(schema.contact)
-    .values({
-      id: newId("contact"),
-      organizationId,
-      phone,
-      name: name?.trim() || phone,
-    })
-    .onConflictDoNothing({
-      target: [schema.contact.organizationId, schema.contact.phone],
-    })
-    .returning();
-  if (inserted[0]) return { contact: inserted[0], isNew: true };
-
-  const rows = await db
-    .select()
-    .from(schema.contact)
-    .where(
-      and(
-        eq(schema.contact.organizationId, organizationId),
-        eq(schema.contact.phone, phone)
-      )
-    )
-    .limit(1);
-  const existing = rows[0];
-  if (!existing) throw new Error("contacto no encontrado tras upsert");
-
-  // Reactivar si estaba archivado (el nombre editado por el operador se respeta).
-  if (existing.archivedAt) {
-    await db
-      .update(schema.contact)
-      .set({ archivedAt: null, updatedAt: new Date() })
-      .where(eq(schema.contact.id, existing.id));
-    existing.archivedAt = null;
-  }
-  return { contact: existing, isNew: false };
+  const normalized = normalizeMx(phone);
+  return getOrCreateContactByIdentity(organizationId, {
+    identity: normalized,
+    phone: normalized,
+    waUserId: null,
+    profileName: name ?? null,
+  });
 }
 
 export async function getOrCreateConversation(
@@ -119,13 +100,18 @@ export async function processMessagesValue(value: WebhookValue): Promise<void> {
 
   for (const msg of value.messages ?? []) {
     if (!SUPPORTED_TYPES.has(msg.type)) continue; // reacciones, etc.: ignorar
-    const profileName = value.contacts?.find(
-      (c) => c.wa_id === msg.from
-    )?.profile?.name;
+    const resolved = resolveIdentity(msg, value.contacts);
+    if (!resolved) {
+      // Mensaje sin NINGUNA identidad utilizable (ni teléfono ni BSUID):
+      // registrar y descartar — jamás reventar el webhook (003).
+      console.warn(
+        `[webhook] mensaje ${msg.id} sin identidad utilizable (sin from ni from_user_id): descartado`
+      );
+      continue;
+    }
     await ingestInboundMessage({
       organizationId,
-      from: msg.from,
-      profileName: profileName ?? null,
+      identity: resolved,
       waMessageId: msg.id,
       type: msg.type,
       text: msg.text?.body ?? null,
@@ -136,8 +122,7 @@ export async function processMessagesValue(value: WebhookValue): Promise<void> {
 
 export async function ingestInboundMessage(input: {
   organizationId: string;
-  from: string;
-  profileName: string | null;
+  identity: ResolvedIdentity;
   waMessageId: string;
   type: string;
   text: string | null;
@@ -146,10 +131,9 @@ export async function ingestInboundMessage(input: {
   const db = getDb();
   const { organizationId } = input;
 
-  const { contact } = await getOrCreateContact(
+  const { contact } = await getOrCreateContactByIdentity(
     organizationId,
-    input.from,
-    input.profileName
+    input.identity
   );
   const conversation = await getOrCreateConversation(
     organizationId,

--- a/src/server/inbox/queries.ts
+++ b/src/server/inbox/queries.ts
@@ -5,7 +5,7 @@ import { isWindowOpen, windowRemainingMs } from "@/server/inbox/window";
 
 export type ConversationDto = {
   id: string;
-  contact: { id: string; name: string; phone: string };
+  contact: { id: string; name: string; phone: string | null };
   stageName: string | null;
   aiEnabled: boolean;
   handoffAt: string | null;

--- a/src/server/inbox/send.ts
+++ b/src/server/inbox/send.ts
@@ -86,9 +86,21 @@ export async function sendText(input: {
     );
   }
 
+  // 003: el destinatario es el teléfono normalizado o, si el contacto llegó
+  // por BSUID sin teléfono, su Business-Scoped User ID.
+  const recipient = row.contact.phone
+    ? normalizeRecipient(row.contact.phone)
+    : row.contact.waUserId;
+  if (!recipient) {
+    throw new SendError(
+      "meta_error",
+      "El contacto no tiene teléfono ni identidad de WhatsApp utilizable"
+    );
+  }
+
   const waMessageId = await callGraphSend(credentials, {
     messaging_product: "whatsapp",
-    to: normalizeRecipient(row.contact.phone),
+    to: recipient,
     type: "text",
     text: { body: input.text },
   });

--- a/src/server/inbox/webhook.ts
+++ b/src/server/inbox/webhook.ts
@@ -40,7 +40,10 @@ export function isValidSignature(
 /* ---------- Tipos del payload de Meta (subconjunto soportado) ---------- */
 
 export type WebhookMessage = {
-  from: string;
+  /** Teléfono del remitente. OPCIONAL desde la migración de Meta a BSUID (003). */
+  from?: string;
+  /** Business-Scoped User ID del remitente cuando no hay teléfono (003). */
+  from_user_id?: string;
   id: string;
   timestamp: string;
   type: string;
@@ -58,7 +61,7 @@ export type WebhookStatus = {
 export type WebhookValue = {
   messaging_product?: string;
   metadata?: { display_phone_number?: string; phone_number_id?: string };
-  contacts?: { profile?: { name?: string }; wa_id?: string }[];
+  contacts?: { profile?: { name?: string }; wa_id?: string; user_id?: string }[];
   messages?: WebhookMessage[];
   statuses?: WebhookStatus[];
   // message_template_status_update

--- a/src/server/lab/runner.ts
+++ b/src/server/lab/runner.ts
@@ -243,11 +243,12 @@ async function upsertTestContact(
       id: newId("contact"),
       organizationId,
       phone: persona.phone,
+      waIdentity: persona.phone,
       name: persona.contactName,
       archivedAt: new Date(),
     })
     .onConflictDoNothing({
-      target: [schema.contact.organizationId, schema.contact.phone],
+      target: [schema.contact.organizationId, schema.contact.waIdentity],
     })
     .returning();
   if (inserted[0]) return inserted[0].id;

--- a/src/server/seed/demo.ts
+++ b/src/server/seed/demo.ts
@@ -188,6 +188,7 @@ export async function seedDemo(
       id: contactId,
       organizationId,
       phone: demo.phone,
+      waIdentity: demo.phone,
       name: demo.name,
       notes: demo.notes ?? null,
     });

--- a/src/server/whatsapp/templates.ts
+++ b/src/server/whatsapp/templates.ts
@@ -336,9 +336,20 @@ export async function sendTemplate(input: {
     throw new TemplateError("reconnect_required", "Reconecta el número");
   }
 
+  // 003: destinatario = teléfono normalizado o BSUID.
+  const templateRecipient = row.contact.phone
+    ? normalizeRecipient(row.contact.phone)
+    : row.contact.waUserId;
+  if (!templateRecipient) {
+    throw new TemplateError(
+      "meta_error",
+      "El contacto no tiene teléfono ni identidad de WhatsApp utilizable"
+    );
+  }
+
   const waMessageId = await callGraphSend(creds, {
     messaging_product: "whatsapp",
-    to: normalizeRecipient(row.contact.phone),
+    to: templateRecipient,
     type: "template",
     template: {
       name: template.name,

--- a/tests/e2e/us-bot-api.md
+++ b/tests/e2e/us-bot-api.md
@@ -1,0 +1,52 @@
+# E2E — API de servicio para un cerebro externo (`/api/bot/*`)
+
+Precondición: app corriendo con mocks (`WA_MOCK_ENABLED=true`,
+`META_GRAPH_BASE_URL` → wa-mock), organización creada, conexión WhatsApp
+guardada y `BOT_API_KEY` configurada (≥16 caracteres).
+
+Esta superficie NO la usa el navegador: la usa un bot propio del operador que
+quiere conducir la conversación sin que el token de WhatsApp salga del CRM. El
+agente in-process de Vocero puede quedar apagado.
+
+## Autorización
+
+1. `GET /api/bot/media/media123` SIN header `X-API-Key` → **401** `unauthorized`.
+2. Lo mismo con una key equivocada → **401** (mismo cuerpo: no filtra si la key
+   existe o no).
+
+## Presencia: marcar leído + "escribiendo…"
+
+3. Provocar un inbound (`POST /api/dev/wa-mock/inbound`) y tomar el
+   `conversationId` de `GET /api/conversations`.
+4. `POST /api/bot/typing {conversationId}` con la key → **200** `{ok: true}`.
+5. `GET /api/dev/wa-mock/outbox` → el conteo NO cambió: marcar leído y el
+   indicador no son mensajes salientes y no contaminan la bandeja.
+6. Pausar la IA de esa conversación (toggle del panel, o
+   `PATCH /api/conversations/{id} {aiEnabled:false}`) y repetir typing →
+   **200** `{ok:false, reason:"ai_paused"}` y Meta ni se toca: con un humano
+   atendiendo, "escribiendo…" le mentiría al cliente.
+7. Conversación del Laboratorio (`is_test`) → `{ok:false, reason:"sandbox"}`.
+
+## Media proxy
+
+8. `GET /api/bot/media/media123` con la key → **200**, `content-type: image/*`
+   y cuerpo no vacío. El token de WhatsApp nunca viajó al bot.
+9. `GET /api/bot/media/media-inexistente` cuando Graph responde 404 → **404**
+   `media_meta_failed` (no 500).
+
+## Reinicio de la conversación de pruebas
+
+10. Con la conversación en handoff (`aiEnabled:false`), `POST /api/bot/reset
+    {conversationId}` con la key → **200** `{ok:true}`.
+11. `GET /api/conversations` → esa conversación vuelve con `aiEnabled: true` y
+    sin `handoffAt`; el lead está en la PRIMERA etapa del pipeline.
+12. El historial de mensajes del inbox sigue completo: el reset es de estado,
+    no borra auditoría.
+13. `POST /api/bot/reset` sin key → **401**.
+
+## Camino infeliz
+
+14. `POST /api/bot/typing` con un `conversationId` inexistente → **404**.
+15. Con Meta caído (token `...-invalid` en el mock), typing → **200**
+    `{ok:false, reason:"meta_error"}`: es best-effort por contrato, al bot
+    jamás le vale reintentarlo.

--- a/tests/e2e/us-bsuid.md
+++ b/tests/e2e/us-bsuid.md
@@ -1,0 +1,31 @@
+# E2E — 003 Identidad resiliente (BSUID)
+
+Precondición: app corriendo con mocks (`WA_MOCK_ENABLED=true`,
+`META_GRAPH_BASE_URL` → wa-mock), organización creada y conexión WhatsApp
+guardada (wizard con credenciales del mock).
+
+## Camino feliz: inbound sin wa_id
+
+1. `POST /api/dev/wa-mock/inbound` con `{phoneNumberId, fromUserId: "bsu_e2e_1",
+   name: "Dueña Dental", text: "hola, vi su anuncio"}` (sin `from`).
+2. En la bandeja: aparece la conversación "Dueña Dental" (NO "bsu_e2e_1") con el
+   mensaje, en ≤2 s (SSE).
+3. Panel de contacto: muestra "Sin teléfono".
+4. Responder desde el composer → el mensaje sale; en el outbox del wa-mock el
+   destinatario es `bsu_e2e_1` (el BSUID, no un teléfono).
+5. Re-entregar el MISMO payload (mismo `waMessageId`) → sin duplicados.
+
+## Reconciliación
+
+6. `POST inbound` con `{from: "5214621349768", name: "Kevin"}` → contacto A.
+7. `POST inbound` con `{from: "524621349768", text: "sigo yo"}` → MISMO contacto
+   A (no aparece un segundo contacto; normalización 521→52 en ingest).
+8. `POST inbound` con `{from: "524621349768", fromUserId: "bsu_kevin"}` →
+   contacto A adquiere el BSUID (verificable respondiendo tras simular pérdida
+   del teléfono — fuera de alcance UI; verificar por API/DB).
+
+## Camino infeliz
+
+9. `POST inbound` con payload sin `from` NI `fromUserId` (construir a mano
+   contra el webhook con firma válida) → 200, log de advertencia, la bandeja
+   NO muestra nada nuevo y la app sigue viva.

--- a/tests/unit/identity.test.ts
+++ b/tests/unit/identity.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { normalizeMx } from "@/lib/meta/client";
+import { BSUID_PREFIX, resolveIdentity } from "@/server/inbox/identity";
+import type { WebhookMessage, WebhookValue } from "@/server/inbox/webhook";
+
+/** Feature 003: identidad resiliente de contacto (BSUID). */
+
+function msg(partial: Partial<WebhookMessage>): WebhookMessage {
+  return { id: "wamid.test.1", timestamp: "1752800000", type: "text", ...partial };
+}
+
+describe("normalizeMx (simétrica ingest/envío)", () => {
+  it("troncal MX 521 + 10 dígitos → 52 + 10 dígitos", () => {
+    expect(normalizeMx("5214621349768")).toBe("524621349768");
+  });
+
+  it("52 + 10 dígitos queda igual", () => {
+    expect(normalizeMx("524621349768")).toBe("524621349768");
+  });
+
+  it("otros países quedan intactos", () => {
+    expect(normalizeMx("5491122334455")).toBe("5491122334455");
+    expect(normalizeMx("14155551212")).toBe("14155551212");
+    expect(normalizeMx("50761234567")).toBe("50761234567");
+  });
+});
+
+describe("resolveIdentity: teléfono presente", () => {
+  const contacts: WebhookValue["contacts"] = [
+    { wa_id: "5214621349768", profile: { name: "Kevin" } },
+  ];
+
+  it("usa el teléfono NORMALIZADO como identidad", () => {
+    const r = resolveIdentity(msg({ from: "5214621349768" }), contacts);
+    expect(r).not.toBeNull();
+    expect(r!.identity).toBe("524621349768");
+    expect(r!.phone).toBe("524621349768");
+    expect(r!.profileName).toBe("Kevin");
+  });
+
+  it("521 y 52 resuelven a la MISMA identidad (dedup del bug MX)", () => {
+    const a = resolveIdentity(msg({ from: "5214621349768" }), contacts);
+    const b = resolveIdentity(msg({ from: "524621349768" }), []);
+    expect(a!.identity).toBe(b!.identity);
+  });
+
+  it("captura el BSUID si además viene user_id", () => {
+    const r = resolveIdentity(msg({ from: "5214621349768" }), [
+      { wa_id: "5214621349768", user_id: "bsu_777", profile: { name: "Kevin" } },
+    ]);
+    expect(r!.waUserId).toBe("bsu_777");
+    expect(r!.identity).toBe("524621349768"); // el teléfono manda si existe
+  });
+});
+
+describe("resolveIdentity: sin wa_id (mundo BSUID)", () => {
+  it("from_user_id en el mensaje → identidad bsuid:", () => {
+    const r = resolveIdentity(msg({ from_user_id: "bsu_123" }), [
+      { user_id: "bsu_123", profile: { name: "Dueña Dental" } },
+    ]);
+    expect(r).not.toBeNull();
+    expect(r!.identity).toBe(`${BSUID_PREFIX}bsu_123`);
+    expect(r!.phone).toBeNull();
+    expect(r!.waUserId).toBe("bsu_123");
+    expect(r!.profileName).toBe("Dueña Dental");
+  });
+
+  it("user_id solo en contacts[] también resuelve", () => {
+    const r = resolveIdentity(msg({}), [
+      { user_id: "bsu_456", profile: { name: "Cliente" } },
+    ]);
+    expect(r).not.toBeNull();
+    expect(r!.identity).toBe(`${BSUID_PREFIX}bsu_456`);
+  });
+
+  it("sin from y sin user_id → null (descartar con log, no reventar)", () => {
+    expect(resolveIdentity(msg({}), [])).toBeNull();
+    expect(resolveIdentity(msg({}), undefined)).toBeNull();
+  });
+
+  it("el nombre de perfil no cae al identificador crudo", () => {
+    const r = resolveIdentity(msg({ from_user_id: "bsu_123" }), []);
+    // Sin perfil: profileName null — el fallback de display se decide al crear
+    // el contacto (nunca el BSUID crudo).
+    expect(r!.profileName).toBeNull();
+  });
+});


### PR DESCRIPTION
Porta a Vocero las mejoras genéricas nacidas en un fork de agencia, sin
introducir dependencias de runtime nuevas ni tocar la constitución. Seis
commits, uno por mejora, revisables y revertibles por separado.

## Qué entra

**`feat(identidad)`** — Meta está migrando de teléfono a Business-Scoped User
IDs y el webhook puede llegar sin `from`. La llave del contacto pasa a ser
`contact.wa_identity` (teléfono normalizado o `bsuid:<id>`) y `phone` queda
como atributo OPCIONAL. `src/server/inbox/identity.ts` concentra esa decisión.
De paso, `normalizeMx` (521→52) se aplica también al ESCRIBIR: sin esa
simetría el mismo número mexicano creaba dos contactos.

La migración `0001` está escrita a mano en vez de la generada por drizzle-kit,
que hacía `ADD COLUMN ... NOT NULL` y habría roto toda instancia con datos.
Esta agrega las columnas nullable, backfilea, fusiona los duplicados 521/52
preexistentes (conserva el contacto más antiguo y le mueve mensajes,
conversaciones y leads) y recién entonces pone NOT NULL.

**`feat(bot-api)`** — superficie `/api/bot/*` autenticada por `BOT_API_KEY`
para quien prefiera conducir la conversación con su propio microservicio en
vez del agente in-process, sin copiarse el token de WhatsApp: `typing`
(marcar leído + "escribiendo…", best-effort, respeta sandbox y handoff),
`media/{id}` (proxy de adjuntos, límite 16 MB) y `reset` (reinicia el estado
de la conversación de pruebas conservando el historial). Sin la key, todo eso
responde 401 y el CRM funciona igual.

**`feat(wa-mock)`** — el mock solo sabía simular lo que la app ya soportaba,
así que ni la identidad BSUID ni el proxy de adjuntos eran probables sin
credenciales reales. Ahora acepta `fromUserId`, sirve metadata y binario de
media, y corta en seco el `status:"read"` para que marcar leído no aparezca
como mensaje saliente.

**`fix(bandeja)`** — el toggle de IA de la conversación estaba deshabilitado
mientras el agente in-process no estuviera encendido, dejando al operador sin
forma de pausar o reactivar. `ai_enabled`/`handoff_at` son la fuente de verdad
y también los respeta un cerebro externo, así que el control opera siempre.

**`test(e2e)`** — `pnpm test:e2e` conduce los guiones de `tests/e2e/*.md`
contra la app viva con los mocks encendidos y sale distinto de cero si algo
falla. La Definición de Hecho ya exigía un self-test de comportamiento, pero
no había forma automatizada de cumplirla.

## Verificación

- Gate técnico verde: `typecheck` + `lint` + `build` + **100 tests** unitarios
  (10 nuevos de identidad).
- Self-test en vivo contra la app real con mocks y BD fresca: **24/24 checks
  OK, 0 fallos** — BSUID de punta a punta, reconciliación 521/52, idempotencia
  del webhook, typing sin contaminar el outbox, media proxy, 401 sin key, y
  reset reactivando la IA sin perder historial.
- La migración se probó aparte sobre una BD **con datos previos y duplicados
  521/52**: sobrevive el contacto canónico, su conversación se fusiona y los
  dos mensajes se conservan.

## Notas de despliegue

`BOT_API_KEY` es opcional y no rompe nada por ausencia. La migración `0001`
corre sola al arrancar el contenedor; en instancias con datos hace la fusión
descrita arriba, que **no es reversible** — conviene respaldar antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
