### PR TITLE
feat(bot-api): perfil del agente y knowledge base para un cerebro externo

### DIFF
--- a/scripts/e2e-selftest.mjs
+++ b/scripts/e2e-selftest.mjs
@@ -236,6 +236,60 @@ async function main() {
     `status=${medBad.res.status}`
   );
 
+  console.log("\n== us-bot-api: perfil del agente + knowledge base ==");
+  const profNoKey = await api("/api/bot/profile");
+  ok("perfil sin API key → 401", profNoKey.res.status === 401);
+
+  const putProf = await api("/api/agent/profile", {
+    method: "PUT",
+    body: JSON.stringify({
+      name: "Sofi",
+      tone: "cálido y directo",
+      instructions: "Vendemos limpiezas dentales.",
+      escalationRules: "Urgencias de dolor → humano.",
+      greeting: "¡Hola! Soy Sofi",
+      enabled: false,
+    }),
+  });
+  ok("perfil guardado desde la pantalla Agente", putProf.res.ok);
+  const kbQa = await api("/api/kb", {
+    method: "POST",
+    body: JSON.stringify({
+      kind: "qa",
+      question: "¿Cuánto cuesta?",
+      answer: "$800.",
+    }),
+  });
+  ok("entrada de KB creada desde la pantalla", kbQa.res.ok, JSON.stringify(kbQa.json));
+
+  const prof = await bot("/api/bot/profile");
+  ok(
+    "GET /api/bot/profile → 200 con el perfil de la pantalla",
+    prof.res.ok && prof.json?.profile?.name === "Sofi",
+    JSON.stringify(prof.json?.profile)
+  );
+  ok(
+    "el knowledge base viaja renderizado (P:/R:)",
+    typeof prof.json?.kb === "string" && prof.json.kb.includes("P: ¿Cuánto cuesta?"),
+    JSON.stringify(prof.json?.kb)
+  );
+  ok(
+    "`enabled` NO viaja: gobierna la IA in-process, no al bot externo",
+    prof.json?.profile && !("enabled" in prof.json.profile)
+  );
+  ok("`resources` presente y vacío", Array.isArray(prof.json?.resources));
+
+  await api("/api/agent/profile", {
+    method: "PUT",
+    body: JSON.stringify({ tone: "seco y breve" }),
+  });
+  const profAgain = await bot("/api/bot/profile");
+  ok(
+    "editar el tono se refleja al instante (sin caché)",
+    profAgain.json?.profile?.tone === "seco y breve",
+    JSON.stringify(profAgain.json?.profile?.tone)
+  );
+
   console.log("\n== us-bot-api: IA pausada y reset ==");
   const pause = await api(`/api/conversations/${convId}`, {
     method: "PATCH",

--- a/src/app/api/bot/profile/route.ts
+++ b/src/app/api/bot/profile/route.ts
@@ -1,0 +1,43 @@
+import { asc, eq } from "drizzle-orm";
+import { getDb, schema } from "@/lib/db";
+import { apiError } from "@/lib/api";
+import { requireBotKey, resolveInstanceOrg } from "@/server/bot/auth";
+import { serializeBotProfile } from "@/server/bot/profile";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Perfil del agente + knowledge base para un cerebro externo.
+ * GET /api/bot/profile → {profile, kb, resources}. Sin caché: cada consulta
+ * refleja lo que el dueño dejó en la UI al momento (el TTL vive del lado del
+ * bot, que es quien sabe cada cuánto le conviene releer).
+ */
+export async function GET(req: Request) {
+  const denied = requireBotKey(req);
+  if (denied) return denied;
+
+  const organizationId = await resolveInstanceOrg();
+  if (!organizationId) {
+    return apiError(409, "no_org", "La instancia aún no tiene organización");
+  }
+
+  const db = getDb();
+  const profiles = await db
+    .select()
+    .from(schema.agentProfile)
+    .where(eq(schema.agentProfile.organizationId, organizationId))
+    .limit(1);
+  const profile = profiles[0];
+  if (!profile) {
+    // Condición esperada (instancia sin perfil): el bot cae a su brief local.
+    return apiError(404, "no_profile", "La instancia no tiene perfil de agente");
+  }
+
+  const kb = await db
+    .select()
+    .from(schema.kbEntry)
+    .where(eq(schema.kbEntry.organizationId, organizationId))
+    .orderBy(asc(schema.kbEntry.createdAt));
+
+  return Response.json(serializeBotProfile(profile, kb));
+}

--- a/src/server/bot/profile.ts
+++ b/src/server/bot/profile.ts
@@ -1,0 +1,27 @@
+import type { schema } from "@/lib/db";
+import { renderKb } from "@/server/ai/prompts";
+
+type AgentProfile = typeof schema.agentProfile.$inferSelect;
+type KbEntry = typeof schema.kbEntry.$inferSelect;
+
+/**
+ * Payload del perfil del agente para un cerebro externo.
+ *
+ * `enabled` NO viaja: ese flag gobierna la IA in-process de Vocero; el bot
+ * externo se pausa por conversación (`aiEnabled` del contexto y los handoffs),
+ * no por este endpoint. `resources` nace vacío para que el shape del consumidor
+ * no cambie cuando existan recursos alternativos reales.
+ */
+export function serializeBotProfile(profile: AgentProfile, kb: KbEntry[]) {
+  return {
+    profile: {
+      name: profile.name,
+      tone: profile.tone ?? null,
+      instructions: profile.instructions ?? null,
+      escalationRules: profile.escalationRules ?? null,
+      greeting: profile.greeting ?? null,
+    },
+    kb: renderKb(kb),
+    resources: [] as { label: string; url: string }[],
+  };
+}

--- a/tests/e2e/us-bot-api.md
+++ b/tests/e2e/us-bot-api.md
@@ -44,9 +44,30 @@ agente in-process de Vocero puede quedar apagado.
     no borra auditoría.
 13. `POST /api/bot/reset` sin key → **401**.
 
+## Perfil del agente y knowledge base
+
+El bot externo no adivina el negocio: lo lee de las mismas dos pantallas que
+edita el dueño (Agente y su knowledge base). Este endpoint es el contrato.
+
+14. `GET /api/bot/profile` con la key → **200** con la forma exacta
+    `{profile: {name, tone, instructions, escalationRules, greeting}, kb, resources}`.
+    Los cinco campos del perfil coinciden con lo guardado en la pantalla Agente;
+    los opcionales vacíos viajan como `null`, no como cadena vacía.
+15. `kb` es el knowledge base ya renderizado (`P:`/`R:` para las preguntas,
+    los bloques tal cual, en el orden de la pantalla). Con el KB vacío viaja
+    la cadena canónica `(knowledge base vacío)`, no `null`: el bot puede
+    inyectarla en su prompt sin ramificar.
+16. `profile.enabled` NO viene, ni con la IA in-process encendida ni apagada:
+    ese flag gobierna el agente de Vocero, no al cerebro externo, que se pausa
+    por conversación (`aiEnabled` y los handoffs).
+17. Editar el tono en la pantalla Agente y volver a pedir el perfil → el cambio
+    ya está: la respuesta no se cachea.
+
 ## Camino infeliz
 
-14. `POST /api/bot/typing` con un `conversationId` inexistente → **404**.
-15. Con Meta caído (token `...-invalid` en el mock), typing → **200**
+18. `GET /api/bot/profile` en una instancia sin perfil de agente → **404**
+    `no_profile` (condición esperada, no un 500: el bot cae a su brief local).
+19. `POST /api/bot/typing` con un `conversationId` inexistente → **404**.
+20. Con Meta caído (token `...-invalid` en el mock), typing → **200**
     `{ok:false, reason:"meta_error"}`: es best-effort por contrato, al bot
     jamás le vale reintentarlo.

--- a/tests/unit/bot-profile.test.ts
+++ b/tests/unit/bot-profile.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { serializeBotProfile } from "@/server/bot/profile";
+import type { schema } from "@/lib/db";
+import { resetRateLimit } from "@/lib/rate-limit";
+
+const dbState = vi.hoisted(() => ({ queue: [] as unknown[][] }));
+
+vi.mock("@/lib/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/db")>();
+  const builder: Record<string, unknown> = {};
+  for (const m of ["select", "from", "where", "limit", "orderBy"]) {
+    builder[m] = () => builder;
+  }
+  (builder as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+    resolve(dbState.queue.shift() ?? []);
+  return { ...actual, getDb: () => builder };
+});
+
+vi.mock("@/server/bot/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/server/bot/auth")>();
+  return { ...actual, resolveInstanceOrg: async () => "org_1" };
+});
+
+/** Perfil del agente + knowledge base vía la API de servicio `/api/bot/*`. */
+
+type AgentProfile = typeof schema.agentProfile.$inferSelect;
+type KbEntry = typeof schema.kbEntry.$inferSelect;
+
+function profileRow(overrides: Partial<AgentProfile> = {}): AgentProfile {
+  return {
+    id: "ap_1",
+    organizationId: "org_1",
+    enabled: false,
+    name: "Sofi",
+    tone: "cálido y directo",
+    instructions: "Vendemos limpiezas dentales.",
+    escalationRules: "Urgencias de dolor → humano.",
+    greeting: "¡Hola! Soy Sofi 🦷",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function qa(question: string, answer: string): KbEntry {
+  return {
+    id: `kb_${question}`,
+    organizationId: "org_1",
+    kind: "qa",
+    question,
+    answer,
+    content: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+describe("serializeBotProfile", () => {
+  it("perfil completo → shape exacto del contrato", () => {
+    const out = serializeBotProfile(profileRow(), [
+      qa("¿Cuánto cuesta?", "$800."),
+    ]);
+    expect(out).toEqual({
+      profile: {
+        name: "Sofi",
+        tone: "cálido y directo",
+        instructions: "Vendemos limpiezas dentales.",
+        escalationRules: "Urgencias de dolor → humano.",
+        greeting: "¡Hola! Soy Sofi 🦷",
+      },
+      kb: "P: ¿Cuánto cuesta?\nR: $800.",
+      resources: [],
+    });
+  });
+
+  it("opcionales vacíos viajan como null, no como cadenas", () => {
+    const out = serializeBotProfile(
+      profileRow({ tone: null, instructions: null, escalationRules: null, greeting: null }),
+      []
+    );
+    expect(out.profile.tone).toBeNull();
+    expect(out.profile.instructions).toBeNull();
+    expect(out.profile.escalationRules).toBeNull();
+    expect(out.profile.greeting).toBeNull();
+  });
+
+  it("KB vacío → render canónico '(knowledge base vacío)'", () => {
+    expect(serializeBotProfile(profileRow(), []).kb).toBe("(knowledge base vacío)");
+  });
+
+  it("enabled NO viaja: gobierna solo la IA in-process", () => {
+    const out = serializeBotProfile(profileRow({ enabled: false }), []);
+    expect("enabled" in out.profile).toBe(false);
+    // Y enabled=true produce exactamente lo mismo:
+    expect(serializeBotProfile(profileRow({ enabled: true }), [])).toEqual(out);
+  });
+
+  it("resources siempre presente y vacío mientras no haya recursos reales", () => {
+    expect(serializeBotProfile(profileRow(), []).resources).toEqual([]);
+  });
+
+  it("bloques del KB van tal cual, mezclados con P/R en orden", () => {
+    const block: KbEntry = { ...qa("x", "y"), kind: "block", question: null, answer: null, content: "Horario: L-V 9-18." };
+    const out = serializeBotProfile(profileRow(), [qa("¿Dónde están?", "En Querétaro."), block]);
+    expect(out.kb).toBe("P: ¿Dónde están?\nR: En Querétaro.\n\nHorario: L-V 9-18.");
+  });
+});
+
+describe("GET /api/bot/profile (ruta, DB fake)", () => {
+  const KEY = "clave-de-servicio-larga-0123456789abcdef";
+
+  beforeEach(() => {
+    vi.stubEnv("BOT_API_KEY", KEY);
+    resetRateLimit();
+    dbState.queue = [];
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  function req(key?: string): Request {
+    return new Request("http://localhost/api/bot/profile", {
+      headers: key ? { "x-api-key": key } : {},
+    });
+  }
+
+  it("sin API key → 401 (no filtra existencia del perfil)", async () => {
+    const { GET } = await import("@/app/api/bot/profile/route");
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+
+  it("instancia sin perfil (legada) → 404 no_profile", async () => {
+    const { GET } = await import("@/app/api/bot/profile/route");
+    dbState.queue = [[]];
+    const res = await GET(req(KEY));
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("no_profile");
+  });
+
+  it("perfil + KB → 200 con el payload del serializador", async () => {
+    const { GET } = await import("@/app/api/bot/profile/route");
+    dbState.queue = [[profileRow()], [qa("¿Cuánto?", "$800.")]];
+    const res = await GET(req(KEY));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ReturnType<typeof serializeBotProfile>;
+    expect(body.profile.name).toBe("Sofi");
+    expect(body.kb).toBe("P: ¿Cuánto?\nR: $800.");
+    expect(body.resources).toEqual([]);
+  });
+});


### PR DESCRIPTION
`nea-agent` —el agente de agendamiento MIT que se conecta a Vocero— pide diez
endpoints `/api/bot/*` y `main` tiene tres. Este PR agrega el primero de los que
faltan, y es el más aislado de todos: **solo lee**, no toca el esquema y no
depende de ningún otro.

Sale del issue #8, donde alguien que instaló los dos repos documentó la brecha
con curl.

## Qué hace

`GET /api/bot/profile` devuelve el perfil del agente y el knowledge base tal
como están en las pantallas **Agente** y su KB:

```json
{
  "profile": {"name": "Sofi", "tone": "…", "instructions": "…", "escalationRules": "…", "greeting": "…"},
  "kb": "P: ¿Cuánto cuesta?\nR: $800.",
  "resources": []
}
```

Así el cerebro externo no lleva el negocio cableado en su propio código: lo lee
del CRM, que es donde el dueño ya lo edita.

## Tres decisiones que vale la pena mirar en la revisión

**`kb` viaja renderizado, no como filas.** Reusa `renderKb()` de
`src/server/ai/prompts.ts`, la misma función que arma el prompt del agente
in-process. Que los dos cerebros vean exactamente el mismo texto es el punto: si
mañana cambia el formato del KB, cambia para ambos en un solo lugar. Con el KB
vacío viaja la cadena canónica `(knowledge base vacío)` en vez de `null`, para
que el consumidor pueda inyectarla sin ramificar.

**`enabled` NO viaja.** Ese flag gobierna la IA in-process de Vocero. Un bot
externo que lo leyera se apagaría solo en la instalación típica —donde el agente
propio está apagado justamente porque hay un bot externo—. El bot se pausa por
conversación, con `aiEnabled` y los handoffs, no con este endpoint.

**`resources` nace vacío.** Es el hueco para catálogos o enlaces que el agente
pueda mandar. Va desde ahora para que el shape del consumidor no cambie el día
que existan.

Sin caché (`force-dynamic`): editar el tono en la pantalla Agente se refleja en
la siguiente consulta. El TTL vive del lado del bot, que es quien sabe cada
cuánto le conviene releer.

## Superficie

Nada que ya existiera cambia de comportamiento. Los tres archivos nuevos son la
ruta (42 líneas), el serializador (27) y su prueba unitaria (150). Reusa
`requireBotKey` y `resolveInstanceOrg` sin tocarlos, así que hereda el 401 sin
key, el 401 con key equivocada y el límite de tasa.

Sin migraciones, sin variables de entorno nuevas (solo la `BOT_API_KEY` que ya
gobierna toda la superficie), sin dependencias nuevas, sin cambios en la UI.

## Verificación

Gate técnico completo en limpio sobre este branch:

```
pnpm typecheck   ✓
pnpm lint        ✓
pnpm test        ✓  24 archivos, 141 pruebas (9 nuevas)
pnpm build       ✓  /api/bot/profile registrada
```

Y comportamiento de punta a punta contra la app viva con los mocks
(`pnpm test:e2e`), con siete checks nuevos en `scripts/e2e-selftest.mjs` que
guardan el contrato: 401 sin key, el perfil guardado desde la pantalla sale por
el endpoint, el KB viaja renderizado, `enabled` no viaja, `resources` está
presente, y editar el tono se refleja al instante. El guion manual
`tests/e2e/us-bot-api.md` queda actualizado con la misma historia, incluido el
404 `no_profile` de una instancia sin perfil de agente.

## Lo que sigue

`GET /api/bot/context` y `POST /api/bot/messages` van juntos en el próximo PR
—el agente saca el `conversationId` del contexto, así que uno sin el otro no
destraba nada—. Después `PUT /api/bot/ficha` (que sí toca el esquema) y
`POST /api/bot/handoff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
