### PR TITLE
feat(bot-api): handoff pedido por el cerebro externo

### DIFF
--- a/scripts/e2e-selftest.mjs
+++ b/scripts/e2e-selftest.mjs
@@ -451,6 +451,106 @@ async function main() {
   });
   ok("texto vacío → 422 (no se manda un mensaje en blanco)", sendVacio.res.status === 422);
 
+  console.log("\n== us-bot-api: el bot pide un humano ==");
+  const hoNoKey = await api("/api/bot/handoff", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId, reason: "cliente" }),
+  });
+  ok("handoff sin API key → 401", hoNoKey.res.status === 401);
+
+  const ho = await bot("/api/bot/handoff", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId, reason: "hostilidad" }),
+  });
+  ok("POST /api/bot/handoff → 200", ho.res.ok && ho.json?.ok === true);
+  await sleep(300);
+  let convTrasHandoff = ((await api("/api/conversations")).json?.conversations ?? [])
+    .find((c) => c.id === convId);
+  ok(
+    "la conversación queda pausada y con su motivo",
+    convTrasHandoff?.aiEnabled === false &&
+      !!convTrasHandoff?.handoffAt &&
+      convTrasHandoff?.handoffReason === "hostilidad",
+    JSON.stringify({
+      aiEnabled: convTrasHandoff?.aiEnabled,
+      reason: convTrasHandoff?.handoffReason,
+    })
+  );
+  const primerHandoffAt = convTrasHandoff?.handoffAt;
+
+  const hoRepe = await bot("/api/bot/handoff", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId, reason: "cliente" }),
+  });
+  await sleep(300);
+  convTrasHandoff = ((await api("/api/conversations")).json?.conversations ?? [])
+    .find((c) => c.id === convId);
+  ok(
+    "repetir el handoff es idempotente: no pisa la hora ni el motivo original",
+    hoRepe.res.ok &&
+      convTrasHandoff?.handoffAt === primerHandoffAt &&
+      convTrasHandoff?.handoffReason === "hostilidad",
+    JSON.stringify({
+      antes: primerHandoffAt,
+      ahora: convTrasHandoff?.handoffAt,
+      reason: convTrasHandoff?.handoffReason,
+    })
+  );
+
+  const hoNoConv = await bot("/api/bot/handoff", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: "cv_no_existe", reason: "cliente" }),
+  });
+  ok("handoff de conversación inexistente → 404", hoNoConv.res.status === 404);
+
+  // El handoff jamás debe perderse por un motivo que no esté en el catálogo:
+  // el bot se quedaría hablándole a alguien que pidió un humano.
+  await bot("/api/bot/reset", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId }),
+  });
+  await sleep(300);
+  const hoRaro = await bot("/api/bot/handoff", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId, reason: "porque sí" }),
+  });
+  await sleep(300);
+  convTrasHandoff = ((await api("/api/conversations")).json?.conversations ?? [])
+    .find((c) => c.id === convId);
+  ok(
+    "un motivo fuera del catálogo NO tira el handoff (cae a 'modelo')",
+    hoRaro.res.ok &&
+      convTrasHandoff?.aiEnabled === false &&
+      convTrasHandoff?.handoffReason === "modelo",
+    JSON.stringify({
+      status: hoRaro.res.status,
+      reason: convTrasHandoff?.handoffReason,
+    })
+  );
+
+  await bot("/api/bot/reset", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId }),
+  });
+  await sleep(300);
+  const hoSinReason = await bot("/api/bot/handoff", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId }),
+  });
+  await sleep(300);
+  convTrasHandoff = ((await api("/api/conversations")).json?.conversations ?? [])
+    .find((c) => c.id === convId);
+  ok(
+    "sin motivo también pausa (cae a 'modelo')",
+    hoSinReason.res.ok && convTrasHandoff?.handoffReason === "modelo",
+    JSON.stringify(convTrasHandoff?.handoffReason)
+  );
+  await bot("/api/bot/reset", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId }),
+  });
+  await sleep(300);
+
   console.log("\n== us-bot-api: IA pausada y reset ==");
   const pause = await api(`/api/conversations/${convId}`, {
     method: "PATCH",

--- a/src/app/api/bot/handoff/route.ts
+++ b/src/app/api/bot/handoff/route.ts
@@ -1,0 +1,73 @@
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { getDb, schema } from "@/lib/db";
+import { apiError, parseBody } from "@/lib/api";
+import { requireBotKey, resolveInstanceOrg } from "@/server/bot/auth";
+import { publish } from "@/server/events/bus";
+import { toHandoffReason } from "@/server/bot/handoff";
+
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({
+  conversationId: z.string().min(1),
+  /**
+   * Texto libre a propósito: el catálogo se aplica después, con fallback
+   * (ver `server/bot/handoff`). Un motivo raro no puede costar el handoff.
+   */
+  reason: z.string().optional(),
+});
+
+/**
+ * Handoff pedido por el cerebro externo: pausa la IA y deja la conversación
+ * para un humano. Idempotente — solo escribe en la transición, así que
+ * reintentar no pisa la hora ni el motivo original.
+ *
+ * Es la misma pausa que el toggle de la bandeja, y publica el mismo evento,
+ * así que la app lo ve en vivo sin refrescar.
+ */
+export async function POST(req: Request) {
+  const denied = requireBotKey(req);
+  if (denied) return denied;
+
+  const organizationId = await resolveInstanceOrg();
+  if (!organizationId) {
+    return apiError(409, "no_org", "La instancia aún no tiene organización");
+  }
+
+  const body = await parseBody(req, bodySchema);
+  if (!body.ok) return body.response;
+
+  const db = getDb();
+  const rows = await db
+    .select({
+      id: schema.conversation.id,
+      handoffAt: schema.conversation.handoffAt,
+    })
+    .from(schema.conversation)
+    .where(
+      and(
+        eq(schema.conversation.organizationId, organizationId),
+        eq(schema.conversation.id, body.data.conversationId)
+      )
+    )
+    .limit(1);
+  const conv = rows[0];
+  if (!conv) return apiError(404, "not_found", "Conversación no encontrada");
+
+  if (!conv.handoffAt) {
+    await db
+      .update(schema.conversation)
+      .set({
+        aiEnabled: false,
+        handoffAt: new Date(),
+        handoffReason: toHandoffReason(body.data.reason),
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.conversation.id, conv.id));
+    publish(organizationId, {
+      type: "conversation.updated",
+      data: { conversation: { id: conv.id } },
+    });
+  }
+  return Response.json({ ok: true });
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -200,7 +200,15 @@ export const conversation = pgTable(
     handoffAt: timestamp("handoff_at"),
     handoffReason: text("handoff_reason", {
       // 008: manual_reply = el dueño respondió desde la app del teléfono.
-      enum: ["cliente", "modelo", "error", "ventana", "manual_reply"],
+      // hostilidad = el lead se puso agresivo y el agente se retiró.
+      enum: [
+        "cliente",
+        "modelo",
+        "error",
+        "ventana",
+        "hostilidad",
+        "manual_reply",
+      ],
     }),
     lastInboundAt: timestamp("last_inbound_at"),
     lastMessageAt: timestamp("last_message_at"),

--- a/src/server/bot/handoff.ts
+++ b/src/server/bot/handoff.ts
@@ -1,0 +1,26 @@
+/**
+ * Motivos por los que un cerebro externo devuelve la conversación a un humano.
+ *
+ * El catálogo es cerrado, pero se aplica con FALLBACK, nunca rechazando: un
+ * motivo fuera de lista no puede costar el handoff. Un 422 aquí dejaría al bot
+ * hablándole a alguien que acaba de pedir una persona — el peor final posible
+ * de esa ruta. Del otro lado hay un LLM: tarde o temprano manda "porque se
+ * enojó" en vez de "hostilidad".
+ */
+
+export const HANDOFF_REASONS = [
+  "cliente",
+  "modelo",
+  "error",
+  "ventana",
+  "hostilidad",
+] as const;
+
+export type HandoffReason = (typeof HANDOFF_REASONS)[number];
+
+export function toHandoffReason(raw: string | undefined | null): HandoffReason {
+  const v = raw?.trim().toLowerCase() ?? "";
+  return (HANDOFF_REASONS as readonly string[]).includes(v)
+    ? (v as HandoffReason)
+    : "modelo";
+}

--- a/tests/e2e/us-bot-api.md
+++ b/tests/e2e/us-bot-api.md
@@ -108,14 +108,25 @@ CRM no impone un cuestionario.
     esquivar la regla de Meta; para eso está el envío de plantilla desde la app.
 30. En una conversación del Laboratorio → **409** `sandbox_violation`.
 
+## El bot pide un humano
+
+31. `POST /api/bot/handoff {conversationId, reason}` con la key → **200**, la
+    conversación queda con `aiEnabled: false`, su `handoffAt` y el motivo. En la
+    bandeja se ve al instante, sin recargar (mismo evento que el toggle).
+32. Repetirlo es idempotente: no pisa la hora ni el motivo del primero.
+33. Un `reason` que no está en el catálogo —o ausente— **no tira el handoff**:
+    cae a `modelo` y la IA se pausa igual. Un 422 aquí dejaría al bot
+    vendiéndole a alguien que acaba de pedir un humano.
+34. Conversación inexistente → **404**.
+
 ## Camino infeliz
 
-31. `GET /api/bot/profile` en una instancia sin perfil de agente → **404**
+35. `GET /api/bot/profile` en una instancia sin perfil de agente → **404**
     `no_profile` (condición esperada, no un 500: el bot cae a su brief local).
-32. `GET /api/bot/context` sin `waIdentity` ni `conversationId` → **422**;
+36. `GET /api/bot/context` sin `waIdentity` ni `conversationId` → **422**;
     con un `conversationId` que no existe → **404**.
-33. `POST /api/bot/messages` con texto vacío → **422**.
-34. `POST /api/bot/typing` con un `conversationId` inexistente → **404**.
-35. Con Meta caído (token `...-invalid` en el mock), typing → **200**
+37. `POST /api/bot/messages` con texto vacío → **422**.
+38. `POST /api/bot/typing` con un `conversationId` inexistente → **404**.
+39. Con Meta caído (token `...-invalid` en el mock), typing → **200**
     `{ok:false, reason:"meta_error"}`: es best-effort por contrato, al bot
     jamás le vale reintentarlo.

--- a/tests/unit/bot-gateway.test.ts
+++ b/tests/unit/bot-gateway.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { requireBotKey } from "@/server/bot/auth";
 import { mergeFicha, normalizeFicha } from "@/server/bot/ficha";
+import { toHandoffReason } from "@/server/bot/handoff";
 import { resetRateLimit } from "@/lib/rate-limit";
 
 /** La puerta de toda la superficie `/api/bot/*`. */
@@ -89,6 +90,27 @@ describe("normalizeFicha (tolerante al drift del LLM)", () => {
     const raw: Record<string, string> = {};
     for (let i = 0; i < 200; i++) raw[`campo${i}`] = "v";
     expect(Object.keys(normalizeFicha(raw)).length).toBe(40);
+  });
+});
+
+describe("toHandoffReason (el handoff nunca se pierde por el motivo)", () => {
+  it("los motivos del catálogo pasan tal cual", () => {
+    for (const r of ["cliente", "modelo", "error", "ventana", "hostilidad"]) {
+      expect(toHandoffReason(r)).toBe(r);
+    }
+  });
+
+  it("un motivo inventado por el LLM cae a 'modelo' en vez de tirar el handoff", () => {
+    expect(toHandoffReason("porque el señor se enojó")).toBe("modelo");
+  });
+
+  it("ausente o vacío también cae a 'modelo'", () => {
+    expect(toHandoffReason(undefined)).toBe("modelo");
+    expect(toHandoffReason("   ")).toBe("modelo");
+  });
+
+  it("tolera mayúsculas y espacios de sobra", () => {
+    expect(toHandoffReason("  Hostilidad ")).toBe("hostilidad");
   });
 });
 


### PR DESCRIPTION
> Apilado sobre #12. GitHub lo re-apunta a `main` cuando los anteriores se
> mergeen.

`POST /api/bot/handoff` deja que el cerebro externo devuelva la conversación a
un humano: pausa la IA, la marca con su motivo y publica el mismo evento que el
toggle de la bandeja, así que el dueño lo ve en vivo sin refrescar. Es el
quinto y último endpoint del issue #8 de los que no necesitan un motor nuevo.

Es idempotente: solo escribe en la transición, así que reintentar no pisa la
hora ni el motivo del primero.

## El detalle que hay que discutir: `hostilidad`

El enum de `conversation.handoffReason` en `main` es:

```ts
["cliente", "modelo", "error", "ventana", "manual_reply"]
```

Le falta `hostilidad`, y los agentes lo emiten: es el motivo con el que un
agente se retira cuando el lead se pone agresivo. Este PR lo agrega.

**Es una línea en `schema.ts` y cero SQL** — la columna ya es `text` sin
constraint, y `pnpm db:generate` confirma "No schema changes, nothing to
migrate".

Y por si acaso, el endpoint **no rechaza motivos desconocidos**: los aplica con
fallback a `modelo`. Esa decisión es el corazón del PR. Si `reason` viniera
validado con 422, un agente que mande "porque el señor se enojó" —y tarde o
temprano lo hace, hay un LLM del otro lado— recibiría un error, el handoff no
ocurriría, y el bot seguiría vendiéndole a alguien que acaba de pedir una
persona. Perder el matiz del motivo es barato; perder el handoff no.

La regla vive en `src/server/bot/handoff.ts` con sus propias pruebas, no
enterrada en el `route.ts`.

## Superficie

Sin migraciones, sin variables de entorno nuevas, sin dependencias, sin cambios
en la UI. La alerta al dueño que existe en el fork del que sale este código se
quedó fuera a propósito: manda por Telegram, y la constitución del proyecto
(Soberanía, II) limita las dependencias de runtime a WhatsApp Cloud API y un
proveedor LLM. El sustituto ya existe y ya se publica aquí: el evento SSE
`conversation.updated` que la bandeja escucha.

## Verificación

```
pnpm typecheck   ✓
pnpm lint        ✓
pnpm test        ✓  162 pruebas (4 nuevas: toHandoffReason)
pnpm build       ✓  /api/bot/handoff registrada
pnpm test:e2e    ✓  87/87 contra la app viva (7 checks nuevos)
```

Los checks nuevos cubren el 401 sin key, el 200 que deja la conversación
pausada con su motivo, la idempotencia (ni la hora ni el motivo se pisan al
repetir), el 404 de conversación inexistente, y los dos casos que importan: un
motivo fuera del catálogo y un cuerpo sin motivo, que en ambos pausan la IA y
caen a `modelo`.

## Con esto se cierra el issue #8

Los cinco endpoints que quedaban del bot gateway están en los PRs #10, #11,
#12 y este. Faltan `availability` y `bookings`, que son otra cosa: necesitan un
motor de agenda que hoy no existe en el repo. Vale la pena discutirlo aparte —
son ~1.000 líneas y dos tablas nuevas, y eso merece su propia conversación
sobre cuánto peso queremos en el core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
