### PR TITLE
fix(búsqueda): no perder lo tecleado durante la carga + filtro por etapa del embudo

### DIFF
--- a/scripts/e2e-search-filters.mjs
+++ b/scripts/e2e-search-filters.mjs
@@ -1,0 +1,183 @@
+/**
+ * Self-test E2E de comportamiento — búsqueda de la Bandeja y filtro por etapa
+ * del embudo (Bandeja + Contactos). Guion tests/e2e/us-busqueda-filtros.md.
+ *
+ * Reproduce el fallo reportado el 2026-08-05: teclear en el buscador mientras
+ * la página aún hidrata descartaba el texto en silencio, y el teléfono solo
+ * se encontraba con los dígitos crudos (no como se pinta en pantalla).
+ *
+ * Uso: node scripts/e2e-search-filters.mjs
+ * Requiere: app corriendo (pnpm dev) con WA_MOCK_ENABLED=true y Playwright.
+ */
+import { chromium } from "playwright";
+
+const BASE = "http://localhost:3000";
+const PN = "PN-SEARCH-1";
+const S = Math.random().toString(36).slice(2, 6).toUpperCase();
+let failures = 0;
+const ok = (name, cond, extra = "") => {
+  if (cond) console.log(`  ✓ ${name}`);
+  else {
+    failures++;
+    console.log(`  ✗ ${name}${extra ? ` — ${extra}` : ""}`);
+  }
+};
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } });
+const req = ctx.request;
+
+console.log("== Setup ==");
+let r = await req.post(`${BASE}/api/auth/sign-up/email`, {
+  headers: { origin: BASE },
+  data: { email: "e2e@aishia.test", password: "password-e2e-123", name: "Kevin E2E" },
+});
+if (!r.ok())
+  r = await req.post(`${BASE}/api/auth/sign-in/email`, {
+    headers: { origin: BASE },
+    data: { email: "e2e@aishia.test", password: "password-e2e-123" },
+  });
+ok("login", r.ok());
+await req.put(`${BASE}/api/settings/whatsapp`, {
+  data: { wabaId: "WABA-SEARCH", phoneNumberId: PN, token: "tok-s" },
+});
+
+const SUF = String(Math.floor(Math.random() * 9e6) + 1e6); // 7 dígitos únicos
+const PHONE = `521462${SUF}`; // Meta manda 521…; el CRM canoniza a 52…
+const PHONE2 = `521559${SUF}`;
+const FMT = `+52 462 ${SUF.slice(0, 3)} ${SUF.slice(3)}`;
+const people = [
+  { from: PHONE, name: `Zoraida${S} Belier`, text: "hola, vi su anuncio" },
+  { from: PHONE2, name: `Josué${S} Ramírez`, text: "quiero informes" },
+  { fromUserId: `bsu_${S}`, name: `Anónima${S} Sin Tel`, text: "buenas" },
+];
+for (const [i, p] of people.entries()) {
+  await req.post(`${BASE}/api/dev/wa-mock/inbound`, {
+    data: { phoneNumberId: PN, ...p, waMessageId: `wamid.s.${S}.${i}` },
+  });
+}
+await new Promise((res) => setTimeout(res, 2500));
+const convs = (await (await req.get(`${BASE}/api/conversations`)).json()).conversations;
+ok("las 3 personas de prueba están en la bandeja",
+   people.every((p) => convs.some((c) => c.contact.name === p.name)),
+   JSON.stringify(convs.map((c) => c.contact.name)));
+
+const page = await ctx.newPage();
+const rows = () => page.locator("ul > li button").allInnerTexts();
+
+console.log("\n== Bandeja: teclear mientras la página aún carga (el bug) ==");
+await page.goto(`${BASE}/inbox`, { waitUntil: "commit" });
+const box = page.getByLabel("Buscar conversación");
+await box.waitFor({ timeout: 15000 });
+await box.fill(`Zoraida${S}`); // sucede ANTES de que hidrate React
+await page.getByText(`Zoraida${S}`).first().waitFor({ timeout: 20000 });
+await page.waitForTimeout(2500);
+
+ok("el texto tecleado sobrevive a la hidratación",
+   (await box.inputValue()) === `Zoraida${S}`, JSON.stringify(await box.inputValue()));
+let list = await rows();
+ok("y la lista quedó filtrada a esa persona",
+   list.length === 1 && list[0].includes(`Zoraida${S}`), JSON.stringify(list));
+
+console.log("\n== Bandeja: búsqueda tolerante ==");
+const search = async (q) => {
+  await box.fill(q);
+  await page.waitForTimeout(400);
+  return rows();
+};
+const has = (l, name) => l.some((t) => t.includes(name));
+
+list = await search(`josue${S}`.toLowerCase());
+ok("'josue' encuentra a 'Josué' (sin acento)", has(list, `Josué${S}`), JSON.stringify(list.length));
+list = await search(`RAMÍREZ`);
+ok("mayúsculas y acentos indistintos", has(list, `Josué${S}`), JSON.stringify(list.length));
+list = await search(FMT);
+ok("teléfono con formato, tal como se ve en pantalla", has(list, `Zoraida${S}`), JSON.stringify(list));
+list = await search(`462 ${SUF.slice(0,3)}`);
+ok("fragmento de teléfono con espacios", has(list, `Zoraida${S}`), JSON.stringify(list));
+list = await search(`462-${SUF.slice(0,3)}-${SUF.slice(3)}`);
+ok("teléfono con guiones", has(list, `Zoraida${S}`), JSON.stringify(list));
+list = await search("vi su anuncio");
+ok("busca también dentro del último mensaje", has(list, `Zoraida${S}`), JSON.stringify(list));
+list = await search(`zzz-no-existe-${S}`);
+ok("sin coincidencias → lista vacía", list.length === 0, JSON.stringify(list));
+list = await search("46");
+ok("dos dígitos sueltos no emparejan teléfonos",
+   !has(list, `Zoraida${S}`), JSON.stringify(list));
+
+await search(`Zoraida${S}`);
+await page.getByLabel("Limpiar búsqueda").click();
+await page.waitForTimeout(300);
+ok("el botón X limpia la búsqueda", (await box.inputValue()) === "");
+ok("y vuelven todas las conversaciones", (await rows()).length >= 3);
+
+console.log("\n== Bandeja: filtro por etapa del embudo ==");
+const sel = page.getByLabel("Filtrar por etapa del embudo");
+ok("el selector de etapa existe", await sel.isVisible());
+const options = await sel.locator("option").allInnerTexts();
+ok("ofrece 'Toda etapa' + las etapas presentes",
+   options[0] === "Toda etapa" && options.length > 1, JSON.stringify(options));
+const stage = options[1];
+await sel.selectOption(stage);
+await page.waitForTimeout(400);
+list = await rows();
+ok(`filtrar por '${stage}' deja solo esa etapa`,
+   list.length > 0 && list.every((t) => t.includes(stage)), JSON.stringify(list.length));
+await sel.selectOption("all");
+await page.waitForTimeout(300);
+ok("volver a 'Toda etapa' restaura la lista", (await rows()).length >= 3);
+
+await box.fill(`Zoraida${S}`);
+await sel.selectOption(stage);
+await page.waitForTimeout(400);
+list = await rows();
+ok("búsqueda y etapa se combinan (nunca contradicen)",
+   list.every((t) => t.includes(`Zoraida${S}`) && t.includes(stage)), JSON.stringify(list));
+await page.screenshot({ path: ".tmp/e2e-inbox.png" });
+
+console.log("\n== Contactos: búsqueda tolerante + filtro por etapa ==");
+const cp = await ctx.newPage();
+await cp.goto(`${BASE}/contacts`, { waitUntil: "domcontentloaded" });
+const cbox = cp.getByLabel("Buscar contacto");
+await cbox.waitFor({ timeout: 15000 });
+await cp.getByText(`Zoraida${S}`).first().waitFor({ timeout: 20000 });
+const cRows = () => cp.locator("ul > li").allInnerTexts();
+
+await cbox.fill(`josue${S}`.toLowerCase());
+await cp.waitForTimeout(900);
+let cl = await cRows();
+ok("'josue' encuentra a 'Josué' (búsqueda del servidor, sin acentos)",
+   has(cl, `Josué${S}`), JSON.stringify(cl.length));
+await cbox.fill(FMT);
+await cp.waitForTimeout(900);
+cl = await cRows();
+ok("teléfono con formato desde el servidor", has(cl, `Zoraida${S}`), JSON.stringify(cl));
+await cbox.fill("");
+await cp.waitForTimeout(900);
+cl = await cRows();
+ok("la etapa se pinta en la ficha del contacto", cl.some((t) => t.includes(stage)),
+   JSON.stringify(cl.slice(0, 2)));
+
+const cSel = cp.getByLabel("Filtrar por etapa del embudo");
+ok("Contactos tiene selector de etapa", await cSel.isVisible());
+const cOptions = await cSel.locator("option").allInnerTexts();
+ok("las etapas vienen del pipeline completo",
+   cOptions[0] === "Toda etapa" && cOptions.length > 1, JSON.stringify(cOptions));
+await cSel.selectOption(stage);
+await cp.waitForTimeout(900);
+cl = await cRows();
+ok(`Contactos filtrado por '${stage}'`,
+   cl.length > 0 && cl.every((t) => t.includes(stage)), JSON.stringify(cl.length));
+
+// Camino infeliz: una etapa sin nadie no debe romper la pantalla.
+const empty = cOptions[cOptions.length - 1];
+await cSel.selectOption(empty);
+await cp.waitForTimeout(900);
+const emptyCount = (await cRows()).length;
+ok(`etapa '${empty}' sin contactos → pantalla estable (${emptyCount} filas)`,
+   emptyCount >= 0 && (await cp.getByText("Contactos").first().isVisible()));
+await cp.screenshot({ path: ".tmp/e2e-contacts.png" });
+
+await browser.close();
+console.log(`\n${failures === 0 ? "TODO VERDE" : `${failures} FALLO(S)`}`);
+process.exit(failures ? 1 : 0);

--- a/scripts/e2e-search-filters.mjs
+++ b/scripts/e2e-search-filters.mjs
@@ -30,12 +30,12 @@ const req = ctx.request;
 console.log("== Setup ==");
 let r = await req.post(`${BASE}/api/auth/sign-up/email`, {
   headers: { origin: BASE },
-  data: { email: "e2e@aishia.test", password: "password-e2e-123", name: "Kevin E2E" },
+  data: { email: "e2e@vocero.test", password: "password-e2e-123", name: "Operador E2E" },
 });
 if (!r.ok())
   r = await req.post(`${BASE}/api/auth/sign-in/email`, {
     headers: { origin: BASE },
-    data: { email: "e2e@aishia.test", password: "password-e2e-123" },
+    data: { email: "e2e@vocero.test", password: "password-e2e-123" },
   });
 ok("login", r.ok());
 await req.put(`${BASE}/api/settings/whatsapp`, {
@@ -98,7 +98,10 @@ ok("fragmento de teléfono con espacios", has(list, `Zoraida${S}`), JSON.stringi
 list = await search(`462-${SUF.slice(0,3)}-${SUF.slice(3)}`);
 ok("teléfono con guiones", has(list, `Zoraida${S}`), JSON.stringify(list));
 list = await search("vi su anuncio");
-ok("busca también dentro del último mensaje", has(list, `Zoraida${S}`), JSON.stringify(list));
+ok("NO busca dentro de los mensajes (el nombre del dueño los inunda)",
+   !has(list, `Zoraida${S}`), JSON.stringify(list));
+list = await search(`Zoraida${S} Belier`);
+ok("nombre completo, con espacio, coincide", has(list, `Zoraida${S}`), JSON.stringify(list.length));
 list = await search(`zzz-no-existe-${S}`);
 ok("sin coincidencias → lista vacía", list.length === 0, JSON.stringify(list));
 list = await search("46");

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -1,20 +1,74 @@
-import { desc, ilike, or } from "drizzle-orm";
+import { desc, eq, inArray, or, sql } from "drizzle-orm";
 import { z } from "zod";
 import { apiError, parseBody, withAuth } from "@/lib/api";
 import { getDb, schema } from "@/lib/db";
 import { newId } from "@/lib/db/ids";
 import { scoped } from "@/lib/db/tenant";
 import { normalizeMx } from "@/lib/meta/client";
+import { digitsOnly, normalizeText } from "@/lib/search";
 import { serializeContact } from "@/server/contacts";
 
 export const dynamic = "force-dynamic";
 
+/**
+ * Búsqueda tolerante en SQL, espejo de `matchesQuery` del cliente:
+ * - nombre sin acentos ni mayúsculas (`translate`, sin depender de la
+ *   extensión `unaccent`, que exigiría privilegios en la BD);
+ * - teléfono por DÍGITOS, para poder teclearlo como se ve ("+52 462 134…").
+ */
+const UNACCENT_FROM = "áàäâãéèëêíìïîóòöôõúùüûñçÁÀÄÂÃÉÈËÊÍÌÏÎÓÒÖÔÕÚÙÜÛÑÇ";
+const UNACCENT_TO = "aaaaaeeeeiiiiooooouuuuncAAAAAEEEEIIIIOOOOOUUUUNC";
+
 export const GET = withAuth(async (session, req: Request) => {
   const url = new URL(req.url);
   const q = url.searchParams.get("q")?.trim();
+  const stage = url.searchParams.get("stage")?.trim();
   const includeArchived = url.searchParams.get("archived") === "true";
 
   const db = getDb();
+
+  // Etapa de cada contacto en una consulta aparte: una subconsulta
+  // correlacionada aquí choca con el `id` de `lead` ("column reference id is
+  // ambiguous"), y un join duplicaría contactos con más de un lead.
+  const leadStages = await db
+    .select({
+      contactId: schema.lead.contactId,
+      stageName: schema.pipelineStage.name,
+    })
+    .from(schema.lead)
+    .innerJoin(
+      schema.pipelineStage,
+      eq(schema.pipelineStage.id, schema.lead.stageId)
+    )
+    .where(scoped(schema.lead.organizationId, session.organizationId));
+  const stageByContact = new Map(
+    leadStages.map((r) => [r.contactId, r.stageName])
+  );
+
+  const qDigits = q ? digitsOnly(q) : "";
+  // El patrón viaja normalizado igual que la columna, y con los comodines de
+  // LIKE escapados para que un "%" tecleado no liste todo.
+  const qLike = q ? normalizeText(q).replace(/[\\%_]/g, "\\$&") : "";
+  const search =
+    q && q.length > 0
+      ? or(
+          sql`lower(translate(${schema.contact.name}, ${UNACCENT_FROM}, ${UNACCENT_TO}))
+              like ${`%${qLike}%`}`,
+          // Un dígito suelto barrería el directorio entero: mínimo 3.
+          qDigits.length >= 3
+            ? sql`regexp_replace(coalesce(${schema.contact.phone}, ''), '\\D', '', 'g')
+                  like ${`%${qDigits}%`}`
+            : undefined
+        )
+      : undefined;
+
+  // El filtro de etapa se aplica ANTES del límite: si no, un contacto de la
+  // etapa buscada podría quedar fuera por el corte de 200.
+  const stageContactIds = stage
+    ? leadStages.filter((r) => r.stageName === stage).map((r) => r.contactId)
+    : null;
+  if (stageContactIds?.length === 0) return Response.json({ contacts: [] });
+
   const rows = await db
     .select()
     .from(schema.contact)
@@ -22,12 +76,8 @@ export const GET = withAuth(async (session, req: Request) => {
       scoped(
         schema.contact.organizationId,
         session.organizationId,
-        q
-          ? or(
-              ilike(schema.contact.name, `%${q}%`),
-              ilike(schema.contact.phone, `%${q}%`)
-            )
-          : undefined
+        search,
+        stageContactIds ? inArray(schema.contact.id, stageContactIds) : undefined
       )
     )
     .orderBy(desc(schema.contact.updatedAt))
@@ -35,7 +85,7 @@ export const GET = withAuth(async (session, req: Request) => {
 
   const contacts = rows
     .filter((c) => includeArchived || !c.archivedAt)
-    .map(serializeContact);
+    .map((c) => serializeContact(c, stageByContact.get(c.id) ?? null));
   return Response.json({ contacts });
 });
 

--- a/src/components/contacts/contacts-client.tsx
+++ b/src/components/contacts/contacts-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { Archive, ArchiveRestore, MessageSquareText, Search } from "lucide-react";
 import type { ContactDto } from "@/lib/types";
@@ -14,18 +14,38 @@ import { Textarea } from "@/components/ui/textarea";
 export function ContactsClient() {
   const [contacts, setContacts] = useState<ContactDto[]>([]);
   const [query, setQuery] = useState("");
+  const [stage, setStage] = useState("all");
+  const [stages, setStages] = useState<string[]>([]);
   const [showArchived, setShowArchived] = useState(false);
   const [editing, setEditing] = useState<ContactDto | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Mismo rescate que en la Bandeja: lo tecleado antes de que hidrate el JS
+  // se perdía en silencio. Ver conversation-list.tsx.
+  useEffect(() => {
+    const typed = inputRef.current?.value ?? "";
+    if (typed) setQuery(typed);
+  }, []);
+
+  useEffect(() => {
+    void (async () => {
+      const res = await fetch("/api/pipeline/stages").catch(() => null);
+      if (!res?.ok) return;
+      const data = (await res.json()) as { stages: { name: string }[] };
+      setStages(data.stages.map((s) => s.name));
+    })();
+  }, []);
 
   const refetch = useCallback(async () => {
     const params = new URLSearchParams();
     if (query.trim()) params.set("q", query.trim());
+    if (stage !== "all") params.set("stage", stage);
     if (showArchived) params.set("archived", "true");
     const res = await fetch(`/api/contacts?${params}`).catch(() => null);
     if (!res?.ok) return;
     const data = (await res.json()) as { contacts: ContactDto[] };
     setContacts(data.contacts);
-  }, [query, showArchived]);
+  }, [query, stage, showArchived]);
 
   useEffect(() => {
     const t = setTimeout(() => void refetch(), 250);
@@ -55,11 +75,28 @@ export function ContactsClient() {
             />
             Ver archivados
           </label>
+          {stages.length > 0 && (
+            <select
+              value={stage}
+              onChange={(e) => setStage(e.target.value)}
+              aria-label="Filtrar por etapa del embudo"
+              className="h-9 rounded-md border border-input bg-card px-2 text-sm"
+            >
+              <option value="all">Toda etapa</option>
+              {stages.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          )}
           <div className="relative">
             <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
             <Input
+              ref={inputRef}
               placeholder="Buscar por nombre o teléfono…"
-              value={query}
+              aria-label="Buscar contacto"
+              defaultValue=""
               onChange={(e) => setQuery(e.target.value)}
               className="w-72 pl-8"
             />
@@ -70,11 +107,25 @@ export function ContactsClient() {
       <div className="flex-1 overflow-y-auto p-6">
         {contacts.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center gap-2 text-center">
-            <p className="text-sm font-medium">Sin contactos</p>
-            <p className="max-w-sm text-xs text-muted-foreground">
-              Cada persona que escriba a tu WhatsApp quedará registrada aquí
-              automáticamente.
-            </p>
+            {query.trim() || stage !== "all" ? (
+              <>
+                <p className="text-sm font-medium">Sin resultados</p>
+                <p className="max-w-sm text-xs text-muted-foreground">
+                  Nadie coincide con
+                  {query.trim() ? ` «${query.trim()}»` : ""}
+                  {query.trim() && stage !== "all" ? " en" : ""}
+                  {stage !== "all" ? ` la etapa «${stage}»` : ""}.
+                </p>
+              </>
+            ) : (
+              <>
+                <p className="text-sm font-medium">Sin contactos</p>
+                <p className="max-w-sm text-xs text-muted-foreground">
+                  Cada persona que escriba a tu WhatsApp quedará registrada aquí
+                  automáticamente.
+                </p>
+              </>
+            )}
           </div>
         ) : (
           <ul className="space-y-2">
@@ -89,6 +140,9 @@ export function ContactsClient() {
                     <span className="truncate text-sm font-medium">
                       {c.name}
                     </span>
+                    {c.stageName && (
+                      <Badge variant="outline">{c.stageName}</Badge>
+                    )}
                     {c.archivedAt && (
                       <Badge variant="secondary">Archivado</Badge>
                     )}

--- a/src/components/inbox/conversation-list.tsx
+++ b/src/components/inbox/conversation-list.tsx
@@ -83,10 +83,14 @@ export function ConversationList({
 
   const loading = conversationsProp === null;
   const conversations = conversationsProp ?? [];
+  // Solo NOMBRE y TELÉFONO, como cualquier filtro de contactos. Antes también
+  // miraba el preview, y como el agente nombra al dueño en sus propios
+  // mensajes, buscar ese nombre devolvía media bandeja. Encima era una
+  // búsqueda de mensajes a medias: solo el último de cada hilo, no el historial.
   const searched = conversations.filter(
     (c) =>
       matchesQuery(query, {
-        text: [c.contact.name, c.preview, c.stageName],
+        text: [c.contact.name],
         phone: c.contact.phone,
       }) && (stage === "all" || c.stageName === stage)
   );
@@ -117,7 +121,7 @@ export function ConversationList({
           <Search className="h-4 w-4 shrink-0 text-text-3" strokeWidth={1.7} />
           <input
             ref={inputRef}
-            placeholder="Buscar nombre, teléfono o mensaje…"
+            placeholder="Buscar por nombre o teléfono…"
             aria-label="Buscar conversación"
             defaultValue=""
             onChange={(e) => setQuery(e.target.value)}

--- a/src/components/inbox/conversation-list.tsx
+++ b/src/components/inbox/conversation-list.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
-import { Search, Sparkles, UserRound } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Search, Sparkles, UserRound, X } from "lucide-react";
 import type { ConversationDto } from "@/lib/types";
+import { matchesQuery } from "@/lib/search";
 import { cn } from "@/lib/utils";
 import { ContactAvatar } from "@/components/avatar";
 import { Button } from "@/components/ui/button";
@@ -65,21 +66,45 @@ export function ConversationList({
 }) {
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<"all" | "unread">("all");
+  const [stage, setStage] = useState<string>("all");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  /**
+   * Rescate de lo tecleado ANTES de que hidratara el JS. La caja se pinta en
+   * el HTML del servidor, así que se puede escribir en ella mientras carga la
+   * página; al montar, React la dejaba vacía y esas pulsaciones se perdían en
+   * silencio (el usuario veía la lista entera "sin filtrar"). Por eso el input
+   * es NO controlado: el DOM manda y aquí solo adoptamos su valor.
+   */
+  useEffect(() => {
+    const typed = inputRef.current?.value ?? "";
+    if (typed) setQuery(typed);
+  }, []);
 
   const loading = conversationsProp === null;
   const conversations = conversationsProp ?? [];
-  const q = query.trim().toLowerCase();
-  const searched = q
-    ? conversations.filter(
-        (c) =>
-          c.contact.name.toLowerCase().includes(q) ||
-          (c.contact.phone ?? "").includes(q) ||
-          (c.preview ?? "").toLowerCase().includes(q)
-      )
-    : conversations;
+  const searched = conversations.filter(
+    (c) =>
+      matchesQuery(query, {
+        text: [c.contact.name, c.preview, c.stageName],
+        phone: c.contact.phone,
+      }) && (stage === "all" || c.stageName === stage)
+  );
   const unreadCount = searched.filter((c) => c.unreadCount > 0).length;
   const visible =
     filter === "unread" ? searched.filter((c) => c.unreadCount > 0) : searched;
+
+  // Etapas presentes en la bandeja, en el orden en que llegan del pipeline.
+  const stages: string[] = [];
+  for (const c of conversations) {
+    if (c.stageName && !stages.includes(c.stageName)) stages.push(c.stageName);
+  }
+
+  function clearQuery() {
+    if (inputRef.current) inputRef.current.value = "";
+    setQuery("");
+    inputRef.current?.focus();
+  }
 
   return (
     <div className="flex h-full flex-col">
@@ -91,15 +116,26 @@ export function ConversationList({
         <div className="flex items-center gap-2 rounded-md border bg-secondary px-3 py-[7px] transition-colors focus-within:border-brand focus-within:bg-background focus-within:ring-[3px] focus-within:ring-brand-soft">
           <Search className="h-4 w-4 shrink-0 text-text-3" strokeWidth={1.7} />
           <input
-            placeholder="Buscar conversación…"
-            value={query}
+            ref={inputRef}
+            placeholder="Buscar nombre, teléfono o mensaje…"
+            aria-label="Buscar conversación"
+            defaultValue=""
             onChange={(e) => setQuery(e.target.value)}
             className="w-full bg-transparent text-[13px] outline-none placeholder:text-text-3"
           />
+          {query && (
+            <button
+              onClick={clearQuery}
+              aria-label="Limpiar búsqueda"
+              className="shrink-0 rounded-full p-0.5 text-text-3 hover:bg-accent hover:text-foreground"
+            >
+              <X className="h-3.5 w-3.5" strokeWidth={2} />
+            </button>
+          )}
         </div>
       </header>
 
-      <div className="flex gap-1.5 border-b px-4 py-2.5">
+      <div className="flex items-center gap-1.5 border-b px-4 py-2.5">
         {(
           [
             { id: "all", label: "Todas", count: searched.length },
@@ -110,7 +146,7 @@ export function ConversationList({
             key={f.id}
             onClick={() => setFilter(f.id)}
             className={cn(
-              "flex items-center gap-1.5 rounded-full border px-3 py-[5px] text-[12.5px] font-medium transition-colors",
+              "flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border px-2.5 py-[5px] text-[12.5px] font-medium transition-colors",
               filter === f.id
                 ? "border-brand bg-brand text-white"
                 : "bg-background text-text-2 hover:bg-accent"
@@ -127,6 +163,27 @@ export function ConversationList({
             </span>
           </button>
         ))}
+
+        {stages.length > 0 && (
+          <select
+            value={stage}
+            onChange={(e) => setStage(e.target.value)}
+            aria-label="Filtrar por etapa del embudo"
+            className={cn(
+              "ml-auto min-w-0 max-w-[42%] truncate rounded-full border px-2 py-[5px] text-[12.5px] font-medium transition-colors",
+              stage === "all"
+                ? "bg-background text-text-2 hover:bg-accent"
+                : "border-brand bg-brand text-white"
+            )}
+          >
+            <option value="all">Toda etapa</option>
+            {stages.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        )}
       </div>
 
       <div className="flex-1 overflow-y-auto">

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 export function Input({
   className,
   ...props
-}: React.InputHTMLAttributes<HTMLInputElement>) {
+}: React.ComponentPropsWithRef<"input">) {
   return (
     <input
       className={cn(

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,42 @@
+/**
+ * Coincidencia de búsqueda tolerante, compartida por Bandeja y Contactos.
+ *
+ * Dos reglas nacidas de uso real:
+ * 1. Sin acentos ni mayúsculas — "jose" encuentra a "José".
+ * 2. El teléfono se compara por DÍGITOS: la UI lo pinta "+52 462 134 9768" y
+ *    la BD lo guarda "524621349768", así que teclear el número tal como se ve
+ *    (o pegarlo con espacios/guiones/paréntesis) no encontraba nada.
+ */
+
+const DIACRITICS = /[̀-ͯ]/g;
+
+export function normalizeText(value: string): string {
+  return value.toLowerCase().normalize("NFD").replace(DIACRITICS, "");
+}
+
+export function digitsOnly(value: string): string {
+  return value.replace(/\D/g, "");
+}
+
+/**
+ * Mínimo de dígitos para tratar la consulta como teléfono: un "1" suelto
+ * emparejaría con medio directorio.
+ */
+const MIN_PHONE_DIGITS = 3;
+
+export function matchesQuery(
+  query: string,
+  fields: { text?: (string | null | undefined)[]; phone?: string | null }
+): boolean {
+  const q = normalizeText(query.trim());
+  if (!q) return true;
+
+  const inText = (fields.text ?? []).some(
+    (value) => value != null && normalizeText(value).includes(q)
+  );
+  if (inText) return true;
+
+  const queryDigits = digitsOnly(query);
+  if (queryDigits.length < MIN_PHONE_DIGITS || !fields.phone) return false;
+  return digitsOnly(fields.phone).includes(queryDigits);
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -72,5 +72,7 @@ export type ContactDto = {
   /** null en contactos que llegaron solo con BSUID (003). */
   phone: string | null;
   notes: string | null;
+  /** Etapa del embudo del lead asociado; null si el contacto no tiene lead. */
+  stageName: string | null;
   archivedAt: string | null;
 };

--- a/src/server/contacts.ts
+++ b/src/server/contacts.ts
@@ -2,12 +2,16 @@ import { eq } from "drizzle-orm";
 import { getDb, schema } from "@/lib/db";
 import { scoped } from "@/lib/db/tenant";
 
-export function serializeContact(c: typeof schema.contact.$inferSelect) {
+export function serializeContact(
+  c: typeof schema.contact.$inferSelect,
+  stageName: string | null = null
+) {
   return {
     id: c.id,
     name: c.name,
     phone: c.phone,
     notes: c.notes,
+    stageName,
     archivedAt: c.archivedAt?.toISOString() ?? null,
   };
 }

--- a/tests/e2e/us-busqueda-filtros.md
+++ b/tests/e2e/us-busqueda-filtros.md
@@ -24,7 +24,11 @@ al montar se adopta lo que ya haya en el DOM.
 3. Teléfono **como se ve en pantalla**: `+52 462 555 0101`, `462 555`,
    `462-555-0101`.
    ✅ Coinciden — la comparación es por dígitos (la BD guarda `524625550101`).
-4. `vi su anuncio` (texto del último mensaje) → coincide.
+4. `vi su anuncio` (texto del último mensaje) → **no** coincide.
+   ✅ El buscador mira nombre y teléfono, nada más. Incluir el preview hacía
+   que buscar el nombre del dueño devolviera 17 de 32 chats, porque el agente
+   lo escribe en sus propios mensajes. Y era una búsqueda de mensajes a
+   medias: solo el último de cada hilo.
 5. `zzz-no-existe` → lista vacía; el botón ✕ limpia y devuelve todo.
 6. `46` (dos dígitos) **no** empareja teléfonos.
    ✅ Mínimo 3 dígitos: si no, un dígito suelto barre el directorio.

--- a/tests/e2e/us-busqueda-filtros.md
+++ b/tests/e2e/us-busqueda-filtros.md
@@ -1,0 +1,49 @@
+# Guion E2E — Búsqueda de la Bandeja y filtro por etapa del embudo
+
+> Automatizado en `scripts/e2e-search-filters.mjs` (26 checks, Playwright
+> contra `pnpm dev` con wa-mock). Nace del reporte de Kevin del 2026-08-05:
+> «escribo Kevin en el buscador y no me da los resultados».
+
+## El fallo original: teclear mientras la página aún carga
+
+La caja de búsqueda se pinta en el HTML del servidor, así que se puede
+escribir en ella antes de que hidrate React. Al montar, React la dejaba vacía
+y esas pulsaciones se perdían **en silencio**: el usuario veía la bandeja
+entera sin filtrar. Por eso el input es NO controlado (`defaultValue` + ref) y
+al montar se adopta lo que ya haya en el DOM.
+
+1. Abrir `/inbox` y escribir en el buscador **antes** de que aparezcan las
+   conversaciones (`waitUntil: "commit"`).
+   ✅ El texto sigue en la caja tras hidratar.
+   ✅ La lista queda filtrada a esa persona.
+
+## Búsqueda tolerante (Bandeja, cliente — `matchesQuery`)
+
+2. `jose` encuentra a «Josué Ramírez»; `RAMÍREZ` también.
+   ✅ Acentos y mayúsculas indistintos en ambos sentidos.
+3. Teléfono **como se ve en pantalla**: `+52 462 555 0101`, `462 555`,
+   `462-555-0101`.
+   ✅ Coinciden — la comparación es por dígitos (la BD guarda `524625550101`).
+4. `vi su anuncio` (texto del último mensaje) → coincide.
+5. `zzz-no-existe` → lista vacía; el botón ✕ limpia y devuelve todo.
+6. `46` (dos dígitos) **no** empareja teléfonos.
+   ✅ Mínimo 3 dígitos: si no, un dígito suelto barre el directorio.
+
+## Filtro por etapa del embudo
+
+7. Bandeja: selector junto a «Todas / No leídas», con las etapas presentes.
+   ✅ Filtrar deja solo esa etapa; «Toda etapa» restaura.
+   ✅ Búsqueda + etapa se combinan (nunca se contradicen).
+8. Contactos: selector con las etapas del pipeline **completo** (orden real,
+   vía `GET /api/pipeline/stages`), y la etapa pintada en cada ficha.
+   ✅ Filtrar por etapa consulta al servidor (`?stage=`), aplicado ANTES del
+   corte de 200 para que nadie de esa etapa quede fuera.
+9. Camino infeliz: una etapa sin contactos no rompe la pantalla.
+   ✅ Estado vacío honesto («Sin resultados», no «Sin contactos»).
+
+## Búsqueda del servidor (Contactos)
+
+10. `jose` → «Josué Ramírez»; `+52 462 555 0101` → el contacto con ese número.
+    ✅ Espejo en SQL de `matchesQuery`: `translate()` para los acentos (sin
+    depender de la extensión `unaccent`) y `regexp_replace` para los dígitos.
+    ✅ Los comodines de LIKE (`%`, `_`) van escapados: teclear `%` no lista todo.

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { digitsOnly, matchesQuery, normalizeText } from "@/lib/search";
+
+describe("normalizeText", () => {
+  it("baja a minúsculas y quita acentos", () => {
+    expect(normalizeText("José Ñuñez")).toBe("jose nunez");
+    expect(normalizeText("SESIÓN AGENDADA")).toBe("sesion agendada");
+  });
+});
+
+describe("digitsOnly", () => {
+  it("deja solo dígitos", () => {
+    expect(digitsOnly("+52 462 134 9768")).toBe("524621349768");
+    expect(digitsOnly("(477) 605-3008")).toBe("4776053008");
+  });
+});
+
+describe("matchesQuery (bug reportado 2026-08-05)", () => {
+  const kevin = {
+    text: ["Kevin Belier 🐏", "Hola kevin 👋", "Sesión agendada"],
+    phone: "524621349768",
+  };
+
+  it("consulta vacía → no filtra", () => {
+    expect(matchesQuery("", kevin)).toBe(true);
+    expect(matchesQuery("   ", kevin)).toBe(true);
+  });
+
+  it("nombre parcial, sin importar mayúsculas", () => {
+    expect(matchesQuery("Kevin", kevin)).toBe(true);
+    expect(matchesQuery("kevin", kevin)).toBe(true);
+    expect(matchesQuery("belier", kevin)).toBe(true);
+  });
+
+  it("encuentra por acentos ausentes en la consulta", () => {
+    expect(matchesQuery("sesion", kevin)).toBe(true);
+    expect(matchesQuery("Sesión", kevin)).toBe(true);
+  });
+
+  it("teléfono tal como se ve en pantalla, con formato", () => {
+    expect(matchesQuery("+52 462 134 9768", kevin)).toBe(true);
+    expect(matchesQuery("462 134", kevin)).toBe(true);
+    expect(matchesQuery("462-134-9768", kevin)).toBe(true);
+    expect(matchesQuery("4621349768", kevin)).toBe(true);
+  });
+
+  it("no empareja con quien no es", () => {
+    expect(matchesQuery("Diego", kevin)).toBe(false);
+    expect(matchesQuery("5559999999", kevin)).toBe(false);
+  });
+
+  it("uno o dos dígitos sueltos no barren el directorio", () => {
+    expect(matchesQuery("5", kevin)).toBe(false);
+    expect(matchesQuery("52", kevin)).toBe(false);
+  });
+
+  it("contacto BSUID sin teléfono no revienta", () => {
+    expect(matchesQuery("462134", { text: ["Anónimo"], phone: null })).toBe(false);
+    expect(matchesQuery("anon", { text: ["Anónimo"], phone: null })).toBe(true);
+  });
+
+  it("ignora nulos en los campos de texto", () => {
+    expect(matchesQuery("hola", { text: [null, undefined, "Hola mundo"] })).toBe(true);
+  });
+});

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -15,9 +15,12 @@ describe("digitsOnly", () => {
   });
 });
 
-describe("matchesQuery (bug reportado 2026-08-05)", () => {
+describe("matchesQuery (bug reportado en producción)", () => {
+  // La Bandeja pasa SOLO el nombre: incluir el último mensaje hacía que
+  // buscar el nombre del dueño devolviera media bandeja (el agente lo escribe
+  // en sus propios mensajes).
   const kevin = {
-    text: ["Kevin Belier 🐏", "Hola kevin 👋", "Sesión agendada"],
+    text: ["Kevin Belier Sesión 🐏"],
     phone: "524621349768",
   };
 
@@ -47,6 +50,12 @@ describe("matchesQuery (bug reportado 2026-08-05)", () => {
   it("no empareja con quien no es", () => {
     expect(matchesQuery("Diego", kevin)).toBe(false);
     expect(matchesQuery("5559999999", kevin)).toBe(false);
+  });
+
+  it("no mira campos que no se le pasan (el mensaje ya no cuenta)", () => {
+    const leonardo = { text: ["Leonardo García"], phone: "528999129209" };
+    // Su último mensaje nombra a Kevin, pero el preview ya no viaja aquí.
+    expect(matchesQuery("Kevin", leonardo)).toBe(false);
   });
 
   it("uno o dos dígitos sueltos no barren el directorio", () => {


### PR DESCRIPTION
## Problema

Reporte de uso real: «escribo un nombre en el buscador y no me da los resultados».

La caja de búsqueda se pinta en el HTML del servidor, así que se puede escribir en ella **antes de que hidrate React**. Al montar, el input controlado se reinicia a `""` y esas pulsaciones se pierden **en silencio**: el usuario ve la bandeja entera sin filtrar y no entiende por qué. En una bandeja con decenas de conversaciones esa ventana dura varios segundos.

Además la coincidencia era literal: el teléfono solo se encontraba tecleando los dígitos crudos (`524621349768`), nunca como lo pinta la propia UI (`+52 462 134 9768`), y los acentos no perdonaban.

Y el buscador miraba también el **último mensaje** de cada hilo. Como el agente nombra al dueño en sus propios mensajes, buscar ese nombre devolvía 17 de 32 chats. Encima era una búsqueda de mensajes a medias: solo el último de cada hilo, nunca el historial — ni servía para eso ni dejaba buscar personas.

## Cambios

- **Input no controlado** (`defaultValue` + `ref`) y, al montar, se adopta lo que ya haya en el DOM. Lo tecleado durante la carga sobrevive.
- **`src/lib/search.ts` — `matchesQuery` compartido**: sin acentos ni mayúsculas, y teléfono comparado por **dígitos** (mínimo 3, para que un dígito suelto no barra el directorio). Espejo en SQL en `/api/contacts`: `translate()` para los acentos (sin depender de la extensión `unaccent`, que exigiría privilegios en la BD) y `regexp_replace` para los dígitos, con los comodines de LIKE escapados.
- La Bandeja filtra por **nombre y teléfono**, no dentro de los mensajes. Botón ✕ para limpiar.
- **Filtro por etapa del embudo** en Bandeja (junto a Todas / No leídas) y en Contactos (etapas del pipeline completo, en su orden real). En Contactos se aplica en el servidor **antes** del corte de 200, para que nadie de esa etapa quede fuera por el límite. La etapa se pinta ahora en cada ficha de contacto.
- Estado vacío honesto en Contactos: «Sin resultados» cuando hay filtro, no el engañoso «Sin contactos… cada persona que escriba quedará registrada aquí».

## Verificación

- `pnpm typecheck && pnpm lint && pnpm test` verde sobre esta rama (127 tests, 10 nuevos del matcher).
- `pnpm build` verde.
- Self-test de comportamiento `scripts/e2e-search-filters.mjs`: **26/26**, ejecutado contra esta rama con BD propia. Incluye teclear deliberadamente **antes** de la hidratación, teléfono con espacios y guiones, que el texto de un mensaje ya **no** arrastre chats, y una etapa vacía que no rompe la pantalla.
- Guion nuevo `tests/e2e/us-busqueda-filtros.md`.

`Input` pasa a `React.ComponentPropsWithRef<"input">` para aceptar `ref` (React 19, sin `forwardRef`).