### PR TITLE
fix(plantillas): auto-sync con Meta al abrir la pantalla + categoría real

### DIFF
--- a/scripts/e2e-templates-sync.mjs
+++ b/scripts/e2e-templates-sync.mjs
@@ -1,0 +1,158 @@
+/**
+ * Self-test E2E de comportamiento — sincronización de plantillas (guion
+ * tests/e2e/us6-templates.md, sección "modo agencia").
+ *
+ * Reproduce un fallo visto en producción: Meta aprobó una plantilla y la
+ * reclasificó de UTILITY a MARKETING, pero el CRM la seguía mostrando
+ * "Pendiente de Meta" porque el webhook
+ * `message_template_status_update` se entrega al callback A NIVEL APP (que en
+ * modo agencia no es el de esta instancia). El único camino es el pull.
+ *
+ * Uso: node --env-file=.env scripts/e2e-templates-sync.mjs
+ * Requiere: app corriendo (pnpm dev) con WA_MOCK_ENABLED=true y BD migrada.
+ */
+
+const BASE = process.env.APP_BASE_URL ?? "http://localhost:3000";
+
+let cookie = "";
+let failures = 0;
+let checks = 0;
+
+function ok(name, cond, extra = "") {
+  checks++;
+  if (cond) {
+    console.log(`  ✓ ${name}`);
+  } else {
+    failures++;
+    console.log(`  ✗ ${name}${extra ? ` — ${extra}` : ""}`);
+  }
+}
+
+async function api(path, opts = {}) {
+  const res = await fetch(`${BASE}${path}`, {
+    ...opts,
+    headers: {
+      "content-type": "application/json",
+      origin: BASE,
+      ...(cookie ? { cookie } : {}),
+      ...(opts.headers ?? {}),
+    },
+  });
+  const setCookie = res.headers.getSetCookie?.() ?? [];
+  if (setCookie.length) {
+    cookie = setCookie.map((c) => c.split(";")[0]).join("; ");
+  }
+  let json = null;
+  try {
+    json = await res.clone().json();
+  } catch {}
+  return { res, json };
+}
+
+const PN = "PN-TPL-1";
+const WABA = "WABA-TPL";
+const stamp = Date.now().toString(36);
+
+async function findTemplate(name) {
+  const { json } = await api("/api/templates");
+  return (json?.templates ?? []).find((t) => t.name === name);
+}
+
+/** Mueve SOLO el panel simulado de Meta: sin webhook, como en modo agencia. */
+function metaApproves(name, category) {
+  return api("/api/dev/wa-mock/template-status", {
+    method: "POST",
+    body: JSON.stringify({
+      wabaId: WABA,
+      name,
+      language: "es_MX",
+      event: "APPROVED",
+      category,
+      notify: false,
+    }),
+  });
+}
+
+async function main() {
+  console.log("== Setup: registro + conexión WhatsApp ==");
+  const email = "e2e@vocero.test";
+  const password = "password-e2e-123";
+  let su = await api("/api/auth/sign-up/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password, name: "Operador E2E" }),
+  });
+  if (!su.res.ok) {
+    su = await api("/api/auth/sign-in/email", {
+      method: "POST",
+      body: JSON.stringify({ email, password }),
+    });
+  }
+  ok("registro o login del operador", su.res.ok, JSON.stringify(su.json));
+
+  const conn = await api("/api/settings/whatsapp", {
+    method: "PUT",
+    body: JSON.stringify({ wabaId: WABA, phoneNumberId: PN, token: "tok-tpl" }),
+  });
+  ok("conexión WhatsApp guardada", conn.res.ok, JSON.stringify(conn.json));
+
+  console.log("\n== us6: alta de plantilla → Pendiente de Meta ==");
+  const name = `seguimiento_${stamp}`;
+  const created = await api("/api/templates", {
+    method: "POST",
+    body: JSON.stringify({
+      name,
+      language: "es_MX",
+      category: "UTILITY",
+      body: "Hola {{1}} 👋 ¿Retomamos tu cotización?",
+    }),
+  });
+  ok("plantilla creada y enviada a Meta", created.res.ok, JSON.stringify(created.json));
+  let local = await findTemplate(name);
+  ok("estado inicial = pending", local?.status === "pending", local?.status);
+  ok("categoría inicial = UTILITY", local?.category === "UTILITY", local?.category);
+
+  console.log("\n== us6: Meta aprueba y reclasifica, SIN webhook (modo agencia) ==");
+  const flip = await metaApproves(name, "MARKETING");
+  ok("panel de Meta movido sin entregar webhook", flip.json?.delivered === false, JSON.stringify(flip.json));
+
+  local = await findTemplate(name);
+  ok(
+    "el CRM sigue en pending (el webhook nunca llega) — este era el bug",
+    local?.status === "pending",
+    local?.status
+  );
+
+  console.log("\n== us6: el pull sincroniza estado Y categoría ==");
+  const sync = await api("/api/templates/sync", { method: "POST" });
+  ok("sync 200", sync.res.ok, JSON.stringify(sync.json));
+  ok("sync reporta 1 actualizada", sync.json?.updated === 1, JSON.stringify(sync.json));
+
+  local = await findTemplate(name);
+  ok("estado = approved", local?.status === "approved", local?.status);
+  ok(
+    "categoría reclasificada por Meta = MARKETING",
+    local?.category === "MARKETING",
+    local?.category
+  );
+
+  console.log("\n== us6: idempotencia del sync ==");
+  const again = await api("/api/templates/sync", { method: "POST" });
+  ok("segundo sync no reescribe nada", again.json?.updated === 0, JSON.stringify(again.json));
+
+  console.log("\n== us6: camino infeliz — Meta caído no tumba la pantalla ==");
+  const listStillOk = await api("/api/templates");
+  ok(
+    "GET /api/templates responde aunque el sync sea aparte",
+    listStillOk.res.ok && (listStillOk.json?.templates?.length ?? 0) > 0
+  );
+
+  console.log(
+    `\n${failures === 0 ? "TODO VERDE" : "CON FALLOS"} — ${checks - failures}/${checks} checks`
+  );
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/dev/wa-mock/template-status/route.ts
+++ b/src/app/api/dev/wa-mock/template-status/route.ts
@@ -15,6 +15,15 @@ const bodySchema = z.object({
   language: z.string().min(1),
   event: z.enum(["APPROVED", "REJECTED"]),
   reason: z.string().optional(),
+  /** Meta reclasifica al aprobar (UTILITY → MARKETING). Solo lado "Meta". */
+  category: z.string().optional(),
+  /**
+   * `false` = mueve solo el panel simulado de Meta, sin entregar el webhook.
+   * Reproduce el modo agencia real, donde `message_template_status_update` va
+   * al callback a nivel app y esta instancia jamás lo ve: el único camino es
+   * el pull de `POST /api/templates/sync`.
+   */
+  notify: z.boolean().optional(),
 });
 
 export async function POST(req: Request) {
@@ -29,7 +38,14 @@ export async function POST(req: Request) {
   const tpl = state.templates.find(
     (t) => t.name === body.data.name && t.language === body.data.language
   );
-  if (tpl) tpl.status = body.data.event;
+  if (tpl) {
+    tpl.status = body.data.event;
+    if (body.data.category) tpl.category = body.data.category;
+  }
+
+  if (body.data.notify === false) {
+    return Response.json({ delivered: false, metaStatus: body.data.event });
+  }
 
   const payload = buildTemplateStatusPayload({
     ...body.data,

--- a/src/components/settings/templates-client.tsx
+++ b/src/components/settings/templates-client.tsx
@@ -32,41 +32,56 @@ export function TemplatesClient() {
     setTemplates(data.templates);
   }, []);
 
-  useEffect(() => {
-    void refetch();
-  }, [refetch]);
-
-  async function sync() {
-    setSyncing(true);
-    setSyncMsg(null);
-    const res = await fetch("/api/templates/sync", { method: "POST" }).catch(
-      () => null
-    );
-    setSyncing(false);
-    if (res?.ok) {
-      const data = (await res.json()) as { updated: number };
-      setSyncMsg(
-        data.updated > 0
-          ? `${data.updated} plantilla(s) actualizada(s)`
-          : "Todo al día"
+  /**
+   * `silent`: sincronización automática al abrir la pantalla. Meta entrega
+   * `message_template_status_update` al callback A NIVEL APP, que en modo
+   * agencia no es el de esta instancia — sin este pull la plantilla se queda
+   * "Pendiente de Meta" para siempre aunque ya esté aprobada.
+   */
+  const sync = useCallback(
+    async ({ silent = false } = {}) => {
+      if (!silent) {
+        setSyncing(true);
+        setSyncMsg(null);
+      }
+      const res = await fetch("/api/templates/sync", { method: "POST" }).catch(
+        () => null
       );
-      void refetch();
-    } else {
-      const data = (await res?.json().catch(() => null)) as {
-        error?: { message?: string };
-      } | null;
-      setSyncMsg(data?.error?.message ?? "No se pudo sincronizar");
-    }
-  }
+      if (!silent) setSyncing(false);
+      if (res?.ok) {
+        const data = (await res.json()) as { updated: number };
+        if (!silent) {
+          setSyncMsg(
+            data.updated > 0
+              ? `${data.updated} plantilla(s) actualizada(s)`
+              : "Todo al día"
+          );
+        }
+        if (!silent || data.updated > 0) void refetch();
+      } else if (!silent) {
+        // El auto-sync falla en silencio: la lista local ya se pintó.
+        const data = (await res?.json().catch(() => null)) as {
+          error?: { message?: string };
+        } | null;
+        setSyncMsg(data?.error?.message ?? "No se pudo sincronizar");
+      }
+    },
+    [refetch]
+  );
+
+  useEffect(() => {
+    void refetch().then(() => sync({ silent: true }));
+  }, [refetch, sync]);
 
   return (
     <div className="max-w-3xl space-y-6">
       <div className="flex items-start justify-between gap-4">
         <p className="text-sm text-muted-foreground">
           Las plantillas permiten reabrir conversaciones con la ventana de 24 h
-          cerrada. Meta las aprueba en horas o días; el estado se actualiza por
-          webhook y con el botón Sincronizar (imprescindible en modo agencia,
-          donde los eventos de plantillas no llegan al webhook de la instancia).
+          cerrada. Meta las aprueba en horas o días y puede reclasificar la
+          categoría (lo que cambia el costo por conversación). Esta pantalla
+          consulta el estado a Meta cada vez que la abres; Sincronizar fuerza
+          la consulta sin recargar.
         </p>
         <Button variant="outline" size="sm" disabled={syncing} onClick={() => void sync()}>
           <RefreshCw className={`h-4 w-4 ${syncing ? "animate-spin" : ""}`} />
@@ -83,7 +98,9 @@ export function TemplatesClient() {
             <div className="flex items-center justify-between gap-3">
               <p className="font-mono text-sm font-medium">
                 {t.name}{" "}
-                <span className="text-muted-foreground">({t.language})</span>
+                <span className="text-muted-foreground">
+                  ({t.language} · {t.category})
+                </span>
               </p>
               <Badge variant={STATUS_BADGE[t.status].variant}>
                 {STATUS_BADGE[t.status].label}

--- a/src/server/whatsapp/templates.ts
+++ b/src/server/whatsapp/templates.ts
@@ -197,7 +197,7 @@ export async function syncTemplates(organizationId: string): Promise<number> {
   }
 
   let data: {
-    data?: { id?: string; name?: string; language?: string; status?: string; quality_score?: unknown; rejected_reason?: string }[];
+    data?: { id?: string; name?: string; language?: string; status?: string; category?: string; quality_score?: unknown; rejected_reason?: string }[];
   };
   try {
     data = await graphRequest(`${creds.wabaId}/message_templates`, {
@@ -229,11 +229,16 @@ export async function syncTemplates(organizationId: string): Promise<number> {
         (remote.id && t.waTemplateId === remote.id) ||
         (t.name === remote.name && t.language === remote.language)
     );
-    if (!match || match.status === status) continue;
+    if (!match) continue;
+    // Meta reclasifica la categoría al aprobar (una UTILITY puede volverse
+    // MARKETING, lo que cambia el costo por conversación): es autoridad.
+    const category = remote.category ?? match.category;
+    if (match.status === status && match.category === category) continue;
     await db
       .update(schema.template)
       .set({
         status,
+        category,
         rejectionReason: remote.rejected_reason ?? null,
         waTemplateId: match.waTemplateId ?? remote.id ?? null,
         updatedAt: new Date(),

--- a/tests/e2e/us6-templates.md
+++ b/tests/e2e/us6-templates.md
@@ -14,6 +14,28 @@
    ✅ Estado "Rechazada" mostrando la razón.
 4. `POST /api/templates/sync` → 200 (pull por Graph; cubre modo agencia).
 
+## Modo agencia: aprobación que NUNCA llega por webhook
+
+> Automatizado en `scripts/e2e-templates-sync.mjs` (13 checks) + comprobación
+> de UI con Playwright. Reproduce un fallo visto en producción.
+
+`message_template_status_update` se entrega al callback **a nivel app**, que en
+modo agencia no es el de esta instancia: sin pull, la plantilla se queda
+"Pendiente de Meta" para siempre aunque Meta ya la haya aprobado.
+
+8. Crear plantilla (UTILITY) y mover el panel simulado de Meta con
+   `POST /api/dev/wa-mock/template-status` `{ event: "APPROVED",
+   category: "MARKETING", notify: false }` — `notify:false` NO entrega webhook.
+   ✅ El CRM sigue en "Pendiente de Meta" (el bug reproducido).
+9. `POST /api/templates/sync`.
+   ✅ `updated: 1`, estado "Aprobada" y categoría **MARKETING** (Meta es la
+   autoridad de la categoría: reclasifica al aprobar y eso cambia el costo).
+   ✅ Un segundo sync devuelve `updated: 0` (idempotente).
+10. Abrir `/settings/templates` con la plantilla en pending y Meta ya aprobada.
+    ✅ El badge muestra "Aprobada" **sin tocar Sincronizar** (auto-sync al
+    montar); si el pull falla, la lista local se pinta igual y el error se
+    calla (solo el botón manual reporta errores).
+
 ## Envío con ventana cerrada
 
 5. Abrir una conversación con ventana cerrada en la bandeja.


### PR DESCRIPTION
## Problema

En **modo agencia**, el webhook `message_template_status_update` se entrega al callback **a nivel app**, que no es el de la instancia. Resultado: una plantilla ya aprobada por Meta se queda en «Pendiente de Meta» para siempre, salvo que alguien recuerde apretar «Sincronizar» a mano.

Pasó en producción: Meta había aprobado la plantilla horas antes y el CRM seguía mostrándola pendiente.

Segundo hallazgo del mismo caso: **Meta reclasifica la categoría al aprobar** (una UTILITY puede volverse MARKETING, lo que cambia el costo por conversación). `syncTemplates` ignoraba ese campo, así que el CRM mentía sobre la categoría.

## Cambios

- La pantalla de Plantillas hace pull silencioso a `/api/templates/sync` al montar. Pinta primero la lista local para no retrasar el render; si el pull falla, la pantalla sigue en pie y solo el botón manual reporta errores.
- `syncTemplates` copia también `category`: Meta es la autoridad de ese campo. Visible ya en la tarjeta.
- wa-mock: `notify:false` y `category` en `template-status`, para reproducir el modo agencia en pruebas (mover el panel de Meta sin entregar webhook).

## Verificación

- `pnpm typecheck && pnpm lint && pnpm test` verde sobre esta rama (116 tests).
- `pnpm build` verde.
- Self-test de comportamiento nuevo `scripts/e2e-templates-sync.mjs`: **13/13**, ejecutado contra esta rama con BD propia. Reproduce el bug (Meta aprueba sin webhook → CRM en pending), el pull arreglándolo, la categoría reclasificada y la idempotencia (segundo sync = `updated: 0`).
- Guion `tests/e2e/us6-templates.md` ampliado con la sección de modo agencia.