### PR TITLE
feat(bot-api): contexto y envio para un cerebro externo

### DIFF
--- a/scripts/e2e-selftest.mjs
+++ b/scripts/e2e-selftest.mjs
@@ -290,6 +290,90 @@ async function main() {
     JSON.stringify(profAgain.json?.profile?.tone)
   );
 
+  console.log("\n== us-bot-api: contexto conversacional ==");
+  const ctxNoKey = await api(`/api/bot/context?conversationId=${convId}`);
+  ok("contexto sin API key → 401", ctxNoKey.res.status === 401);
+
+  const ctx = await bot(`/api/bot/context?conversationId=${convId}`);
+  ok(
+    "GET /api/bot/context por conversationId → 200",
+    ctx.res.ok && ctx.json?.conversation?.id === convId,
+    JSON.stringify(ctx.json?.conversation)
+  );
+  ok(
+    "trae la identidad estable del contacto (no solo el teléfono)",
+    typeof ctx.json?.contact?.waIdentity === "string" &&
+      ctx.json.contact.waIdentity.length > 0
+  );
+  ok(
+    "trae la etapa del lead en el pipeline",
+    typeof ctx.json?.lead?.stageName === "string",
+    JSON.stringify(ctx.json?.lead)
+  );
+  ok(
+    "la ventana de 24 h viaja abierta tras un entrante reciente",
+    ctx.json?.conversation?.windowOpen === true &&
+      ctx.json?.conversation?.windowRemainingMs > 0,
+    JSON.stringify(ctx.json?.conversation)
+  );
+
+  const ctxByIdentity = await bot(
+    `/api/bot/context?waIdentity=${encodeURIComponent(ctx.json.contact.waIdentity)}`
+  );
+  ok(
+    "resolver por waIdentity da la MISMA conversación",
+    ctxByIdentity.json?.conversation?.id === convId,
+    JSON.stringify(ctxByIdentity.json?.conversation?.id)
+  );
+
+  const ctxSinArgs = await bot("/api/bot/context");
+  ok("contexto sin waIdentity ni conversationId → 422", ctxSinArgs.res.status === 422);
+  const ctx404 = await bot("/api/bot/context?conversationId=cv_no_existe");
+  ok("contexto de una conversación inexistente → 404", ctx404.res.status === 404);
+
+  console.log("\n== us-bot-api: el bot envía a través del CRM ==");
+  const sendNoKey = await api("/api/bot/messages", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId, text: "hola" }),
+  });
+  ok("envío sin API key → 401", sendNoKey.res.status === 401);
+
+  const outboxBeforeBot =
+    ((await api("/api/dev/wa-mock/outbox")).json?.outbox ?? []).length;
+  const botSend = await bot("/api/bot/messages", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId, text: "Hola, soy el bot." }),
+  });
+  ok(
+    "POST /api/bot/messages → 200 con messageId",
+    botSend.res.ok && typeof botSend.json?.messageId === "string",
+    JSON.stringify(botSend.json)
+  );
+  const outboxAfterBot =
+    ((await api("/api/dev/wa-mock/outbox")).json?.outbox ?? []).length;
+  ok(
+    "el mensaje salió de verdad por el canal de WhatsApp",
+    outboxAfterBot === outboxBeforeBot + 1,
+    `antes=${outboxBeforeBot} después=${outboxAfterBot}`
+  );
+  const botMsg = ((await api(`/api/conversations/${convId}/messages`)).json
+    ?.messages ?? []).find((m) => m.id === botSend.json?.messageId);
+  ok(
+    "queda en la bandeja marcado como IA (aiGenerated + origin=ai)",
+    botMsg?.aiGenerated === true && botMsg?.origin === "ai",
+    JSON.stringify({ aiGenerated: botMsg?.aiGenerated, origin: botMsg?.origin })
+  );
+  const sendNoConv = await bot("/api/bot/messages", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: "cv_no_existe", text: "hola" }),
+  });
+  ok("envío a conversación inexistente → 404", sendNoConv.res.status === 404);
+  const sendVacio = await bot("/api/bot/messages", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId, text: "" }),
+  });
+  ok("texto vacío → 422 (no se manda un mensaje en blanco)", sendVacio.res.status === 422);
+
   console.log("\n== us-bot-api: IA pausada y reset ==");
   const pause = await api(`/api/conversations/${convId}`, {
     method: "PATCH",
@@ -307,6 +391,26 @@ async function main() {
       typPaused.json?.ok === false &&
       typPaused.json?.reason === "ai_paused",
     JSON.stringify(typPaused.json)
+  );
+
+  const outboxBeforePaused =
+    ((await api("/api/dev/wa-mock/outbox")).json?.outbox ?? []).length;
+  const sendPaused = await bot("/api/bot/messages", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId, text: "¿sigo yo?" }),
+  });
+  ok(
+    "el bot NO habla sobre una conversación tomada por un humano → 409 ai_paused",
+    sendPaused.res.status === 409 &&
+      sendPaused.json?.error?.code === "ai_paused",
+    JSON.stringify(sendPaused.json)
+  );
+  const outboxAfterPaused =
+    ((await api("/api/dev/wa-mock/outbox")).json?.outbox ?? []).length;
+  ok(
+    "y el rechazo ocurre ANTES de tocar Meta",
+    outboxAfterPaused === outboxBeforePaused,
+    `antes=${outboxBeforePaused} después=${outboxAfterPaused}`
   );
 
   const msgsBeforeReset =

--- a/src/app/api/bot/context/route.ts
+++ b/src/app/api/bot/context/route.ts
@@ -1,0 +1,125 @@
+import { and, eq } from "drizzle-orm";
+import { getDb, schema } from "@/lib/db";
+import { apiError } from "@/lib/api";
+import { requireBotKey, resolveInstanceOrg } from "@/server/bot/auth";
+import { isWindowOpen, windowRemainingMs } from "@/server/inbox/window";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Contexto conversacional para un cerebro externo (solo lectura).
+ * GET /api/bot/context?waIdentity=... | ?conversationId=...
+ *
+ * NO devuelve el historial de mensajes: el bot lleva su propia memoria de la
+ * conversación. Lo que aquí sale es lo que solo el CRM sabe — quién es la
+ * persona, si un humano tomó el control y si la ventana de 24 h sigue abierta.
+ */
+export async function GET(req: Request) {
+  const denied = requireBotKey(req);
+  if (denied) return denied;
+
+  const organizationId = await resolveInstanceOrg();
+  if (!organizationId) {
+    return apiError(409, "no_org", "La instancia aún no tiene organización");
+  }
+
+  const url = new URL(req.url);
+  const waIdentity = url.searchParams.get("waIdentity");
+  const conversationId = url.searchParams.get("conversationId");
+  if (!waIdentity && !conversationId) {
+    return apiError(422, "invalid", "Falta waIdentity o conversationId");
+  }
+
+  const db = getDb();
+
+  let contact: typeof schema.contact.$inferSelect | undefined;
+  let conversation: typeof schema.conversation.$inferSelect | undefined;
+
+  if (conversationId) {
+    const rows = await db
+      .select({ conversation: schema.conversation, contact: schema.contact })
+      .from(schema.conversation)
+      .innerJoin(
+        schema.contact,
+        eq(schema.conversation.contactId, schema.contact.id)
+      )
+      .where(
+        and(
+          eq(schema.conversation.organizationId, organizationId),
+          eq(schema.conversation.id, conversationId)
+        )
+      )
+      .limit(1);
+    contact = rows[0]?.contact;
+    conversation = rows[0]?.conversation;
+  } else if (waIdentity) {
+    const contacts = await db
+      .select()
+      .from(schema.contact)
+      .where(
+        and(
+          eq(schema.contact.organizationId, organizationId),
+          eq(schema.contact.waIdentity, waIdentity)
+        )
+      )
+      .limit(1);
+    contact = contacts[0];
+    if (contact) {
+      // La conversación del Laboratorio jamás se resuelve por identidad: ese
+      // camino es para el bot de producción, que nunca debe hablarle a un
+      // cliente simulado.
+      const convs = await db
+        .select()
+        .from(schema.conversation)
+        .where(
+          and(
+            eq(schema.conversation.organizationId, organizationId),
+            eq(schema.conversation.contactId, contact.id),
+            eq(schema.conversation.isTest, false)
+          )
+        )
+        .limit(1);
+      conversation = convs[0];
+    }
+  }
+
+  if (!contact || !conversation) {
+    return apiError(404, "not_found", "Conversación no encontrada");
+  }
+
+  const leadRows = await db
+    .select({ lead: schema.lead, stage: schema.pipelineStage })
+    .from(schema.lead)
+    .innerJoin(
+      schema.pipelineStage,
+      eq(schema.lead.stageId, schema.pipelineStage.id)
+    )
+    .where(
+      and(
+        eq(schema.lead.organizationId, organizationId),
+        eq(schema.lead.contactId, contact.id)
+      )
+    )
+    .limit(1);
+
+  return Response.json({
+    contact: {
+      id: contact.id,
+      name: contact.name,
+      waIdentity: contact.waIdentity,
+      phone: contact.phone,
+    },
+    conversation: {
+      id: conversation.id,
+      // Una sola verdad para el bot: si hay handoff, la IA está apagada
+      // aunque el flag siga en true.
+      aiEnabled: conversation.aiEnabled && !conversation.handoffAt,
+      handoffAt: conversation.handoffAt?.toISOString() ?? null,
+      windowOpen: isWindowOpen(conversation.lastInboundAt),
+      windowRemainingMs: windowRemainingMs(conversation.lastInboundAt),
+    },
+    lead: leadRows[0]
+      ? { id: leadRows[0].lead.id, stageName: leadRows[0].stage.name }
+      : null,
+  });
+}

--- a/src/app/api/bot/messages/route.ts
+++ b/src/app/api/bot/messages/route.ts
@@ -1,0 +1,79 @@
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { getDb, schema } from "@/lib/db";
+import { apiError, parseBody } from "@/lib/api";
+import { requireBotKey, resolveInstanceOrg } from "@/server/bot/auth";
+import { SendError, sendText } from "@/server/inbox/send";
+
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({
+  conversationId: z.string().min(1),
+  text: z.string().min(1).max(4096),
+});
+
+/**
+ * Envío del cerebro externo A TRAVÉS del CRM: el token de WhatsApp nunca sale
+ * de aquí. Usa el mismo camino que el composer de la bandeja (`sendText`), así
+ * que el mensaje queda en el hilo marcado como IA, respeta la ventana de 24 h
+ * y hereda el guard de sandbox del Laboratorio.
+ *
+ * 409 tipados: ai_paused (un humano tomó la conversación) · window_closed ·
+ * sandbox_violation.
+ */
+export async function POST(req: Request) {
+  const denied = requireBotKey(req);
+  if (denied) return denied;
+
+  const organizationId = await resolveInstanceOrg();
+  if (!organizationId) {
+    return apiError(409, "no_org", "La instancia aún no tiene organización");
+  }
+
+  const body = await parseBody(req, bodySchema);
+  if (!body.ok) return body.response;
+
+  // Gate de handoff: el bot JAMÁS habla sobre una conversación pausada. Se
+  // relee aquí porque entre que el bot pidió el contexto y armó su respuesta
+  // (segundos de un LLM) el dueño pudo haber tomado la conversación.
+  const db = getDb();
+  const convs = await db
+    .select({
+      aiEnabled: schema.conversation.aiEnabled,
+      handoffAt: schema.conversation.handoffAt,
+    })
+    .from(schema.conversation)
+    .where(
+      and(
+        eq(schema.conversation.organizationId, organizationId),
+        eq(schema.conversation.id, body.data.conversationId)
+      )
+    )
+    .limit(1);
+  const conv = convs[0];
+  if (!conv) return apiError(404, "not_found", "Conversación no encontrada");
+  if (!conv.aiEnabled || conv.handoffAt) {
+    return apiError(409, "ai_paused", "La IA está en pausa en esta conversación");
+  }
+
+  try {
+    const result = await sendText({
+      conversationId: body.data.conversationId,
+      organizationId,
+      text: body.data.text,
+      aiGenerated: true,
+    });
+    return Response.json({ messageId: result.messageId });
+  } catch (err) {
+    if (err instanceof SendError) {
+      if (err.code === "window_closed") {
+        return apiError(409, "window_closed", err.message);
+      }
+      if (err.code === "sandbox_violation") {
+        return apiError(409, "sandbox_violation", err.message);
+      }
+      return apiError(502, err.code, err.message);
+    }
+    throw err;
+  }
+}

--- a/tests/e2e/us-bot-api.md
+++ b/tests/e2e/us-bot-api.md
@@ -63,11 +63,44 @@ edita el dueño (Agente y su knowledge base). Este endpoint es el contrato.
 17. Editar el tono en la pantalla Agente y volver a pedir el perfil → el cambio
     ya está: la respuesta no se cachea.
 
+## Contexto de la conversación
+
+Lo que solo el CRM sabe: quién es la persona, si un humano tomó el control y si
+la ventana de 24 h sigue abierta. El historial de mensajes NO viaja: esa memoria
+es del bot.
+
+18. `GET /api/bot/context?conversationId={id}` con la key → **200** con
+    `contact` (id, name, waIdentity, phone), `conversation`
+    (id, aiEnabled, handoffAt, windowOpen, windowRemainingMs) y `lead`
+    (id, stageName).
+19. `GET /api/bot/context?waIdentity={identidad}` → la MISMA conversación. Es el
+    camino que usa el bot cuando le llega un mensaje y solo tiene el remitente.
+20. Tras un entrante reciente, `windowOpen: true` y `windowRemainingMs` > 0.
+21. Con la conversación en handoff, `aiEnabled` viene en **false** aunque el
+    flag de la fila siga en true: para el bot hay una sola verdad.
+22. Una conversación del Laboratorio no se resuelve nunca por `waIdentity`: el
+    bot de producción no debe hablarle a un cliente simulado.
+
+## El bot envía a través del CRM
+
+23. `POST /api/bot/messages {conversationId, text}` con la key → **200**
+    `{messageId}`, el mensaje aparece en la bandeja marcado como IA
+    (`aiGenerated: true`, `origin: "ai"`) y sale por el canal de WhatsApp. El
+    token de Meta nunca viajó al bot.
+24. Con la IA pausada (handoff), el mismo envío → **409** `ai_paused` y el
+    outbox NO cambia: el rechazo ocurre antes de tocar Meta.
+25. Con la ventana de 24 h cerrada → **409** `window_closed`. El bot no puede
+    esquivar la regla de Meta; para eso está el envío de plantilla desde la app.
+26. En una conversación del Laboratorio → **409** `sandbox_violation`.
+
 ## Camino infeliz
 
-18. `GET /api/bot/profile` en una instancia sin perfil de agente → **404**
+27. `GET /api/bot/profile` en una instancia sin perfil de agente → **404**
     `no_profile` (condición esperada, no un 500: el bot cae a su brief local).
-19. `POST /api/bot/typing` con un `conversationId` inexistente → **404**.
-20. Con Meta caído (token `...-invalid` en el mock), typing → **200**
+28. `GET /api/bot/context` sin `waIdentity` ni `conversationId` → **422**;
+    con un `conversationId` que no existe → **404**.
+29. `POST /api/bot/messages` con texto vacío → **422**.
+30. `POST /api/bot/typing` con un `conversationId` inexistente → **404**.
+31. Con Meta caído (token `...-invalid` en el mock), typing → **200**
     `{ok:false, reason:"meta_error"}`: es best-effort por contrato, al bot
     jamás le vale reintentarlo.

--- a/tests/unit/bot-gateway.test.ts
+++ b/tests/unit/bot-gateway.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { requireBotKey } from "@/server/bot/auth";
+import { resetRateLimit } from "@/lib/rate-limit";
+
+/** La puerta de toda la superficie `/api/bot/*`. */
+
+const KEY = "clave-de-servicio-larga-0123456789abcdef";
+
+function reqWith(key?: string): Request {
+  return new Request("http://localhost/api/bot/context", {
+    headers: key ? { "x-api-key": key } : {},
+  });
+}
+
+describe("requireBotKey", () => {
+  beforeEach(() => {
+    vi.stubEnv("BOT_API_KEY", KEY);
+    resetRateLimit();
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("key correcta → pasa (null)", () => {
+    expect(requireBotKey(reqWith(KEY))).toBeNull();
+  });
+
+  it("key incorrecta → 401", () => {
+    const res = requireBotKey(reqWith("otra-clave-igual-de-larga-pero-mala!!"));
+    expect(res?.status).toBe(401);
+  });
+
+  it("sin header → 401", () => {
+    expect(requireBotKey(reqWith())?.status).toBe(401);
+  });
+
+  it("sin BOT_API_KEY configurada → 401 SIEMPRE (aunque manden algo)", () => {
+    vi.stubEnv("BOT_API_KEY", "");
+    expect(requireBotKey(reqWith("cualquier-cosa"))?.status).toBe(401);
+  });
+
+  it("key demasiado corta configurada → 401 (no se acepta una key débil)", () => {
+    vi.stubEnv("BOT_API_KEY", "corta");
+    expect(requireBotKey(reqWith("corta"))?.status).toBe(401);
+  });
+
+  it("longitudes distintas no filtran información (401 uniforme)", () => {
+    const res = requireBotKey(reqWith("x"));
+    expect(res?.status).toBe(401);
+  });
+});


### PR DESCRIPTION
> Apilado sobre #10 (`feat/bot-profile`). GitHub lo re-apunta a `main` en cuanto
> #10 se mergee; el diff propio son los cinco archivos de abajo.

Con estos dos endpoints un bot propio ya conduce una conversación completa
contra Vocero: pide el contexto, decide, y responde a través del CRM. Es el par
que de verdad cierra la brecha del issue #8 — hasta hoy, un agente externo no
podía enviar un solo mensaje.

## Por qué van juntos

El bot saca el `conversationId` del contexto. `messages` sin `context` no
destraba nada, y `context` sin `messages` deja al bot mirando una conversación
a la que no le puede contestar.

## `GET /api/bot/context`

Resuelve por `conversationId` o por `waIdentity`. El segundo es el camino real:
cuando llega un mensaje, el bot solo tiene al remitente.

```json
{
  "contact": {"id": "ct_…", "name": "Ana", "waIdentity": "…", "phone": "+52…"},
  "conversation": {"id": "cv_…", "aiEnabled": true, "handoffAt": null, "windowOpen": true, "windowRemainingMs": 83400000},
  "lead": {"id": "ld_…", "stageName": "En conversación"}
}
```

**No devuelve el historial de mensajes.** Esa memoria es del bot; traerla aquí
sería pagar una consulta grande en cada turno para devolverle lo que ya tiene.
Lo que sale es lo que *solo* el CRM sabe.

**`aiEnabled` viene colapsado con el handoff**: si un humano tomó la
conversación llega en `false` aunque el flag de la fila siga en `true`. Para el
bot hay una sola verdad y no tiene que reconstruirla cruzando dos campos.

**Una conversación del Laboratorio no se resuelve nunca por `waIdentity`**: el
bot de producción no debe poder hablarle a un cliente simulado.

## `POST /api/bot/messages`

Usa el **mismo `sendText` del composer de la bandeja**. El token de WhatsApp
jamás sale del CRM, y el mensaje hereda todo lo que ya existe: queda en el hilo
marcado como IA (`aiGenerated`, `origin: "ai"`), respeta la ventana de 24 h y
choca con el guard de sandbox del Laboratorio.

Los 409 son tipados para que el bot sepa qué hacer, no solo que falló:

| Código | Qué significa para el bot |
|---|---|
| `ai_paused` | Un humano tomó la conversación. Callarse. |
| `window_closed` | Pasaron 24 h sin respuesta. Toca plantilla desde la app. |
| `sandbox_violation` | Es una conversación del Laboratorio. |

**El gate de handoff se relee justo antes de enviar**, no se confía en lo que
dijo el contexto: entre que el bot pidió el contexto y su LLM terminó de
responder pasan segundos, y en esos segundos el dueño pudo haber tomado la
conversación. Verificado que el rechazo ocurre *antes* de tocar Meta.

## De paso: la puerta se queda con pruebas

`requireBotKey` gobierna toda la superficie `/api/bot/*` y no tenía ninguna.
Van seis: key correcta, key equivocada, sin header, sin `BOT_API_KEY`
configurada, key demasiado débil, y longitudes distintas devolviendo un 401
uniforme que no filtra información.

## Superficie

Nada que ya existiera cambia de comportamiento. Sin migraciones, sin variables
de entorno nuevas, sin dependencias, sin cambios en la UI.

## Verificación

```
pnpm typecheck   ✓
pnpm lint        ✓
pnpm test        ✓  147 pruebas (6 nuevas)
pnpm build       ✓  /api/bot/context y /api/bot/messages registradas
pnpm test:e2e    ✓  71/71 contra la app viva (16 checks nuevos)
```

Los checks nuevos del arnés cubren el camino feliz y el infeliz: resolver por
`conversationId` y por `waIdentity` dando la misma conversación, la etapa del
lead, la ventana abierta, 422 sin parámetros, 404 con conversación inexistente,
el envío llegando de verdad al canal y quedando marcado como IA, texto vacío
rechazado, y el 409 `ai_paused` sin tocar el outbox.

Tres guardrails que el arnés no puede montar, probados a mano contra la base:

- ventana de 24 h vencida → `409 window_closed`, con el contexto anticipándolo
  en `windowOpen: false`;
- conversación del Laboratorio → `409 sandbox_violation`, y no resoluble por
  `waIdentity`;
- handoff activo → `aiEnabled: false` con el flag de la fila en `true`.

## Lo que sigue

`PUT /api/bot/ficha` (el único del gateway que toca el esquema: una migración
aditiva de columnas nullable sobre `contact`) y `POST /api/bot/handoff`. Ese
último necesita una decisión chica: el enum de `conversation.handoffReason` no
contempla `hostilidad`, que los agentes emiten al escalar un lead agresivo.
Ensancharlo es una línea en `schema.ts` y cero SQL, porque la columna ya es
`text` sin constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
