### PR TITLE
fix(envío): mostrar POR QUÉ falló un mensaje, no un triángulo mudo

### DIFF
--- a/scripts/e2e-send-failure.mjs
+++ b/scripts/e2e-send-failure.mjs
@@ -1,0 +1,139 @@
+/**
+ * Self-test E2E de comportamiento — un envío fallido DEBE decir por qué.
+ * Guion tests/e2e/us-envio-fallido.md.
+ *
+ * Reproduce un caso real: se manda una plantilla APROBADA y el operador solo
+ * ve un triángulo mudo. Meta sí había explicado el motivo (error 130472,
+ * "User's number is part of an experiment"): el CRM lo guardaba en
+ * `message.error` y nunca lo mostraba.
+ *
+ * Uso: node scripts/e2e-send-failure.mjs
+ * Requiere: app corriendo (pnpm dev) con WA_MOCK_ENABLED=true y Playwright.
+ */
+import { chromium } from "playwright";
+
+const BASE = "http://localhost:3000";
+const PN = "PN-FAIL-1";
+const S = Math.random().toString(36).slice(2, 6).toUpperCase();
+let failures = 0;
+const ok = (name, cond, extra = "") => {
+  if (cond) console.log(`  ✓ ${name}`);
+  else {
+    failures++;
+    console.log(`  ✗ ${name}${extra ? ` — ${extra}` : ""}`);
+  }
+};
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } });
+const req = ctx.request;
+
+console.log("== Setup ==");
+let r = await req.post(`${BASE}/api/auth/sign-up/email`, {
+  headers: { origin: BASE },
+  data: { email: "e2e@vocero.test", password: "password-e2e-123", name: "Operador E2E" },
+});
+if (!r.ok())
+  r = await req.post(`${BASE}/api/auth/sign-in/email`, {
+    headers: { origin: BASE },
+    data: { email: "e2e@vocero.test", password: "password-e2e-123" },
+  });
+ok("login", r.ok());
+await req.put(`${BASE}/api/settings/whatsapp`, {
+  data: { wabaId: "WABA-FAIL", phoneNumberId: PN, token: "tok-f" },
+});
+
+const NAME = `Destino${S}`;
+await req.post(`${BASE}/api/dev/wa-mock/inbound`, {
+  data: {
+    phoneNumberId: PN,
+    from: `521477${Math.floor(Math.random() * 9e6) + 1e6}`,
+    name: NAME,
+    text: "hola",
+    waMessageId: `wamid.fail.${S}`,
+  },
+});
+await new Promise((res) => setTimeout(res, 2000));
+
+const convs = (await (await req.get(`${BASE}/api/conversations`)).json()).conversations;
+const conv = convs.find((c) => c.contact.name === NAME);
+ok("conversación de prueba creada", !!conv);
+
+const sent = await req.post(`${BASE}/api/conversations/${conv.id}/messages`, {
+  data: { text: "mensaje que Meta va a rechazar" },
+});
+ok("mensaje enviado (queda pending)", sent.ok());
+
+let msgs = (await (await req.get(`${BASE}/api/conversations/${conv.id}/messages`)).json()).messages;
+const out = msgs.filter((m) => m.direction === "out").at(-1);
+ok("el DTO del mensaje incluye el campo `error`", "error" in out, JSON.stringify(Object.keys(out)));
+ok("aún sin error (todavía no falla)", out.error === null, JSON.stringify(out.error));
+
+console.log("\n== Meta responde 'failed' con el error 130472 (caso real) ==");
+const waId = msgs
+  .filter((m) => m.direction === "out")
+  .at(-1);
+// El waMessageId no viaja en el DTO: se recupera del outbox del mock.
+const outbox = (await (await req.get(`${BASE}/api/dev/wa-mock/outbox`)).json()).outbox;
+const waMessageId = outbox.at(-1)?.waMessageId;
+ok("outbox del mock expone el wa_message_id", !!waMessageId, String(waMessageId));
+
+const st = await req.post(`${BASE}/api/dev/wa-mock/status`, {
+  data: {
+    waMessageId,
+    status: "failed",
+    errorCode: 130472,
+    errorMessage: "User's number is part of an experiment",
+  },
+});
+ok("webhook de estado entregado", st.ok(), JSON.stringify(await st.text()));
+await new Promise((res) => setTimeout(res, 1200));
+
+msgs = (await (await req.get(`${BASE}/api/conversations/${conv.id}/messages`)).json()).messages;
+const failed = msgs.find((m) => m.id === waId.id);
+ok("el mensaje quedó en failed", failed?.status === "failed", failed?.status);
+ok("y trae el motivo traducido, no la jerga de Meta",
+   /experimento/i.test(failed?.error ?? ""), JSON.stringify(failed?.error));
+ok("el motivo sugiere qué hacer (plantilla UTILITY)",
+   /UTILITY/.test(failed?.error ?? ""), JSON.stringify(failed?.error));
+ok("conserva el código de Meta para rastrearlo",
+   /130472/.test(failed?.error ?? ""), JSON.stringify(failed?.error));
+
+console.log("\n== El operador lo VE en el hilo ==");
+const page = await ctx.newPage();
+await page.goto(`${BASE}/inbox`, { waitUntil: "domcontentloaded" });
+await page.getByText(NAME).first().waitFor({ timeout: 20000 });
+await page.getByText(NAME).first().click();
+await page.getByText("mensaje que Meta va a rechazar").waitFor({ timeout: 15000 });
+await page.waitForTimeout(800);
+
+const thread = await page.locator("main, body").first().innerText();
+ok("el hilo dice 'No se entregó'", thread.includes("No se entregó"), "");
+ok("y explica el motivo en español", /experimento/i.test(thread));
+ok("y no deja al operador con el triángulo mudo", thread.includes("130472"));
+
+console.log("\n== En vivo por SSE (sin recargar) ==");
+const sent2 = await req.post(`${BASE}/api/conversations/${conv.id}/messages`, {
+  data: { text: `segundo intento ${S}` },
+});
+ok("segundo mensaje enviado", sent2.ok());
+await page.getByText(`segundo intento ${S}`).waitFor({ timeout: 15000 });
+const outbox2 = (await (await req.get(`${BASE}/api/dev/wa-mock/outbox`)).json()).outbox;
+const waId2 = outbox2.at(-1)?.waMessageId;
+await req.post(`${BASE}/api/dev/wa-mock/status`, {
+  data: {
+    waMessageId: waId2,
+    status: "failed",
+    errorCode: 131049,
+    errorMessage: "Message not delivered to maintain healthy ecosystem",
+  },
+});
+await page.waitForTimeout(2500);
+const thread2 = await page.locator("main, body").first().innerText();
+ok("el motivo aparece SIN recargar la página (evento SSE)",
+   thread2.includes("131049"), thread2.slice(-200));
+
+await page.screenshot({ path: ".tmp/e2e-fallo.png" });
+await browser.close();
+console.log(`\n${failures === 0 ? "TODO VERDE" : `${failures} FALLO(S)`}`);
+process.exit(failures ? 1 : 0);

--- a/src/app/api/dev/wa-mock/graph/[...path]/route.ts
+++ b/src/app/api/dev/wa-mock/graph/[...path]/route.ts
@@ -2,6 +2,7 @@ import { mockGuard } from "@/lib/dev-guard";
 import {
   getWaMockState,
   nextN,
+  nextOutboundWamid,
   type MockTemplate,
 } from "@/server/dev/wa-mock-state";
 
@@ -117,8 +118,10 @@ export async function POST(req: Request, ctx: Params) {
   if (path.length === 2 && path[1] === "messages") {
     const state = getWaMockState();
     const n = nextN();
+    const waMessageId = nextOutboundWamid();
     state.outbox.push({
       n,
+      waMessageId,
       phoneNumberId: path[0]!,
       to: String(body.to ?? ""),
       type: String(body.type ?? "text"),
@@ -128,7 +131,7 @@ export async function POST(req: Request, ctx: Params) {
     return Response.json({
       messaging_product: "whatsapp",
       contacts: [{ input: body.to, wa_id: body.to }],
-      messages: [{ id: `wamid.mock.out.${n}` }],
+      messages: [{ id: waMessageId }],
     });
   }
 

--- a/src/app/api/dev/wa-mock/status/route.ts
+++ b/src/app/api/dev/wa-mock/status/route.ts
@@ -14,6 +14,9 @@ export const dynamic = "force-dynamic";
 const bodySchema = z.object({
   waMessageId: z.string().min(1),
   status: z.enum(["sent", "delivered", "read", "failed"]),
+  /** Reproduce el `errors[]` que Meta adjunta a los `failed`. */
+  errorCode: z.number().int().optional(),
+  errorMessage: z.string().optional(),
 });
 
 export async function POST(req: Request) {
@@ -40,6 +43,8 @@ export async function POST(req: Request) {
     phoneNumberId: creds.phoneNumberId,
     waMessageId: body.data.waMessageId,
     status: body.data.status,
+    errorCode: body.data.errorCode,
+    errorMessage: body.data.errorMessage,
   });
   const res = await deliverToWebhook(payload);
   return res.ok

--- a/src/components/inbox/inbox-client.tsx
+++ b/src/components/inbox/inbox-client.tsx
@@ -95,11 +95,17 @@ export function InboxClient() {
       // Un entrante nuevo puede crear/mover el lead: refresca el panel.
       setDetailRev((v) => v + 1);
     },
-    onMessageStatus: ({ conversationId, messageId, status }) => {
+    onMessageStatus: ({ conversationId, messageId, status, error }) => {
       if (selectedIdRef.current !== conversationId) return;
       setMessages((prev) =>
         prev.map((m) =>
-          m.id === messageId ? { ...m, status: status as MessageDto["status"] } : m
+          m.id === messageId
+            ? {
+                ...m,
+                status: status as MessageDto["status"],
+                error: error ?? null,
+              }
+            : m
         )
       );
     },

--- a/src/components/inbox/message-thread.tsx
+++ b/src/components/inbox/message-thread.tsx
@@ -272,6 +272,20 @@ export function MessageThread({ messages }: { messages: MessageDto[] }) {
                   </span>
                   {out && <StatusTicks status={m.status} />}
                 </span>
+                {out && m.status === "failed" && (
+                  // El triángulo solo decía "algo falló". El motivo lo manda
+                  // Meta y lo guardábamos sin enseñarlo nunca.
+                  <p className="mt-1.5 flex items-start gap-1.5 rounded-md border border-[#ecd4d2] bg-[#faf1f0] px-2 py-1.5 text-[11.5px] leading-snug text-[#a2504c]">
+                    <AlertTriangle
+                      className="mt-[1px] h-3.5 w-3.5 shrink-0"
+                      strokeWidth={1.8}
+                    />
+                    <span>
+                      <span className="font-semibold">No se entregó.</span>{" "}
+                      {m.error ?? "Meta no informó el motivo."}
+                    </span>
+                  </p>
+                )}
               </div>
             </div>
           </div>

--- a/src/components/use-events.ts
+++ b/src/components/use-events.ts
@@ -8,6 +8,8 @@ export type EventHandlers = {
     conversationId: string;
     messageId: string;
     status: string;
+    /** Motivo, presente solo cuando status = "failed". */
+    error?: string | null;
   }) => void;
   onConversationUpdated?: (data: { conversation: unknown }) => void;
   onLabRun?: (data: {

--- a/src/lib/meta/send-errors.ts
+++ b/src/lib/meta/send-errors.ts
@@ -1,0 +1,59 @@
+/**
+ * Traduce el error de envío de Meta a algo que el operador pueda ACCIONAR.
+ *
+ * Meta manda el motivo en inglés y en jerga propia ("User's number is part of
+ * an experiment"), y el CRM lo guardaba sin mostrarlo: el mensaje fallido solo
+ * enseñaba un triángulo mudo. Aquí se convierte en una frase que dice qué
+ * pasó y qué hacer, conservando el código para poder rastrearlo en la
+ * documentación de Meta.
+ */
+
+const DESCRIPTIONS: Record<number, string> = {
+  130472:
+    "Meta tiene el número del destinatario en un experimento y le está bloqueando los mensajes de MARKETING. No es un fallo de tu configuración: prueba con una plantilla de categoría UTILITY o con otro número.",
+  131049:
+    "Meta limitó los mensajes de marketing hacia este usuario para cuidar la calidad del ecosistema. Espera o usa una plantilla de categoría UTILITY.",
+  131047:
+    "Pasaron más de 24 h desde el último mensaje del cliente: solo se puede reabrir con una plantilla aprobada.",
+  131048:
+    "Meta frenó el envío por límite de spam en tu número. Baja el ritmo de envíos y revisa la calidad del número.",
+  131026:
+    "El destinatario no puede recibir mensajes de WhatsApp (número inexistente, sin cuenta o que no acepta mensajes de empresas).",
+  131031:
+    "Tu cuenta de WhatsApp Business está bloqueada o restringida por Meta. Revísalo en el Administrador de WhatsApp.",
+  131030:
+    "El número del destinatario no está en la lista de permitidos de tu app en modo de prueba.",
+  130429:
+    "Superaste el límite de mensajes por segundo de Meta. Reintenta en unos momentos.",
+  132000:
+    "La plantilla y los parámetros enviados no coinciden (faltan o sobran variables).",
+  132001:
+    "Meta no encuentra esa plantilla con ese idioma. Sincroniza las plantillas y confirma que sigue aprobada.",
+  132005:
+    "El texto traducido de la plantilla supera el límite de caracteres de Meta.",
+  132007:
+    "El contenido de la plantilla viola las políticas de Meta.",
+  132012:
+    "Los parámetros de la plantilla no respetan el formato que Meta espera.",
+  132015:
+    "La plantilla está pausada por baja calidad: Meta no la deja enviar hasta que se recupere.",
+  132016:
+    "La plantilla fue deshabilitada por calidad y ya no se puede enviar.",
+  133010: "El número no está registrado en la Cloud API.",
+  368: "El número está temporalmente bloqueado por infringir las políticas de Meta.",
+};
+
+/**
+ * @param code   Código numérico de Meta (`errors[0].code`), si vino.
+ * @param detail Texto crudo de Meta, como respaldo cuando el código es nuevo.
+ */
+export function describeSendError(
+  code: number | null | undefined,
+  detail?: string | null
+): string {
+  const known = code != null ? DESCRIPTIONS[code] : undefined;
+  // `||` y no `??`: Meta a veces manda el texto vacío o en blanco, y un
+  // mensaje de error vacío es tan inútil como el triángulo mudo.
+  const base = known || detail?.trim() || "Meta rechazó el envío";
+  return code != null ? `${base} (Meta ${code})` : base;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -42,6 +42,8 @@ export type MessageDto = {
   type: string;
   text: string | null;
   status: "pending" | "sent" | "delivered" | "read" | "failed";
+  /** Motivo del fallo en lenguaje llano cuando status = "failed". */
+  error: string | null;
   aiGenerated: boolean;
   /** 008 — Origen del saliente (en entrantes viene 'operator' y se ignora). */
   origin: "ai" | "operator" | "manual" | "template";

--- a/src/server/dev/wa-mock-inbound.ts
+++ b/src/server/dev/wa-mock-inbound.ts
@@ -175,6 +175,9 @@ export function buildStatusPayload(input: {
   waMessageId: string;
   status: string;
   recipientId?: string;
+  /** Meta adjunta `errors[]` en los `failed` (ej. 130472 del 2026-08-05). */
+  errorCode?: number;
+  errorMessage?: string;
 }) {
   return {
     object: "whatsapp_business_account",
@@ -196,6 +199,17 @@ export function buildStatusPayload(input: {
                   status: input.status,
                   timestamp: String(Math.floor(Date.now() / 1000)),
                   recipient_id: input.recipientId ?? "5215511111111",
+                  ...(input.errorCode != null
+                    ? {
+                        errors: [
+                          {
+                            code: input.errorCode,
+                            title: input.errorMessage ?? "Error de envío",
+                            message: input.errorMessage ?? "Error de envío",
+                          },
+                        ],
+                      }
+                    : {}),
                 },
               ],
             },

--- a/src/server/dev/wa-mock-state.ts
+++ b/src/server/dev/wa-mock-state.ts
@@ -11,6 +11,11 @@ export type OutboxEntry = {
   type: string;
   body: unknown;
   at: string;
+  /**
+   * Id que se le devolvió al CRM. Lo expone el outbox para que un self-test
+   * pueda mandarle un webhook de estado a ESE mensaje sin adivinar el formato.
+   */
+  waMessageId?: string;
 };
 
 export type MockTemplate = {
@@ -43,4 +48,16 @@ export function resetWaMockState(): void {
 
 export function nextN(): number {
   return ++getWaMockState().counter;
+}
+
+/**
+ * Sello único por arranque del proceso. Sin él, el contador del mock reinicia
+ * al reiniciar `pnpm dev` y vuelve a emitir `wamid.mock.out.1`, que choca con
+ * el UNIQUE de `wa_message_id` en la BD de una corrida anterior (500 al
+ * enviar). No es un fallo del producto: la idempotencia hace su trabajo.
+ */
+const boot = Math.random().toString(36).slice(2, 8);
+
+export function nextOutboundWamid(): string {
+  return `wamid.mock.out.${boot}.${nextN()}`;
 }

--- a/src/server/events/bus.ts
+++ b/src/server/events/bus.ts
@@ -10,7 +10,13 @@ export type SseEvent =
   | { type: "message.new"; data: { conversationId: string; message: unknown } }
   | {
       type: "message.status";
-      data: { conversationId: string; messageId: string; status: string };
+      data: {
+        conversationId: string;
+        messageId: string;
+        status: string;
+        /** Motivo del fallo, presente solo cuando status = "failed". */
+        error?: string | null;
+      };
     }
   | { type: "conversation.updated"; data: { conversation: unknown } }
   | {

--- a/src/server/inbox/ingest.ts
+++ b/src/server/inbox/ingest.ts
@@ -445,6 +445,8 @@ export function serializeMessage(
     type: m.type,
     text: m.text,
     status: m.status,
+    /** Motivo del fallo, ya traducido a algo accionable (`describeSendError`). */
+    error: m.error,
     aiGenerated: m.aiGenerated,
     origin: m.origin,
     media: media

--- a/src/server/inbox/status.ts
+++ b/src/server/inbox/status.ts
@@ -1,5 +1,6 @@
 import { and, eq } from "drizzle-orm";
 import { getDb, schema } from "@/lib/db";
+import { describeSendError } from "@/lib/meta/send-errors";
 import { publish } from "@/server/events/bus";
 import type { WebhookStatus } from "@/server/inbox/webhook";
 
@@ -47,11 +48,10 @@ export async function applyStatusUpdate(
   if (!msg) return;
   if (!isUpgrade(msg.status, next)) return;
 
+  const failure = status.errors?.[0];
   const error =
     next === "failed"
-      ? (status.errors?.[0]?.message ??
-        status.errors?.[0]?.title ??
-        "Envío fallido")
+      ? describeSendError(failure?.code, failure?.message ?? failure?.title)
       : null;
 
   await db
@@ -65,6 +65,8 @@ export async function applyStatusUpdate(
       conversationId: msg.conversationId,
       messageId: msg.id,
       status: next,
+      // Sin esto el operador ve el triángulo de fallo pero nunca el motivo.
+      error,
     },
   });
 }

--- a/tests/e2e/us-envio-fallido.md
+++ b/tests/e2e/us-envio-fallido.md
@@ -1,0 +1,50 @@
+# Guion E2E — Un envío fallido debe decir POR QUÉ
+
+> Automatizado en `scripts/e2e-send-failure.mjs` (15 checks, Playwright contra
+> `pnpm dev` con wa-mock). Nace de un caso real en producción.
+
+## El fallo original
+
+Se mandó una plantilla **aprobada** a un número real y el operador solo vio un
+triángulo rojo, sin explicación. Meta sí había dicho el motivo en el webhook
+de estado:
+
+```json
+{ "code": 130472, "title": "User's number is part of an experiment" }
+```
+
+El CRM lo guardaba en `message.error` desde el principio… y no lo exponía en
+ninguna parte: ni en `MessageDto`, ni en el evento SSE `message.status`, ni en
+el hilo. El operador no tenía forma de saber si el problema era suyo o de Meta.
+
+## Camino verificado
+
+1. Enviar un mensaje a una conversación con la ventana abierta.
+   ✅ Queda `pending` y el DTO ya trae el campo `error` (en `null`).
+2. Meta responde `failed` con `errors[0].code = 130472`
+   (`POST /api/dev/wa-mock/status` con `errorCode`/`errorMessage`).
+   ✅ El mensaje pasa a `failed`.
+   ✅ `error` explica el motivo **en español** ("…está en un experimento…"),
+   sugiere la salida (usar una plantilla **UTILITY**) y conserva el código
+   `(Meta 130472)` para rastrearlo en la documentación.
+3. Abrir el hilo en la Bandeja.
+   ✅ Bajo la burbuja aparece «**No se entregó.** …», no un triángulo mudo.
+4. Un segundo envío falla con 131049 mientras el hilo está abierto.
+   ✅ El motivo aparece **sin recargar**: el evento SSE `message.status` ahora
+   viaja con `error`.
+
+## Reglas del traductor (`lib/meta/send-errors.ts`)
+
+- Código conocido → frase accionable en español + `(Meta <código>)`.
+- Código desconocido → texto crudo de Meta + código, nunca se pierde.
+- Sin código ni texto (o texto en blanco) → "Meta rechazó el envío".
+  ⚠️ Con `??` en vez de `||` esto devolvía cadena vacía: un error tan mudo
+  como el triángulo. Cubierto en `tests/unit/send-errors.test.ts`.
+
+## Gotcha del harness
+
+El wa-mock numeraba sus salientes `wamid.mock.out.<n>` con un contador que
+reinicia con el proceso, mientras la BD conserva los mensajes de corridas
+anteriores → el UNIQUE de `wa_message_id` reventaba con 500 al enviar. Ahora
+el id lleva un sello por arranque y el outbox expone el `waMessageId`, para no
+adivinar su formato desde los tests.

--- a/tests/unit/send-errors.test.ts
+++ b/tests/unit/send-errors.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { describeSendError } from "@/lib/meta/send-errors";
+
+describe("describeSendError (fallo real del 2026-08-05)", () => {
+  it("130472 → explica el experimento de Meta y qué hacer", () => {
+    const msg = describeSendError(130472, "User's number is part of an experiment");
+    expect(msg).toMatch(/experimento/i);
+    expect(msg).toMatch(/UTILITY/);
+    expect(msg).toMatch(/130472/);
+    // Nada de jerga cruda de Meta en la frase principal.
+    expect(msg).not.toMatch(/User's number/);
+  });
+
+  it("códigos conocidos de plantillas y ventana", () => {
+    expect(describeSendError(131047)).toMatch(/24 h/);
+    expect(describeSendError(132001)).toMatch(/plantilla/i);
+    expect(describeSendError(132015)).toMatch(/pausada/i);
+    expect(describeSendError(131026)).toMatch(/no puede recibir/i);
+  });
+
+  it("código desconocido → conserva el texto crudo de Meta y el número", () => {
+    expect(describeSendError(999999, "Something odd happened")).toBe(
+      "Something odd happened (Meta 999999)"
+    );
+  });
+
+  it("sin código ni texto → mensaje honesto, nunca vacío", () => {
+    expect(describeSendError(null)).toBe("Meta rechazó el envío");
+    expect(describeSendError(undefined, "   ")).toBe("Meta rechazó el envío");
+  });
+
+  it("sin código pero con texto → usa el texto tal cual", () => {
+    expect(describeSendError(null, "Fallo de red")).toBe("Fallo de red");
+  });
+});


### PR DESCRIPTION
## Problema

Se manda una plantilla **aprobada** a un número real, falla, y el operador solo ve un triángulo rojo. Sin texto, sin código, sin pista de si el problema es suyo o de Meta.

Meta **sí** había explicado el motivo en el webhook de estado:

```json
{ "code": 130472, "title": "User's number is part of an experiment" }
```

(Meta tenía ese número en un experimento y le bloqueaba los mensajes de categoría MARKETING.)

El CRM lo guardaba en `message.error` desde siempre… y no lo exponía en ninguna parte: ni en `MessageDto`, ni en el evento SSE `message.status`, ni en el hilo. El dato existía y nadie podía verlo.

## Cambios

- **`src/lib/meta/send-errors.ts`**: traduce el código de Meta a una frase accionable en español, conservando `(Meta <código>)` para rastrearlo en su documentación. Cubre los que de verdad ocurren: experimentos y límites de marketing, ventana de 24 h vencida, plantilla pausada por calidad o inexistente, número que no recibe WhatsApp, cuenta bloqueada y rate limits. Código desconocido → texto crudo de Meta + código; nunca se pierde información.
- El motivo viaja en `MessageDto.error` y en el evento SSE `message.status`, así que se ve al abrir el hilo **y en vivo, sin recargar**.
- El hilo pinta «**No se entregó.** \<motivo\>» bajo la burbuja fallida.
- wa-mock: `errorCode`/`errorMessage` en el webhook de estado, y `waMessageId` expuesto en el outbox para no adivinar su formato desde los tests. Los salientes del mock llevan sello por arranque: su contador reiniciaba con el proceso y chocaba con el UNIQUE de `wa_message_id` de corridas anteriores (500 al enviar — artefacto del harness, no del producto).

## Verificación

- `pnpm typecheck && pnpm lint && pnpm test` verde sobre esta rama (121 tests, 5 nuevos).
- `pnpm build` verde.
- Self-test de comportamiento `scripts/e2e-send-failure.mjs`: **15/15**, ejecutado contra esta rama con BD propia. Reproduce el 130472 exacto, comprueba que el motivo llega traducido con la salida sugerida y el código, que se ve en el hilo, y que un segundo fallo (131049) aparece **sin recargar** por SSE.
- Guion nuevo `tests/e2e/us-envio-fallido.md`.

Una de las pruebas unitarias cazó un fallo propio durante el desarrollo: con `??` en vez de `||`, un texto en blanco de Meta dejaba el mensaje de error **vacío** — tan mudo como el triángulo. Está cubierto.