### PR TITLE
chore(bot-api): llevar a main la pila #11, #12 y #13

### DIFF
--- a/drizzle/0003_flippant_mastermind.sql
+++ b/drizzle/0003_flippant_mastermind.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "contact" ADD COLUMN "ficha" jsonb;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,2127 @@
+{
+  "id": "f8d220d4-2f13-4063-bfc2-a1bc88b746d3",
+  "prevId": "4e644067-d1cd-4441-9317-8964fb421de5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_profile": {
+      "name": "agent_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asistente'"
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalation_rules": {
+          "name": "escalation_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_profile_org_uq": {
+          "name": "agent_profile_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_profile_organization_id_organization_id_fk": {
+          "name": "agent_profile_organization_id_organization_id_fk",
+          "tableFrom": "agent_profile",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_case": {
+      "name": "agent_test_case",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "veredicto": {
+          "name": "veredicto",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hallazgos": {
+          "name": "hallazgos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_case_run_idx": {
+          "name": "test_case_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_case_organization_id_organization_id_fk": {
+          "name": "agent_test_case_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_run_id_agent_test_run_id_fk": {
+          "name": "agent_test_case_run_id_agent_test_run_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "agent_test_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_conversation_id_conversation_id_fk": {
+          "name": "agent_test_case_conversation_id_conversation_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_run": {
+      "name": "agent_test_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "test_run_org_running_uq": {
+          "name": "test_run_org_running_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_test_run\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_run_org_idx": {
+          "name": "test_run_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_run_organization_id_organization_id_fk": {
+          "name": "agent_test_run_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact": {
+      "name": "contact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_identity": {
+          "name": "wa_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_user_id": {
+          "name": "wa_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ficha": {
+          "name": "ficha",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_org_wa_identity_uq": {
+          "name": "contact_org_wa_identity_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_wa_user_id_idx": {
+          "name": "contact_org_wa_user_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_name_idx": {
+          "name": "contact_org_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_organization_id_organization_id_fk": {
+          "name": "contact_organization_id_organization_id_fk",
+          "tableFrom": "contact",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_test": {
+          "name": "is_test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ai_enabled": {
+          "name": "ai_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handoff_at": {
+          "name": "handoff_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_reason": {
+          "name": "handoff_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_inbound_at": {
+          "name": "last_inbound_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_org_contact_real_uq": {
+          "name": "conversation_org_contact_real_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation\".\"is_test\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_org_last_idx": {
+          "name": "conversation_org_last_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_organization_id_organization_id_fk": {
+          "name": "conversation_organization_id_organization_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_contact_id_contact_id_fk": {
+          "name": "conversation_contact_id_contact_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_entry": {
+      "name": "kb_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kb_org_idx": {
+          "name": "kb_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_entry_organization_id_organization_id_fk": {
+          "name": "kb_entry_organization_id_organization_id_fk",
+          "tableFrom": "kb_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead": {
+      "name": "lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lead_contact_uq": {
+          "name": "lead_contact_uq",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lead_org_stage_idx": {
+          "name": "lead_org_stage_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_organization_id_organization_id_fk": {
+          "name": "lead_organization_id_organization_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_contact_id_contact_id_fk": {
+          "name": "lead_contact_id_contact_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_asset": {
+      "name": "media_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_media_id": {
+          "name": "wa_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_status": {
+          "name": "fetch_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_asset_org_idx": {
+          "name": "media_asset_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_asset_wa_media_idx": {
+          "name": "media_asset_wa_media_idx",
+          "columns": [
+            {
+              "expression": "wa_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_asset_organization_id_organization_id_fk": {
+          "name": "media_asset_organization_id_organization_id_fk",
+          "tableFrom": "media_asset",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_message_id": {
+          "name": "wa_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated": {
+          "name": "ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'operator'"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_timestamp": {
+          "name": "wa_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_org_conv_idx": {
+          "name": "message_org_conv_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_organization_id_organization_id_fk": {
+          "name": "message_organization_id_organization_id_fk",
+          "tableFrom": "message",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_media_asset_id_media_asset_id_fk": {
+          "name": "message_media_asset_id_media_asset_id_fk",
+          "tableFrom": "message",
+          "tableTo": "media_asset",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_wa_message_id_unique": {
+          "name": "message_wa_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wa_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_credentials": {
+      "name": "meta_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waba_id": {
+          "name": "waba_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number_id": {
+          "name": "phone_number_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_phone_number": {
+          "name": "display_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_name": {
+          "name": "verified_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_cipher": {
+          "name": "token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meta_credentials_org_uq": {
+          "name": "meta_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meta_credentials_phone_uq": {
+          "name": "meta_credentials_phone_uq",
+          "columns": [
+            {
+              "expression": "phone_number_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meta_credentials_organization_id_organization_id_fk": {
+          "name": "meta_credentials_organization_id_organization_id_fk",
+          "tableFrom": "meta_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_stage": {
+      "name": "pipeline_stage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stage_org_pos_idx": {
+          "name": "stage_org_pos_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_stage_organization_id_organization_id_fk": {
+          "name": "pipeline_stage_organization_id_organization_id_fk",
+          "tableFrom": "pipeline_stage",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_template_id": {
+          "name": "wa_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_org_name_lang_uq": {
+          "name": "template_org_name_lang_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_organization_id_organization_id_fk": {
+          "name": "template_organization_id_organization_id_fk",
+          "tableFrom": "template",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1785872764254,
       "tag": "0002_closed_millenium_guard",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1786835958011,
+      "tag": "0003_flippant_mastermind",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/e2e-selftest.mjs
+++ b/scripts/e2e-selftest.mjs
@@ -290,6 +290,90 @@ async function main() {
     JSON.stringify(profAgain.json?.profile?.tone)
   );
 
+  console.log("\n== us-bot-api: contexto conversacional ==");
+  const ctxNoKey = await api(`/api/bot/context?conversationId=${convId}`);
+  ok("contexto sin API key → 401", ctxNoKey.res.status === 401);
+
+  const ctx = await bot(`/api/bot/context?conversationId=${convId}`);
+  ok(
+    "GET /api/bot/context por conversationId → 200",
+    ctx.res.ok && ctx.json?.conversation?.id === convId,
+    JSON.stringify(ctx.json?.conversation)
+  );
+  ok(
+    "trae la identidad estable del contacto (no solo el teléfono)",
+    typeof ctx.json?.contact?.waIdentity === "string" &&
+      ctx.json.contact.waIdentity.length > 0
+  );
+  ok(
+    "trae la etapa del lead en el pipeline",
+    typeof ctx.json?.lead?.stageName === "string",
+    JSON.stringify(ctx.json?.lead)
+  );
+  ok(
+    "la ventana de 24 h viaja abierta tras un entrante reciente",
+    ctx.json?.conversation?.windowOpen === true &&
+      ctx.json?.conversation?.windowRemainingMs > 0,
+    JSON.stringify(ctx.json?.conversation)
+  );
+
+  const ctxByIdentity = await bot(
+    `/api/bot/context?waIdentity=${encodeURIComponent(ctx.json.contact.waIdentity)}`
+  );
+  ok(
+    "resolver por waIdentity da la MISMA conversación",
+    ctxByIdentity.json?.conversation?.id === convId,
+    JSON.stringify(ctxByIdentity.json?.conversation?.id)
+  );
+
+  const ctxSinArgs = await bot("/api/bot/context");
+  ok("contexto sin waIdentity ni conversationId → 422", ctxSinArgs.res.status === 422);
+  const ctx404 = await bot("/api/bot/context?conversationId=cv_no_existe");
+  ok("contexto de una conversación inexistente → 404", ctx404.res.status === 404);
+
+  console.log("\n== us-bot-api: el bot envía a través del CRM ==");
+  const sendNoKey = await api("/api/bot/messages", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId, text: "hola" }),
+  });
+  ok("envío sin API key → 401", sendNoKey.res.status === 401);
+
+  const outboxBeforeBot =
+    ((await api("/api/dev/wa-mock/outbox")).json?.outbox ?? []).length;
+  const botSend = await bot("/api/bot/messages", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId, text: "Hola, soy el bot." }),
+  });
+  ok(
+    "POST /api/bot/messages → 200 con messageId",
+    botSend.res.ok && typeof botSend.json?.messageId === "string",
+    JSON.stringify(botSend.json)
+  );
+  const outboxAfterBot =
+    ((await api("/api/dev/wa-mock/outbox")).json?.outbox ?? []).length;
+  ok(
+    "el mensaje salió de verdad por el canal de WhatsApp",
+    outboxAfterBot === outboxBeforeBot + 1,
+    `antes=${outboxBeforeBot} después=${outboxAfterBot}`
+  );
+  const botMsg = ((await api(`/api/conversations/${convId}/messages`)).json
+    ?.messages ?? []).find((m) => m.id === botSend.json?.messageId);
+  ok(
+    "queda en la bandeja marcado como IA (aiGenerated + origin=ai)",
+    botMsg?.aiGenerated === true && botMsg?.origin === "ai",
+    JSON.stringify({ aiGenerated: botMsg?.aiGenerated, origin: botMsg?.origin })
+  );
+  const sendNoConv = await bot("/api/bot/messages", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: "cv_no_existe", text: "hola" }),
+  });
+  ok("envío a conversación inexistente → 404", sendNoConv.res.status === 404);
+  const sendVacio = await bot("/api/bot/messages", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId, text: "" }),
+  });
+  ok("texto vacío → 422 (no se manda un mensaje en blanco)", sendVacio.res.status === 422);
+
   console.log("\n== us-bot-api: IA pausada y reset ==");
   const pause = await api(`/api/conversations/${convId}`, {
     method: "PATCH",
@@ -307,6 +391,26 @@ async function main() {
       typPaused.json?.ok === false &&
       typPaused.json?.reason === "ai_paused",
     JSON.stringify(typPaused.json)
+  );
+
+  const outboxBeforePaused =
+    ((await api("/api/dev/wa-mock/outbox")).json?.outbox ?? []).length;
+  const sendPaused = await bot("/api/bot/messages", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId, text: "¿sigo yo?" }),
+  });
+  ok(
+    "el bot NO habla sobre una conversación tomada por un humano → 409 ai_paused",
+    sendPaused.res.status === 409 &&
+      sendPaused.json?.error?.code === "ai_paused",
+    JSON.stringify(sendPaused.json)
+  );
+  const outboxAfterPaused =
+    ((await api("/api/dev/wa-mock/outbox")).json?.outbox ?? []).length;
+  ok(
+    "y el rechazo ocurre ANTES de tocar Meta",
+    outboxAfterPaused === outboxBeforePaused,
+    `antes=${outboxBeforePaused} después=${outboxAfterPaused}`
   );
 
   const msgsBeforeReset =

--- a/scripts/e2e-selftest.mjs
+++ b/scripts/e2e-selftest.mjs
@@ -331,6 +331,83 @@ async function main() {
   const ctx404 = await bot("/api/bot/context?conversationId=cv_no_existe");
   ok("contexto de una conversación inexistente → 404", ctx404.res.status === 404);
 
+  console.log("\n== us-bot-api: ficha de calificación ==");
+  const fichaNoKey = await api("/api/bot/ficha", {
+    method: "PUT",
+    body: JSON.stringify({ conversationId: convId, ficha: { rubro: "x" } }),
+  });
+  ok("ficha sin API key → 401", fichaNoKey.res.status === 401);
+
+  const f1 = await bot("/api/bot/ficha", {
+    method: "PUT",
+    body: JSON.stringify({
+      conversationId: convId,
+      ficha: { rubro: "dentista", geo: "Querétaro", calificado: true },
+    }),
+  });
+  ok(
+    "PUT /api/bot/ficha → 200 con la ficha completa",
+    f1.res.ok && f1.json?.ficha?.rubro === "dentista",
+    JSON.stringify(f1.json)
+  );
+  ok(
+    "las claves las pone el negocio: el CRM guarda lo que le manden",
+    f1.json?.ficha?.geo === "Querétaro" && f1.json?.ficha?.calificado === true,
+    JSON.stringify(f1.json?.ficha)
+  );
+
+  const ctxConFicha = await bot(`/api/bot/context?conversationId=${convId}`);
+  ok(
+    "la ficha viaja en el contexto del siguiente turno",
+    ctxConFicha.json?.contact?.ficha?.rubro === "dentista",
+    JSON.stringify(ctxConFicha.json?.contact?.ficha)
+  );
+
+  const f2 = await bot("/api/bot/ficha", {
+    method: "PUT",
+    body: JSON.stringify({
+      conversationId: convId,
+      ficha: { presupuesto: "20 mil", geo: null },
+    }),
+  });
+  ok(
+    "merge campo a campo: lo ausente se conserva",
+    f2.json?.ficha?.rubro === "dentista" && f2.json?.ficha?.presupuesto === "20 mil",
+    JSON.stringify(f2.json?.ficha)
+  );
+  ok(
+    "null explícito borra la clave",
+    f2.json?.ficha && !("geo" in f2.json.ficha),
+    JSON.stringify(f2.json?.ficha)
+  );
+
+  const fBasura = await bot("/api/bot/ficha", {
+    method: "PUT",
+    body: JSON.stringify({
+      conversationId: convId,
+      ficha: { anidado: { a: 1 }, vacío: "", bueno: "  sí  " },
+    }),
+  });
+  ok(
+    "lo que no se entiende se ignora sin 422 (no se le tiran datos al bot)",
+    fBasura.res.ok &&
+      fBasura.json?.ficha?.bueno === "sí" &&
+      !("anidado" in fBasura.json.ficha) &&
+      !("vacío" in fBasura.json.ficha),
+    JSON.stringify(fBasura.json?.ficha)
+  );
+
+  const fNoConv = await bot("/api/bot/ficha", {
+    method: "PUT",
+    body: JSON.stringify({ conversationId: "cv_no_existe", ficha: { a: "b" } }),
+  });
+  ok("ficha de conversación inexistente → 404", fNoConv.res.status === 404);
+  const fSinFicha = await bot("/api/bot/ficha", {
+    method: "PUT",
+    body: JSON.stringify({ conversationId: convId }),
+  });
+  ok("cuerpo sin `ficha` → 422", fSinFicha.res.status === 422);
+
   console.log("\n== us-bot-api: el bot envía a través del CRM ==");
   const sendNoKey = await api("/api/bot/messages", {
     method: "POST",

--- a/scripts/e2e-selftest.mjs
+++ b/scripts/e2e-selftest.mjs
@@ -451,6 +451,106 @@ async function main() {
   });
   ok("texto vacío → 422 (no se manda un mensaje en blanco)", sendVacio.res.status === 422);
 
+  console.log("\n== us-bot-api: el bot pide un humano ==");
+  const hoNoKey = await api("/api/bot/handoff", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId, reason: "cliente" }),
+  });
+  ok("handoff sin API key → 401", hoNoKey.res.status === 401);
+
+  const ho = await bot("/api/bot/handoff", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId, reason: "hostilidad" }),
+  });
+  ok("POST /api/bot/handoff → 200", ho.res.ok && ho.json?.ok === true);
+  await sleep(300);
+  let convTrasHandoff = ((await api("/api/conversations")).json?.conversations ?? [])
+    .find((c) => c.id === convId);
+  ok(
+    "la conversación queda pausada y con su motivo",
+    convTrasHandoff?.aiEnabled === false &&
+      !!convTrasHandoff?.handoffAt &&
+      convTrasHandoff?.handoffReason === "hostilidad",
+    JSON.stringify({
+      aiEnabled: convTrasHandoff?.aiEnabled,
+      reason: convTrasHandoff?.handoffReason,
+    })
+  );
+  const primerHandoffAt = convTrasHandoff?.handoffAt;
+
+  const hoRepe = await bot("/api/bot/handoff", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId, reason: "cliente" }),
+  });
+  await sleep(300);
+  convTrasHandoff = ((await api("/api/conversations")).json?.conversations ?? [])
+    .find((c) => c.id === convId);
+  ok(
+    "repetir el handoff es idempotente: no pisa la hora ni el motivo original",
+    hoRepe.res.ok &&
+      convTrasHandoff?.handoffAt === primerHandoffAt &&
+      convTrasHandoff?.handoffReason === "hostilidad",
+    JSON.stringify({
+      antes: primerHandoffAt,
+      ahora: convTrasHandoff?.handoffAt,
+      reason: convTrasHandoff?.handoffReason,
+    })
+  );
+
+  const hoNoConv = await bot("/api/bot/handoff", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: "cv_no_existe", reason: "cliente" }),
+  });
+  ok("handoff de conversación inexistente → 404", hoNoConv.res.status === 404);
+
+  // El handoff jamás debe perderse por un motivo que no esté en el catálogo:
+  // el bot se quedaría hablándole a alguien que pidió un humano.
+  await bot("/api/bot/reset", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId }),
+  });
+  await sleep(300);
+  const hoRaro = await bot("/api/bot/handoff", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId, reason: "porque sí" }),
+  });
+  await sleep(300);
+  convTrasHandoff = ((await api("/api/conversations")).json?.conversations ?? [])
+    .find((c) => c.id === convId);
+  ok(
+    "un motivo fuera del catálogo NO tira el handoff (cae a 'modelo')",
+    hoRaro.res.ok &&
+      convTrasHandoff?.aiEnabled === false &&
+      convTrasHandoff?.handoffReason === "modelo",
+    JSON.stringify({
+      status: hoRaro.res.status,
+      reason: convTrasHandoff?.handoffReason,
+    })
+  );
+
+  await bot("/api/bot/reset", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId }),
+  });
+  await sleep(300);
+  const hoSinReason = await bot("/api/bot/handoff", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId }),
+  });
+  await sleep(300);
+  convTrasHandoff = ((await api("/api/conversations")).json?.conversations ?? [])
+    .find((c) => c.id === convId);
+  ok(
+    "sin motivo también pausa (cae a 'modelo')",
+    hoSinReason.res.ok && convTrasHandoff?.handoffReason === "modelo",
+    JSON.stringify(convTrasHandoff?.handoffReason)
+  );
+  await bot("/api/bot/reset", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId }),
+  });
+  await sleep(300);
+
   console.log("\n== us-bot-api: IA pausada y reset ==");
   const pause = await api(`/api/conversations/${convId}`, {
     method: "PATCH",

--- a/src/app/api/bot/context/route.ts
+++ b/src/app/api/bot/context/route.ts
@@ -1,0 +1,125 @@
+import { and, eq } from "drizzle-orm";
+import { getDb, schema } from "@/lib/db";
+import { apiError } from "@/lib/api";
+import { requireBotKey, resolveInstanceOrg } from "@/server/bot/auth";
+import { isWindowOpen, windowRemainingMs } from "@/server/inbox/window";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Contexto conversacional para un cerebro externo (solo lectura).
+ * GET /api/bot/context?waIdentity=... | ?conversationId=...
+ *
+ * NO devuelve el historial de mensajes: el bot lleva su propia memoria de la
+ * conversación. Lo que aquí sale es lo que solo el CRM sabe — quién es la
+ * persona, si un humano tomó el control y si la ventana de 24 h sigue abierta.
+ */
+export async function GET(req: Request) {
+  const denied = requireBotKey(req);
+  if (denied) return denied;
+
+  const organizationId = await resolveInstanceOrg();
+  if (!organizationId) {
+    return apiError(409, "no_org", "La instancia aún no tiene organización");
+  }
+
+  const url = new URL(req.url);
+  const waIdentity = url.searchParams.get("waIdentity");
+  const conversationId = url.searchParams.get("conversationId");
+  if (!waIdentity && !conversationId) {
+    return apiError(422, "invalid", "Falta waIdentity o conversationId");
+  }
+
+  const db = getDb();
+
+  let contact: typeof schema.contact.$inferSelect | undefined;
+  let conversation: typeof schema.conversation.$inferSelect | undefined;
+
+  if (conversationId) {
+    const rows = await db
+      .select({ conversation: schema.conversation, contact: schema.contact })
+      .from(schema.conversation)
+      .innerJoin(
+        schema.contact,
+        eq(schema.conversation.contactId, schema.contact.id)
+      )
+      .where(
+        and(
+          eq(schema.conversation.organizationId, organizationId),
+          eq(schema.conversation.id, conversationId)
+        )
+      )
+      .limit(1);
+    contact = rows[0]?.contact;
+    conversation = rows[0]?.conversation;
+  } else if (waIdentity) {
+    const contacts = await db
+      .select()
+      .from(schema.contact)
+      .where(
+        and(
+          eq(schema.contact.organizationId, organizationId),
+          eq(schema.contact.waIdentity, waIdentity)
+        )
+      )
+      .limit(1);
+    contact = contacts[0];
+    if (contact) {
+      // La conversación del Laboratorio jamás se resuelve por identidad: ese
+      // camino es para el bot de producción, que nunca debe hablarle a un
+      // cliente simulado.
+      const convs = await db
+        .select()
+        .from(schema.conversation)
+        .where(
+          and(
+            eq(schema.conversation.organizationId, organizationId),
+            eq(schema.conversation.contactId, contact.id),
+            eq(schema.conversation.isTest, false)
+          )
+        )
+        .limit(1);
+      conversation = convs[0];
+    }
+  }
+
+  if (!contact || !conversation) {
+    return apiError(404, "not_found", "Conversación no encontrada");
+  }
+
+  const leadRows = await db
+    .select({ lead: schema.lead, stage: schema.pipelineStage })
+    .from(schema.lead)
+    .innerJoin(
+      schema.pipelineStage,
+      eq(schema.lead.stageId, schema.pipelineStage.id)
+    )
+    .where(
+      and(
+        eq(schema.lead.organizationId, organizationId),
+        eq(schema.lead.contactId, contact.id)
+      )
+    )
+    .limit(1);
+
+  return Response.json({
+    contact: {
+      id: contact.id,
+      name: contact.name,
+      waIdentity: contact.waIdentity,
+      phone: contact.phone,
+    },
+    conversation: {
+      id: conversation.id,
+      // Una sola verdad para el bot: si hay handoff, la IA está apagada
+      // aunque el flag siga en true.
+      aiEnabled: conversation.aiEnabled && !conversation.handoffAt,
+      handoffAt: conversation.handoffAt?.toISOString() ?? null,
+      windowOpen: isWindowOpen(conversation.lastInboundAt),
+      windowRemainingMs: windowRemainingMs(conversation.lastInboundAt),
+    },
+    lead: leadRows[0]
+      ? { id: leadRows[0].lead.id, stageName: leadRows[0].stage.name }
+      : null,
+  });
+}

--- a/src/app/api/bot/context/route.ts
+++ b/src/app/api/bot/context/route.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 import { getDb, schema } from "@/lib/db";
 import { apiError } from "@/lib/api";
 import { requireBotKey, resolveInstanceOrg } from "@/server/bot/auth";
+import { serializeFicha } from "@/server/bot/ficha";
 import { isWindowOpen, windowRemainingMs } from "@/server/inbox/window";
 
 export const dynamic = "force-dynamic";
@@ -108,6 +109,7 @@ export async function GET(req: Request) {
       name: contact.name,
       waIdentity: contact.waIdentity,
       phone: contact.phone,
+      ficha: serializeFicha(contact),
     },
     conversation: {
       id: conversation.id,

--- a/src/app/api/bot/ficha/route.ts
+++ b/src/app/api/bot/ficha/route.ts
@@ -1,0 +1,53 @@
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { getDb, schema } from "@/lib/db";
+import { apiError, parseBody } from "@/lib/api";
+import { requireBotKey, resolveInstanceOrg } from "@/server/bot/auth";
+import { upsertFicha } from "@/server/bot/ficha";
+
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({
+  conversationId: z.string().min(1),
+  // Objeto libre a propósito: las claves las define el negocio, y el servidor
+  // tolera el drift del LLM en vez de castigarlo con un 422 (ver server/bot/ficha).
+  ficha: z.record(z.unknown()),
+});
+
+/**
+ * Ficha de calificación del lead, escrita por un cerebro externo.
+ * Merge campo a campo contra lo que ya había; `null` explícito borra la clave.
+ * Devuelve la ficha COMPLETA resultante, no solo el parche, para que el bot no
+ * tenga que llevar su propia copia sincronizada.
+ */
+export async function PUT(req: Request) {
+  const denied = requireBotKey(req);
+  if (denied) return denied;
+
+  const organizationId = await resolveInstanceOrg();
+  if (!organizationId) {
+    return apiError(409, "no_org", "La instancia aún no tiene organización");
+  }
+
+  const body = await parseBody(req, bodySchema);
+  if (!body.ok) return body.response;
+
+  const db = getDb();
+  const rows = await db
+    .select({ contactId: schema.conversation.contactId })
+    .from(schema.conversation)
+    .where(
+      and(
+        eq(schema.conversation.organizationId, organizationId),
+        eq(schema.conversation.id, body.data.conversationId)
+      )
+    )
+    .limit(1);
+  if (!rows[0]) return apiError(404, "not_found", "Conversación no encontrada");
+
+  const result = await upsertFicha({
+    contactId: rows[0].contactId,
+    ficha: body.data.ficha,
+  });
+  return Response.json(result);
+}

--- a/src/app/api/bot/handoff/route.ts
+++ b/src/app/api/bot/handoff/route.ts
@@ -1,0 +1,73 @@
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { getDb, schema } from "@/lib/db";
+import { apiError, parseBody } from "@/lib/api";
+import { requireBotKey, resolveInstanceOrg } from "@/server/bot/auth";
+import { publish } from "@/server/events/bus";
+import { toHandoffReason } from "@/server/bot/handoff";
+
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({
+  conversationId: z.string().min(1),
+  /**
+   * Texto libre a propósito: el catálogo se aplica después, con fallback
+   * (ver `server/bot/handoff`). Un motivo raro no puede costar el handoff.
+   */
+  reason: z.string().optional(),
+});
+
+/**
+ * Handoff pedido por el cerebro externo: pausa la IA y deja la conversación
+ * para un humano. Idempotente — solo escribe en la transición, así que
+ * reintentar no pisa la hora ni el motivo original.
+ *
+ * Es la misma pausa que el toggle de la bandeja, y publica el mismo evento,
+ * así que la app lo ve en vivo sin refrescar.
+ */
+export async function POST(req: Request) {
+  const denied = requireBotKey(req);
+  if (denied) return denied;
+
+  const organizationId = await resolveInstanceOrg();
+  if (!organizationId) {
+    return apiError(409, "no_org", "La instancia aún no tiene organización");
+  }
+
+  const body = await parseBody(req, bodySchema);
+  if (!body.ok) return body.response;
+
+  const db = getDb();
+  const rows = await db
+    .select({
+      id: schema.conversation.id,
+      handoffAt: schema.conversation.handoffAt,
+    })
+    .from(schema.conversation)
+    .where(
+      and(
+        eq(schema.conversation.organizationId, organizationId),
+        eq(schema.conversation.id, body.data.conversationId)
+      )
+    )
+    .limit(1);
+  const conv = rows[0];
+  if (!conv) return apiError(404, "not_found", "Conversación no encontrada");
+
+  if (!conv.handoffAt) {
+    await db
+      .update(schema.conversation)
+      .set({
+        aiEnabled: false,
+        handoffAt: new Date(),
+        handoffReason: toHandoffReason(body.data.reason),
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.conversation.id, conv.id));
+    publish(organizationId, {
+      type: "conversation.updated",
+      data: { conversation: { id: conv.id } },
+    });
+  }
+  return Response.json({ ok: true });
+}

--- a/src/app/api/bot/messages/route.ts
+++ b/src/app/api/bot/messages/route.ts
@@ -1,0 +1,79 @@
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { getDb, schema } from "@/lib/db";
+import { apiError, parseBody } from "@/lib/api";
+import { requireBotKey, resolveInstanceOrg } from "@/server/bot/auth";
+import { SendError, sendText } from "@/server/inbox/send";
+
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({
+  conversationId: z.string().min(1),
+  text: z.string().min(1).max(4096),
+});
+
+/**
+ * Envío del cerebro externo A TRAVÉS del CRM: el token de WhatsApp nunca sale
+ * de aquí. Usa el mismo camino que el composer de la bandeja (`sendText`), así
+ * que el mensaje queda en el hilo marcado como IA, respeta la ventana de 24 h
+ * y hereda el guard de sandbox del Laboratorio.
+ *
+ * 409 tipados: ai_paused (un humano tomó la conversación) · window_closed ·
+ * sandbox_violation.
+ */
+export async function POST(req: Request) {
+  const denied = requireBotKey(req);
+  if (denied) return denied;
+
+  const organizationId = await resolveInstanceOrg();
+  if (!organizationId) {
+    return apiError(409, "no_org", "La instancia aún no tiene organización");
+  }
+
+  const body = await parseBody(req, bodySchema);
+  if (!body.ok) return body.response;
+
+  // Gate de handoff: el bot JAMÁS habla sobre una conversación pausada. Se
+  // relee aquí porque entre que el bot pidió el contexto y armó su respuesta
+  // (segundos de un LLM) el dueño pudo haber tomado la conversación.
+  const db = getDb();
+  const convs = await db
+    .select({
+      aiEnabled: schema.conversation.aiEnabled,
+      handoffAt: schema.conversation.handoffAt,
+    })
+    .from(schema.conversation)
+    .where(
+      and(
+        eq(schema.conversation.organizationId, organizationId),
+        eq(schema.conversation.id, body.data.conversationId)
+      )
+    )
+    .limit(1);
+  const conv = convs[0];
+  if (!conv) return apiError(404, "not_found", "Conversación no encontrada");
+  if (!conv.aiEnabled || conv.handoffAt) {
+    return apiError(409, "ai_paused", "La IA está en pausa en esta conversación");
+  }
+
+  try {
+    const result = await sendText({
+      conversationId: body.data.conversationId,
+      organizationId,
+      text: body.data.text,
+      aiGenerated: true,
+    });
+    return Response.json({ messageId: result.messageId });
+  } catch (err) {
+    if (err instanceof SendError) {
+      if (err.code === "window_closed") {
+        return apiError(409, "window_closed", err.message);
+      }
+      if (err.code === "sandbox_violation") {
+        return apiError(409, "sandbox_violation", err.message);
+      }
+      return apiError(502, err.code, err.message);
+    }
+    throw err;
+  }
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -122,6 +122,15 @@ export const contact = pgTable(
     waUserId: text("wa_user_id"),
     name: text("name").notNull(),
     notes: text("notes"),
+    /**
+     * Ficha de calificación que levanta un cerebro externo por
+     * `PUT /api/bot/ficha`. Es un objeto libre a propósito: los datos que
+     * importan de un lead los define cada negocio (una clínica querrá
+     * "tratamiento", una constructora "metros"), y cablearlos como columnas
+     * obligaría a migrar el CRM cada vez que alguien cambia su cuestionario.
+     * Merge campo a campo; `null` explícito borra la clave.
+     */
+    ficha: jsonb("ficha").$type<Record<string, unknown>>(),
     archivedAt: timestamp("archived_at"),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -200,7 +200,15 @@ export const conversation = pgTable(
     handoffAt: timestamp("handoff_at"),
     handoffReason: text("handoff_reason", {
       // 008: manual_reply = el dueño respondió desde la app del teléfono.
-      enum: ["cliente", "modelo", "error", "ventana", "manual_reply"],
+      // hostilidad = el lead se puso agresivo y el agente se retiró.
+      enum: [
+        "cliente",
+        "modelo",
+        "error",
+        "ventana",
+        "hostilidad",
+        "manual_reply",
+      ],
     }),
     lastInboundAt: timestamp("last_inbound_at"),
     lastMessageAt: timestamp("last_message_at"),

--- a/src/server/bot/ficha.ts
+++ b/src/server/bot/ficha.ts
@@ -1,0 +1,101 @@
+import { eq } from "drizzle-orm";
+import { getDb, schema } from "@/lib/db";
+
+/**
+ * Ficha de calificación del lead: lo que el cerebro externo va descubriendo
+ * en la conversación.
+ *
+ * Las claves NO están cableadas. Cada negocio califica distinto —una clínica
+ * pregunta el tratamiento, una constructora los metros, una agencia el
+ * presupuesto— y el CRM no tiene por qué migrar cada vez que alguien cambia su
+ * cuestionario. Lo que sí impone el CRM es que lo guardado sea sano: escalares,
+ * acotados y en número razonable.
+ *
+ * La validación es FLOJA a propósito. Del otro lado hay un LLM que deriva: hoy
+ * manda `dolor_principal` y mañana `dolorPrincipal`, o un `"sí"` donde antes
+ * mandaba `true`. Devolverle un 422 le tira datos reales de calificación que ya
+ * costaron una conversación; se prefiere guardar lo que se entienda e ignorar
+ * en silencio lo que no.
+ */
+
+/** Tope de claves por ficha: contiene un bot en bucle sin estorbar a nadie. */
+const MAX_KEYS = 40;
+const MAX_KEY_LEN = 60;
+const MAX_VALUE_LEN = 500;
+
+export type FichaInput = Record<string, unknown>;
+export type Ficha = Record<string, string | number | boolean | null>;
+
+/**
+ * Deja la ficha en valores que se puedan guardar y mostrar: escalares
+ * acotados. `null` sobrevive porque significa "borra esta clave". Objetos,
+ * arreglos y claves absurdas se ignoran sin error.
+ */
+export function normalizeFicha(raw: FichaInput): Ficha {
+  const out: Ficha = {};
+  if (!raw || typeof raw !== "object") return out;
+
+  for (const [rawKey, value] of Object.entries(raw)) {
+    if (Object.keys(out).length >= MAX_KEYS) break;
+
+    const key = rawKey.trim();
+    if (!key || key.length > MAX_KEY_LEN) continue;
+
+    if (value === null) {
+      out[key] = null;
+      continue;
+    }
+    if (typeof value === "boolean" || typeof value === "number") {
+      if (typeof value === "number" && !Number.isFinite(value)) continue;
+      out[key] = value;
+      continue;
+    }
+    if (typeof value === "string") {
+      const v = value.trim();
+      // La cadena vacía no borra: para eso está `null` explícito. Un LLM manda
+      // "" con demasiada facilidad como para dejarlo tirar un dato bueno.
+      if (v) out[key] = v.slice(0, MAX_VALUE_LEN);
+      continue;
+    }
+    // Objetos y arreglos: fuera. Se ignoran sin error (ver arriba).
+  }
+  return out;
+}
+
+/** Merge campo a campo: lo ausente se conserva, `null` explícito borra. */
+export function mergeFicha(prev: Ficha | null | undefined, patch: Ficha): Ficha {
+  const out: Ficha = { ...(prev ?? {}) };
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null) delete out[key];
+    else out[key] = value;
+  }
+  return out;
+}
+
+export async function upsertFicha(input: {
+  contactId: string;
+  ficha: FichaInput;
+}): Promise<{ ficha: Ficha }> {
+  const db = getDb();
+  const patch = normalizeFicha(input.ficha);
+
+  const rows = await db
+    .select({ ficha: schema.contact.ficha })
+    .from(schema.contact)
+    .where(eq(schema.contact.id, input.contactId))
+    .limit(1);
+  const merged = mergeFicha(rows[0]?.ficha as Ficha | null, patch);
+
+  await db
+    .update(schema.contact)
+    .set({ ficha: merged, updatedAt: new Date() })
+    .where(eq(schema.contact.id, input.contactId));
+
+  return { ficha: merged };
+}
+
+export function serializeFicha(
+  contact: typeof schema.contact.$inferSelect
+): Ficha {
+  return (contact.ficha as Ficha | null) ?? {};
+}

--- a/src/server/bot/handoff.ts
+++ b/src/server/bot/handoff.ts
@@ -1,0 +1,26 @@
+/**
+ * Motivos por los que un cerebro externo devuelve la conversación a un humano.
+ *
+ * El catálogo es cerrado, pero se aplica con FALLBACK, nunca rechazando: un
+ * motivo fuera de lista no puede costar el handoff. Un 422 aquí dejaría al bot
+ * hablándole a alguien que acaba de pedir una persona — el peor final posible
+ * de esa ruta. Del otro lado hay un LLM: tarde o temprano manda "porque se
+ * enojó" en vez de "hostilidad".
+ */
+
+export const HANDOFF_REASONS = [
+  "cliente",
+  "modelo",
+  "error",
+  "ventana",
+  "hostilidad",
+] as const;
+
+export type HandoffReason = (typeof HANDOFF_REASONS)[number];
+
+export function toHandoffReason(raw: string | undefined | null): HandoffReason {
+  const v = raw?.trim().toLowerCase() ?? "";
+  return (HANDOFF_REASONS as readonly string[]).includes(v)
+    ? (v as HandoffReason)
+    : "modelo";
+}

--- a/tests/e2e/us-bot-api.md
+++ b/tests/e2e/us-bot-api.md
@@ -63,11 +63,44 @@ edita el dueño (Agente y su knowledge base). Este endpoint es el contrato.
 17. Editar el tono en la pantalla Agente y volver a pedir el perfil → el cambio
     ya está: la respuesta no se cachea.
 
+## Contexto de la conversación
+
+Lo que solo el CRM sabe: quién es la persona, si un humano tomó el control y si
+la ventana de 24 h sigue abierta. El historial de mensajes NO viaja: esa memoria
+es del bot.
+
+18. `GET /api/bot/context?conversationId={id}` con la key → **200** con
+    `contact` (id, name, waIdentity, phone), `conversation`
+    (id, aiEnabled, handoffAt, windowOpen, windowRemainingMs) y `lead`
+    (id, stageName).
+19. `GET /api/bot/context?waIdentity={identidad}` → la MISMA conversación. Es el
+    camino que usa el bot cuando le llega un mensaje y solo tiene el remitente.
+20. Tras un entrante reciente, `windowOpen: true` y `windowRemainingMs` > 0.
+21. Con la conversación en handoff, `aiEnabled` viene en **false** aunque el
+    flag de la fila siga en true: para el bot hay una sola verdad.
+22. Una conversación del Laboratorio no se resuelve nunca por `waIdentity`: el
+    bot de producción no debe hablarle a un cliente simulado.
+
+## El bot envía a través del CRM
+
+23. `POST /api/bot/messages {conversationId, text}` con la key → **200**
+    `{messageId}`, el mensaje aparece en la bandeja marcado como IA
+    (`aiGenerated: true`, `origin: "ai"`) y sale por el canal de WhatsApp. El
+    token de Meta nunca viajó al bot.
+24. Con la IA pausada (handoff), el mismo envío → **409** `ai_paused` y el
+    outbox NO cambia: el rechazo ocurre antes de tocar Meta.
+25. Con la ventana de 24 h cerrada → **409** `window_closed`. El bot no puede
+    esquivar la regla de Meta; para eso está el envío de plantilla desde la app.
+26. En una conversación del Laboratorio → **409** `sandbox_violation`.
+
 ## Camino infeliz
 
-18. `GET /api/bot/profile` en una instancia sin perfil de agente → **404**
+27. `GET /api/bot/profile` en una instancia sin perfil de agente → **404**
     `no_profile` (condición esperada, no un 500: el bot cae a su brief local).
-19. `POST /api/bot/typing` con un `conversationId` inexistente → **404**.
-20. Con Meta caído (token `...-invalid` en el mock), typing → **200**
+28. `GET /api/bot/context` sin `waIdentity` ni `conversationId` → **422**;
+    con un `conversationId` que no existe → **404**.
+29. `POST /api/bot/messages` con texto vacío → **422**.
+30. `POST /api/bot/typing` con un `conversationId` inexistente → **404**.
+31. Con Meta caído (token `...-invalid` en el mock), typing → **200**
     `{ok:false, reason:"meta_error"}`: es best-effort por contrato, al bot
     jamás le vale reintentarlo.

--- a/tests/e2e/us-bot-api.md
+++ b/tests/e2e/us-bot-api.md
@@ -81,26 +81,41 @@ es del bot.
 22. Una conversación del Laboratorio no se resuelve nunca por `waIdentity`: el
     bot de producción no debe hablarle a un cliente simulado.
 
+## Ficha de calificación
+
+Lo que el bot va descubriendo del lead. Las claves las define el negocio: el
+CRM no impone un cuestionario.
+
+23. `PUT /api/bot/ficha {conversationId, ficha}` con la key → **200** con la
+    ficha COMPLETA resultante (no solo el parche), y esa misma ficha aparece en
+    `contact.ficha` del contexto del siguiente turno.
+24. Un segundo PUT con otras claves las **suma**: lo que no viene se conserva.
+    Un `null` explícito **borra** esa clave.
+25. Valores que el CRM no puede guardar —objetos, arreglos, cadenas vacías,
+    números no finitos— se ignoran en silencio y el resto sí se guarda: un 422
+    le tiraría al bot datos de calificación que ya costaron una conversación.
+26. Conversación inexistente → **404**. Cuerpo sin `ficha` → **422**.
+
 ## El bot envía a través del CRM
 
-23. `POST /api/bot/messages {conversationId, text}` con la key → **200**
+27. `POST /api/bot/messages {conversationId, text}` con la key → **200**
     `{messageId}`, el mensaje aparece en la bandeja marcado como IA
     (`aiGenerated: true`, `origin: "ai"`) y sale por el canal de WhatsApp. El
     token de Meta nunca viajó al bot.
-24. Con la IA pausada (handoff), el mismo envío → **409** `ai_paused` y el
+28. Con la IA pausada (handoff), el mismo envío → **409** `ai_paused` y el
     outbox NO cambia: el rechazo ocurre antes de tocar Meta.
-25. Con la ventana de 24 h cerrada → **409** `window_closed`. El bot no puede
+29. Con la ventana de 24 h cerrada → **409** `window_closed`. El bot no puede
     esquivar la regla de Meta; para eso está el envío de plantilla desde la app.
-26. En una conversación del Laboratorio → **409** `sandbox_violation`.
+30. En una conversación del Laboratorio → **409** `sandbox_violation`.
 
 ## Camino infeliz
 
-27. `GET /api/bot/profile` en una instancia sin perfil de agente → **404**
+31. `GET /api/bot/profile` en una instancia sin perfil de agente → **404**
     `no_profile` (condición esperada, no un 500: el bot cae a su brief local).
-28. `GET /api/bot/context` sin `waIdentity` ni `conversationId` → **422**;
+32. `GET /api/bot/context` sin `waIdentity` ni `conversationId` → **422**;
     con un `conversationId` que no existe → **404**.
-29. `POST /api/bot/messages` con texto vacío → **422**.
-30. `POST /api/bot/typing` con un `conversationId` inexistente → **404**.
-31. Con Meta caído (token `...-invalid` en el mock), typing → **200**
+33. `POST /api/bot/messages` con texto vacío → **422**.
+34. `POST /api/bot/typing` con un `conversationId` inexistente → **404**.
+35. Con Meta caído (token `...-invalid` en el mock), typing → **200**
     `{ok:false, reason:"meta_error"}`: es best-effort por contrato, al bot
     jamás le vale reintentarlo.

--- a/tests/e2e/us-bot-api.md
+++ b/tests/e2e/us-bot-api.md
@@ -108,14 +108,25 @@ CRM no impone un cuestionario.
     esquivar la regla de Meta; para eso está el envío de plantilla desde la app.
 30. En una conversación del Laboratorio → **409** `sandbox_violation`.
 
+## El bot pide un humano
+
+31. `POST /api/bot/handoff {conversationId, reason}` con la key → **200**, la
+    conversación queda con `aiEnabled: false`, su `handoffAt` y el motivo. En la
+    bandeja se ve al instante, sin recargar (mismo evento que el toggle).
+32. Repetirlo es idempotente: no pisa la hora ni el motivo del primero.
+33. Un `reason` que no está en el catálogo —o ausente— **no tira el handoff**:
+    cae a `modelo` y la IA se pausa igual. Un 422 aquí dejaría al bot
+    vendiéndole a alguien que acaba de pedir un humano.
+34. Conversación inexistente → **404**.
+
 ## Camino infeliz
 
-31. `GET /api/bot/profile` en una instancia sin perfil de agente → **404**
+35. `GET /api/bot/profile` en una instancia sin perfil de agente → **404**
     `no_profile` (condición esperada, no un 500: el bot cae a su brief local).
-32. `GET /api/bot/context` sin `waIdentity` ni `conversationId` → **422**;
+36. `GET /api/bot/context` sin `waIdentity` ni `conversationId` → **422**;
     con un `conversationId` que no existe → **404**.
-33. `POST /api/bot/messages` con texto vacío → **422**.
-34. `POST /api/bot/typing` con un `conversationId` inexistente → **404**.
-35. Con Meta caído (token `...-invalid` en el mock), typing → **200**
+37. `POST /api/bot/messages` con texto vacío → **422**.
+38. `POST /api/bot/typing` con un `conversationId` inexistente → **404**.
+39. Con Meta caído (token `...-invalid` en el mock), typing → **200**
     `{ok:false, reason:"meta_error"}`: es best-effort por contrato, al bot
     jamás le vale reintentarlo.

--- a/tests/unit/bot-gateway.test.ts
+++ b/tests/unit/bot-gateway.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { requireBotKey } from "@/server/bot/auth";
+import { resetRateLimit } from "@/lib/rate-limit";
+
+/** La puerta de toda la superficie `/api/bot/*`. */
+
+const KEY = "clave-de-servicio-larga-0123456789abcdef";
+
+function reqWith(key?: string): Request {
+  return new Request("http://localhost/api/bot/context", {
+    headers: key ? { "x-api-key": key } : {},
+  });
+}
+
+describe("requireBotKey", () => {
+  beforeEach(() => {
+    vi.stubEnv("BOT_API_KEY", KEY);
+    resetRateLimit();
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("key correcta → pasa (null)", () => {
+    expect(requireBotKey(reqWith(KEY))).toBeNull();
+  });
+
+  it("key incorrecta → 401", () => {
+    const res = requireBotKey(reqWith("otra-clave-igual-de-larga-pero-mala!!"));
+    expect(res?.status).toBe(401);
+  });
+
+  it("sin header → 401", () => {
+    expect(requireBotKey(reqWith())?.status).toBe(401);
+  });
+
+  it("sin BOT_API_KEY configurada → 401 SIEMPRE (aunque manden algo)", () => {
+    vi.stubEnv("BOT_API_KEY", "");
+    expect(requireBotKey(reqWith("cualquier-cosa"))?.status).toBe(401);
+  });
+
+  it("key demasiado corta configurada → 401 (no se acepta una key débil)", () => {
+    vi.stubEnv("BOT_API_KEY", "corta");
+    expect(requireBotKey(reqWith("corta"))?.status).toBe(401);
+  });
+
+  it("longitudes distintas no filtran información (401 uniforme)", () => {
+    const res = requireBotKey(reqWith("x"));
+    expect(res?.status).toBe(401);
+  });
+});

--- a/tests/unit/bot-gateway.test.ts
+++ b/tests/unit/bot-gateway.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { requireBotKey } from "@/server/bot/auth";
+import { mergeFicha, normalizeFicha } from "@/server/bot/ficha";
 import { resetRateLimit } from "@/lib/rate-limit";
 
 /** La puerta de toda la superficie `/api/bot/*`. */
@@ -45,5 +46,72 @@ describe("requireBotKey", () => {
   it("longitudes distintas no filtran información (401 uniforme)", () => {
     const res = requireBotKey(reqWith("x"));
     expect(res?.status).toBe(401);
+  });
+});
+
+describe("normalizeFicha (tolerante al drift del LLM)", () => {
+  it("las claves las pone el negocio, no el CRM", () => {
+    expect(
+      normalizeFicha({ tratamiento: "ortodoncia", metros: 120, urgente: true })
+    ).toEqual({ tratamiento: "ortodoncia", metros: 120, urgente: true });
+  });
+
+  it("recorta espacios y trunca a 500 caracteres", () => {
+    const out = normalizeFicha({ notas: "  hola  ", largo: "x".repeat(900) });
+    expect(out.notas).toBe("hola");
+    expect((out.largo as string).length).toBe(500);
+  });
+
+  it("la cadena vacía se descarta; null explícito sobrevive para borrar", () => {
+    const out = normalizeFicha({ rubro: "", geo: null });
+    expect("rubro" in out).toBe(false);
+    expect(out.geo).toBeNull();
+  });
+
+  it("objetos y arreglos se ignoran sin reventar", () => {
+    expect(normalizeFicha({ nested: { a: 1 }, lista: [1, 2], ok: "sí" })).toEqual({
+      ok: "sí",
+    });
+  });
+
+  it("números no finitos fuera; el cero sí es un dato", () => {
+    expect(normalizeFicha({ a: Number.NaN, b: Infinity, empleados: 0 })).toEqual({
+      empleados: 0,
+    });
+  });
+
+  it("claves vacías o larguísimas se descartan", () => {
+    const out = normalizeFicha({ "  ": "x", ["k".repeat(80)]: "y", bien: "z" });
+    expect(out).toEqual({ bien: "z" });
+  });
+
+  it("un bot en bucle no puede inflar la ficha sin límite", () => {
+    const raw: Record<string, string> = {};
+    for (let i = 0; i < 200; i++) raw[`campo${i}`] = "v";
+    expect(Object.keys(normalizeFicha(raw)).length).toBe(40);
+  });
+});
+
+describe("mergeFicha", () => {
+  it("lo ausente se conserva y lo nuevo se agrega", () => {
+    expect(mergeFicha({ rubro: "dentista" }, { geo: "Querétaro" })).toEqual({
+      rubro: "dentista",
+      geo: "Querétaro",
+    });
+  });
+
+  it("un valor nuevo pisa al viejo", () => {
+    expect(mergeFicha({ geo: "CDMX" }, { geo: "Querétaro" })).toEqual({
+      geo: "Querétaro",
+    });
+  });
+
+  it("null borra la clave en vez de guardarla en null", () => {
+    const out = mergeFicha({ rubro: "dentista", geo: "CDMX" }, { geo: null });
+    expect(out).toEqual({ rubro: "dentista" });
+  });
+
+  it("sin ficha previa parte de cero", () => {
+    expect(mergeFicha(null, { a: 1 })).toEqual({ a: 1 });
   });
 });

--- a/tests/unit/bot-gateway.test.ts
+++ b/tests/unit/bot-gateway.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { requireBotKey } from "@/server/bot/auth";
 import { mergeFicha, normalizeFicha } from "@/server/bot/ficha";
+import { toHandoffReason } from "@/server/bot/handoff";
 import { resetRateLimit } from "@/lib/rate-limit";
 
 /** La puerta de toda la superficie `/api/bot/*`. */
@@ -89,6 +90,27 @@ describe("normalizeFicha (tolerante al drift del LLM)", () => {
     const raw: Record<string, string> = {};
     for (let i = 0; i < 200; i++) raw[`campo${i}`] = "v";
     expect(Object.keys(normalizeFicha(raw)).length).toBe(40);
+  });
+});
+
+describe("toHandoffReason (el handoff nunca se pierde por el motivo)", () => {
+  it("los motivos del catálogo pasan tal cual", () => {
+    for (const r of ["cliente", "modelo", "error", "ventana", "hostilidad"]) {
+      expect(toHandoffReason(r)).toBe(r);
+    }
+  });
+
+  it("un motivo inventado por el LLM cae a 'modelo' en vez de tirar el handoff", () => {
+    expect(toHandoffReason("porque el señor se enojó")).toBe("modelo");
+  });
+
+  it("ausente o vacío también cae a 'modelo'", () => {
+    expect(toHandoffReason(undefined)).toBe("modelo");
+    expect(toHandoffReason("   ")).toBe("modelo");
+  });
+
+  it("tolera mayúsculas y espacios de sobra", () => {
+    expect(toHandoffReason("  Hostilidad ")).toBe("hostilidad");
   });
 });
 

--- a/tests/unit/bot-profile.test.ts
+++ b/tests/unit/bot-profile.test.ts
@@ -1,7 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+﻿import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { serializeBotProfile } from "@/server/bot/profile";
 import type { schema } from "@/lib/db";
 import { resetRateLimit } from "@/lib/rate-limit";
+// Estático a propósito: `vi.mock` se hoistea por encima de los imports, así que
+// la ruta ya nace con la BD falsa. Importarla DENTRO de cada test cargaba la
+// cadena de módulos con el reloj corriendo y, con la suite completa en
+// paralelo, el primero se pasaba de los 5 s de timeout.
+import { GET } from "@/app/api/bot/profile/route";
 
 const dbState = vi.hoisted(() => ({ queue: [] as unknown[][] }));
 
@@ -123,13 +128,11 @@ describe("GET /api/bot/profile (ruta, DB fake)", () => {
   }
 
   it("sin API key → 401 (no filtra existencia del perfil)", async () => {
-    const { GET } = await import("@/app/api/bot/profile/route");
     const res = await GET(req());
     expect(res.status).toBe(401);
   });
 
   it("instancia sin perfil (legada) → 404 no_profile", async () => {
-    const { GET } = await import("@/app/api/bot/profile/route");
     dbState.queue = [[]];
     const res = await GET(req(KEY));
     expect(res.status).toBe(404);
@@ -138,7 +141,6 @@ describe("GET /api/bot/profile (ruta, DB fake)", () => {
   });
 
   it("perfil + KB → 200 con el payload del serializador", async () => {
-    const { GET } = await import("@/app/api/bot/profile/route");
     dbState.queue = [[profileRow()], [qa("¿Cuánto?", "$800.")]];
     const res = await GET(req(KEY));
     expect(res.status).toBe(200);


### PR DESCRIPTION
Cierre mecánico de la pila #10–#13: los cuatro PRs quedaron mergeados, pero
tres de ellos se mergearon **contra su rama base** en vez de contra `main`, así
que hoy `main` solo tiene `GET /api/bot/profile`. El trabajo de #11, #12 y #13
está sano dentro de `feat/bot-ficha`; esto lo trae.

| PR | Qué trae | ¿Está en `main` hoy? |
|---|---|---|
| #10 | `GET /api/bot/profile` | sí |
| #11 | `GET /api/bot/context` + `POST /api/bot/messages` | no |
| #12 | `PUT /api/bot/ficha` (+ columna `contact.ficha`) | no |
| #13 | `POST /api/bot/handoff` (+ `hostilidad` en el enum) | no |

Es el mismo código ya revisado en esos cuatro PRs, sin un solo cambio nuevo.
Mergea limpio contra `main` (verificado con `git merge-tree`, cero conflictos).

Con esto sí quedan cubiertos los cinco endpoints del issue #8 que no piden un
motor de agenda.

## Verificación sobre el árbol combinado

```
pnpm typecheck   ✓
pnpm lint        ✓
pnpm test        ✓  162 pruebas, 25 archivos
pnpm build       ✓  las 8 rutas /api/bot/* registradas
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
