### PR TITLE
feat(plantillas): varias variables {{1}}..{{n}} por cuerpo

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,10 @@ Agente de referencia: [nea-agent](https://github.com/kevinrivm/nea-agent), MIT.
 
 ### 📄 Plantillas · 👥 Multi-usuario · 🔐 Self-hosted
 
-Plantillas con una variable y aprobación de Meta sincronizada; cuentas de
-equipo creadas por el propietario (el registro público se cierra tras la
-primera organización); token de WhatsApp cifrado en reposo (AES-256-GCM),
+Plantillas con varias variables `{{1}}…{{n}}` y aprobación de Meta
+sincronizada; cuentas de equipo creadas por el propietario (el registro público
+se cierra tras la primera organización); token de WhatsApp cifrado en reposo
+(AES-256-GCM),
 webhook autenticado en dos capas y cero dependencias de runtime más allá de
 Meta y tu proveedor LLM opcional.
 
@@ -295,7 +296,7 @@ base64 (44 caracteres): `openssl rand -base64 32`.
 - Multimedia completa en la bandeja (hoy: indicador de tipo).
 - RAG para knowledge bases grandes (hoy: se inyecta completo con aviso de tamaño).
 - Personas configurables del Laboratorio y comparativas entre corridas.
-- Variables múltiples y borrado de plantillas.
+- Borrado de plantillas desde la app.
 - Analytics de conversación y plantillas.
 - Broadcast con opt-in verificado.
 

--- a/scripts/e2e-templates-multivar.mjs
+++ b/scripts/e2e-templates-multivar.mjs
@@ -1,0 +1,253 @@
+/**
+ * Self-test E2E de comportamiento — plantillas con VARIAS variables
+ * (guion tests/e2e/us6-templates.md, sección "multivariable").
+ *
+ * Reproduce el bloqueo reportado el 2026-08-09: el CRM rechazaba en la propia
+ * pantalla un cuerpo con {{1}} {{2}} {{3}} ("v1 admite una sola variable"),
+ * aunque Meta las acepta. Cubre alta, aprobación, envío con N parámetros y los
+ * caminos infelices (numeración con saltos, valor faltante).
+ *
+ * Uso: node --env-file=.env scripts/e2e-templates-multivar.mjs
+ * Requiere: app corriendo (pnpm dev) con WA_MOCK_ENABLED=true y BD migrada.
+ */
+
+const BASE = process.env.APP_BASE_URL ?? "http://localhost:3000";
+
+let cookie = "";
+let failures = 0;
+let checks = 0;
+
+function ok(name, cond, extra = "") {
+  checks++;
+  if (cond) {
+    console.log(`  ✓ ${name}`);
+  } else {
+    failures++;
+    console.log(`  ✗ ${name}${extra ? ` — ${extra}` : ""}`);
+  }
+}
+
+async function api(path, opts = {}) {
+  const res = await fetch(`${BASE}${path}`, {
+    ...opts,
+    headers: {
+      "content-type": "application/json",
+      origin: BASE,
+      ...(cookie ? { cookie } : {}),
+      ...(opts.headers ?? {}),
+    },
+  });
+  const setCookie = res.headers.getSetCookie?.() ?? [];
+  if (setCookie.length) {
+    cookie = setCookie.map((c) => c.split(";")[0]).join("; ");
+  }
+  let json = null;
+  try {
+    json = await res.clone().json();
+  } catch {}
+  return { res, json };
+}
+
+const PN = "PN-TPLMV-1";
+const WABA = "WABA-TPLMV";
+const FROM = "5215599990001";
+const stamp = Date.now().toString(36);
+
+async function findTemplate(name) {
+  const { json } = await api("/api/templates");
+  return (json?.templates ?? []).find((t) => t.name === name);
+}
+
+function metaApproves(name) {
+  return api("/api/dev/wa-mock/template-status", {
+    method: "POST",
+    body: JSON.stringify({
+      wabaId: WABA,
+      name,
+      language: "es_MX",
+      event: "APPROVED",
+      notify: false,
+    }),
+  });
+}
+
+async function lastOutbound() {
+  const { json } = await api("/api/dev/wa-mock/outbox");
+  const list = json?.outbox ?? [];
+  return list[list.length - 1] ?? null;
+}
+
+async function main() {
+  console.log("== Setup: registro + conexión WhatsApp ==");
+  const email = "e2e@vocero.test";
+  const password = "password-e2e-123";
+  let su = await api("/api/auth/sign-up/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password, name: "Operador E2E" }),
+  });
+  if (!su.res.ok) {
+    su = await api("/api/auth/sign-in/email", {
+      method: "POST",
+      body: JSON.stringify({ email, password }),
+    });
+  }
+  ok("registro o login del operador", su.res.ok, JSON.stringify(su.json));
+
+  const conn = await api("/api/settings/whatsapp", {
+    method: "PUT",
+    body: JSON.stringify({ wabaId: WABA, phoneNumberId: PN, token: "tok-mv" }),
+  });
+  ok("conexión WhatsApp guardada", conn.res.ok, JSON.stringify(conn.json));
+
+  console.log("\n== Alta: cuerpo con TRES variables ==");
+  const name = `confirmacion_cita_${stamp}`;
+  const body =
+    "Hola {{1}} 👋 Te confirmamos tu cita:\n" +
+    "🗓 {{2}} a las {{3}} · 20-30 min";
+  const created = await api("/api/templates", {
+    method: "POST",
+    body: JSON.stringify({ name, language: "es_MX", category: "UTILITY", body }),
+  });
+  ok(
+    "plantilla de 3 variables aceptada (antes: 422 'una sola variable')",
+    created.res.ok,
+    JSON.stringify(created.json)
+  );
+
+  const remote = await api(`/api/dev/wa-mock/graph/${WABA}/message_templates`);
+  const atMeta = (remote.json?.data ?? []).find((t) => t.name === name);
+  const bodyComp = (atMeta?.components ?? []).find(
+    (c) => (c.type ?? "").toUpperCase() === "BODY"
+  );
+  ok("Meta la recibió", Boolean(atMeta), JSON.stringify(remote.json));
+  ok(
+    "se mandó UN ejemplo por variable (si no, Meta responde 100)",
+    (bodyComp?.example?.body_text?.[0] ?? []).length === 3,
+    JSON.stringify(bodyComp?.example)
+  );
+
+  console.log("\n== Camino infeliz: numeración con saltos ==");
+  const gap = await api("/api/templates", {
+    method: "POST",
+    body: JSON.stringify({
+      name: `salto_${stamp}`,
+      language: "es_MX",
+      category: "UTILITY",
+      body: "Hola {{1}}, tu pedido {{3}} llegó",
+    }),
+  });
+  ok("422 con salto en la numeración", gap.res.status === 422, String(gap.res.status));
+  ok(
+    "el mensaje explica la regla",
+    /sin saltos/.test(gap.json?.error?.message ?? ""),
+    JSON.stringify(gap.json)
+  );
+
+  console.log("\n== Aprobación y conversación ==");
+  await metaApproves(name);
+  const sync = await api("/api/templates/sync", { method: "POST" });
+  ok("sync 200", sync.res.ok, JSON.stringify(sync.json));
+  const local = await findTemplate(name);
+  ok("estado = approved", local?.status === "approved", local?.status);
+
+  const inbound = await api("/api/dev/wa-mock/inbound", {
+    method: "POST",
+    body: JSON.stringify({
+      phoneNumberId: PN,
+      from: FROM,
+      name: "Lead Multivar",
+      text: "Hola, quiero la sesión",
+    }),
+  });
+  ok("inbound entregado", inbound.res.ok, JSON.stringify(inbound.json));
+  const convs = await api("/api/conversations");
+  const conv = (convs.json?.conversations ?? []).find(
+    (c) => (c.contact?.phone ?? "").includes("5599990001")
+  );
+  ok("conversación creada", Boolean(conv?.id), JSON.stringify(convs.json)?.slice(0, 200));
+
+  console.log("\n== Camino infeliz: falta un valor ==");
+  const short = await api(`/api/conversations/${conv?.id}/messages/template`, {
+    method: "POST",
+    body: JSON.stringify({
+      templateId: local?.id,
+      variables: ["María", "12 de agosto"],
+    }),
+  });
+  ok("422 si faltan valores", short.res.status === 422, String(short.res.status));
+  ok(
+    "dice cuál falta",
+    /\{\{3\}\}/.test(short.json?.error?.message ?? ""),
+    JSON.stringify(short.json)
+  );
+
+  console.log("\n== Envío con los 3 valores ==");
+  const sent = await api(`/api/conversations/${conv?.id}/messages/template`, {
+    method: "POST",
+    body: JSON.stringify({
+      templateId: local?.id,
+      variables: ["María", "12 de agosto", "5:00 pm"],
+    }),
+  });
+  ok("envío 200", sent.res.ok, JSON.stringify(sent.json));
+
+  const out = await lastOutbound();
+  const params =
+    out?.body?.template?.components?.find((c) => c.type === "body")?.parameters ??
+    [];
+  ok("Meta recibió type=template", out?.body?.type === "template", out?.body?.type);
+  ok("3 parámetros en orden", params.length === 3, JSON.stringify(params));
+  ok(
+    "los valores van en su posición",
+    params[0]?.text === "María" &&
+      params[1]?.text === "12 de agosto" &&
+      params[2]?.text === "5:00 pm",
+    JSON.stringify(params)
+  );
+
+  const msgs = await api(`/api/conversations/${conv?.id}/messages`);
+  const list = msgs.json?.messages ?? [];
+  const tplMsg = [...list].reverse().find((m) => m.type === "template");
+  ok(
+    "el hilo muestra el texto ya sustituido",
+    tplMsg?.text?.includes("Hola María") &&
+      tplMsg?.text?.includes("12 de agosto a las 5:00 pm"),
+    tplMsg?.text
+  );
+
+  console.log("\n== Compatibilidad: plantilla de UNA variable con `variable` ==");
+  const oneName = `una_var_${stamp}`;
+  const one = await api("/api/templates", {
+    method: "POST",
+    body: JSON.stringify({
+      name: oneName,
+      language: "es_MX",
+      category: "UTILITY",
+      body: "Hola {{1}} 👋 ¿Retomamos tu cotización?",
+    }),
+  });
+  ok("alta de una variable sigue OK", one.res.ok, JSON.stringify(one.json));
+  await metaApproves(oneName);
+  await api("/api/templates/sync", { method: "POST" });
+  const oneLocal = await findTemplate(oneName);
+  const legacy = await api(`/api/conversations/${conv?.id}/messages/template`, {
+    method: "POST",
+    body: JSON.stringify({ templateId: oneLocal?.id, variable: "María" }),
+  });
+  ok("el payload viejo {variable} sigue enviando", legacy.res.ok, JSON.stringify(legacy.json));
+  const outOne = await lastOutbound();
+  const paramsOne =
+    outOne?.body?.template?.components?.find((c) => c.type === "body")
+      ?.parameters ?? [];
+  ok("1 parámetro", paramsOne.length === 1 && paramsOne[0]?.text === "María", JSON.stringify(paramsOne));
+
+  console.log(
+    `\n${failures === 0 ? "TODO VERDE" : "CON FALLOS"} — ${checks - failures}/${checks} checks`
+  );
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/conversations/[id]/messages/template/route.ts
+++ b/src/app/api/conversations/[id]/messages/template/route.ts
@@ -13,6 +13,8 @@ type Params = { params: Promise<{ id: string }> };
 
 const bodySchema = z.object({
   templateId: z.string().min(1),
+  /** Valores de {{1}}..{{n}} en orden. `variable` sigue vivo por compatibilidad. */
+  variables: z.array(z.string().trim().max(500)).max(10).optional(),
   variable: z.string().trim().max(500).optional(),
 });
 
@@ -26,7 +28,9 @@ export const POST = withAuth(async (session, req: Request, ctx: Params) => {
       organizationId: session.organizationId,
       conversationId: id,
       templateId: body.data.templateId,
-      variable: body.data.variable,
+      variables:
+        body.data.variables ??
+        (body.data.variable === undefined ? undefined : [body.data.variable]),
     });
     return Response.json({ messageId: result.messageId });
   } catch (err) {

--- a/src/app/api/dev/wa-mock/graph/[...path]/route.ts
+++ b/src/app/api/dev/wa-mock/graph/[...path]/route.ts
@@ -56,7 +56,7 @@ export async function GET(req: Request, ctx: Params) {
         language: t.language,
         category: t.category,
         status: t.status,
-        components: [{ type: "BODY", text: t.body }],
+        components: t.components ?? [{ type: "BODY", text: t.body }],
       })),
     });
   }
@@ -117,6 +117,40 @@ export async function POST(req: Request, ctx: Params) {
   // POST {phoneNumberId}/messages → registra en el outbox
   if (path.length === 2 && path[1] === "messages") {
     const state = getWaMockState();
+    // Meta responde 132000 si los parámetros no cuadran con las {{n}} de la
+    // plantilla aprobada. El mock lo replica para que un desfase no pase.
+    if (body.type === "template") {
+      const tplSend = body.template as
+        | {
+            name?: string;
+            components?: { type?: string; parameters?: unknown[] }[];
+          }
+        | undefined;
+      const known = state.templates.find((t) => t.name === tplSend?.name);
+      if (known) {
+        const expected = [...known.body.matchAll(/\{\{\s*(\d+)\s*\}\}/g)].reduce(
+          (max, m) => Math.max(max, Number(m[1])),
+          0
+        );
+        const got =
+          tplSend?.components?.find(
+            (c) => (c.type ?? "").toLowerCase() === "body"
+          )?.parameters?.length ?? 0;
+        if (expected !== got) {
+          return Response.json(
+            {
+              error: {
+                message: `(#132000) Number of parameters does not match the expected number of params: expected ${expected}, got ${got}`,
+                type: "OAuthException",
+                code: 132000,
+                fbtrace_id: "mock",
+              },
+            },
+            { status: 400 }
+          );
+        }
+      }
+    }
     const n = nextN();
     const waMessageId = nextOutboundWamid();
     state.outbox.push({
@@ -138,9 +172,33 @@ export async function POST(req: Request, ctx: Params) {
   // POST {wabaId}/message_templates → alta de plantilla (queda PENDING)
   if (path.length === 2 && path[1] === "message_templates") {
     const state = getWaMockState();
-    const bodyComponent = (
-      body.components as { type?: string; text?: string }[] | undefined
-    )?.find((c) => (c.type ?? "").toUpperCase() === "BODY");
+    const components = (body.components ?? []) as {
+      type?: string;
+      text?: string;
+      example?: { body_text?: string[][] };
+    }[];
+    const bodyComponent = components.find(
+      (c) => (c.type ?? "").toUpperCase() === "BODY"
+    );
+    // Meta valida que haya un ejemplo por cada {{n}} del cuerpo: sin esto el
+    // mock aceptaría plantillas que producción rechaza (error 100).
+    const highestVar = [
+      ...(bodyComponent?.text ?? "").matchAll(/\{\{\s*(\d+)\s*\}\}/g),
+    ].reduce((max, m) => Math.max(max, Number(m[1])), 0);
+    const examples = bodyComponent?.example?.body_text?.[0] ?? [];
+    if (highestVar !== examples.length) {
+      return Response.json(
+        {
+          error: {
+            message: `Invalid parameter: expected ${highestVar} example value(s) for the body, got ${examples.length}`,
+            type: "GraphMethodException",
+            code: 100,
+            fbtrace_id: "mock",
+          },
+        },
+        { status: 400 }
+      );
+    }
     const tpl: MockTemplate = {
       id: `tplmock_${nextN()}`,
       name: String(body.name ?? ""),
@@ -148,6 +206,7 @@ export async function POST(req: Request, ctx: Params) {
       category: String(body.category ?? "UTILITY"),
       status: "PENDING",
       body: bodyComponent?.text ?? "",
+      components,
     };
     state.templates.push(tpl);
     return Response.json({ id: tpl.id, status: "PENDING", category: tpl.category });

--- a/src/components/inbox/template-sender.tsx
+++ b/src/components/inbox/template-sender.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import type { TemplateDto } from "@/lib/types";
+import { countVariables } from "@/lib/templates";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -19,7 +20,7 @@ export function TemplateSender({
 }) {
   const [templates, setTemplates] = useState<TemplateDto[] | null>(null);
   const [selectedId, setSelectedId] = useState<string>("");
-  const [variable, setVariable] = useState("");
+  const [variables, setVariables] = useState<string[]>([]);
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -59,7 +60,11 @@ export function TemplateSender({
   }
 
   const selected = templates.find((t) => t.id === selectedId) ?? null;
-  const needsVariable = selected ? /\{\{\s*1\s*\}\}/.test(selected.body) : false;
+  // El cuerpo puede llevar {{1}}..{{n}}: el número de parámetros es el índice
+  // más alto, y Meta los exige todos.
+  const variableCount = selected ? countVariables(selected.body) : 0;
+  const values = Array.from({ length: variableCount }, (_, i) => variables[i] ?? "");
+  const missingValue = values.some((v) => !v.trim());
 
   async function send() {
     if (!selected || sending) return;
@@ -72,7 +77,7 @@ export function TemplateSender({
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
           templateId: selected.id,
-          variable: needsVariable ? variable : undefined,
+          variables: variableCount > 0 ? values : undefined,
         }),
       }
     );
@@ -85,7 +90,7 @@ export function TemplateSender({
       return;
     }
     setSelectedId("");
-    setVariable("");
+    setVariables([]);
     onSent();
   }
 
@@ -96,7 +101,10 @@ export function TemplateSender({
         <select
           id="template-select"
           value={selectedId}
-          onChange={(e) => setSelectedId(e.target.value)}
+          onChange={(e) => {
+            setSelectedId(e.target.value);
+            setVariables([]);
+          }}
           className="flex h-9 w-full rounded-md border border-input bg-card px-3 py-1 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
         >
           <option value="">Elige una plantilla…</option>
@@ -112,21 +120,32 @@ export function TemplateSender({
           {selected.body}
         </p>
       )}
-      {needsVariable && (
-        <div className="space-y-1.5">
-          <Label htmlFor="template-variable">Valor de la variable {"{{1}}"}</Label>
+      {values.map((value, i) => (
+        <div key={i} className="space-y-1.5">
+          <Label htmlFor={`template-variable-${i + 1}`}>
+            Valor de {`{{${i + 1}}}`}
+          </Label>
           <Input
-            id="template-variable"
-            value={variable}
-            onChange={(e) => setVariable(e.target.value)}
-            placeholder="p. ej. el nombre del cliente"
+            id={`template-variable-${i + 1}`}
+            value={value}
+            onChange={(e) =>
+              setVariables((prev) => {
+                const next = [...prev];
+                while (next.length < variableCount) next.push("");
+                next[i] = e.target.value;
+                return next;
+              })
+            }
+            placeholder={
+              i === 0 ? "p. ej. el nombre del cliente" : "p. ej. 12 de agosto"
+            }
           />
         </div>
-      )}
+      ))}
       {error && <p className="text-xs text-destructive">{error}</p>}
       <Button
         onClick={() => void send()}
-        disabled={!selected || sending || (needsVariable && !variable.trim())}
+        disabled={!selected || sending || missingValue}
       >
         {sending ? "Enviando…" : "Enviar plantilla"}
       </Button>

--- a/src/components/settings/templates-client.tsx
+++ b/src/components/settings/templates-client.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { RefreshCw } from "lucide-react";
 import type { TemplateDto } from "@/lib/types";
+import { countVariables, validateBodyVariables } from "@/lib/templates";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -134,6 +135,10 @@ function CreateForm({ onCreated }: { onCreated: () => void }) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Misma validación que el servidor: avisa antes de gastar una llamada a Meta.
+  const bodyError = body.trim() ? validateBodyVariables(body) : null;
+  const variableCount = countVariables(body);
+
   async function create() {
     setSaving(true);
     setError(null);
@@ -160,8 +165,9 @@ function CreateForm({ onCreated }: { onCreated: () => void }) {
       <CardHeader>
         <CardTitle>Nueva plantilla</CardTitle>
         <CardDescription>
-          Cuerpo con máximo UNA variable <code>{"{{1}}"}</code> (v1). Se envía a
-          aprobación de Meta al crearla.
+          Cuerpo con las variables que necesites: numéralas{" "}
+          <code>{"{{1}}"}</code>, <code>{"{{2}}"}</code>, <code>{"{{3}}"}</code>
+          … en orden y sin saltos. Se envía a aprobación de Meta al crearla.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -209,14 +215,25 @@ function CreateForm({ onCreated }: { onCreated: () => void }) {
           <Textarea
             id="tpl-body"
             rows={3}
-            placeholder="Hola {{1}}, seguimos disponibles. ¿Retomamos tu cotización?"
+            placeholder="Hola {{1}}, te confirmo tu sesión el {{2}} a las {{3}}."
             value={body}
             onChange={(e) => setBody(e.target.value)}
           />
+          {bodyError ? (
+            <p className="text-xs text-destructive">{bodyError}</p>
+          ) : (
+            variableCount > 0 && (
+              <p className="text-xs text-muted-foreground">
+                {variableCount === 1
+                  ? "1 variable: al enviar pedirá su valor."
+                  : `${variableCount} variables: al enviar pedirá los ${variableCount} valores.`}
+              </p>
+            )
+          )}
         </div>
         {error && <p className="text-sm text-destructive">{error}</p>}
         <Button
-          disabled={saving || !name.trim() || !body.trim()}
+          disabled={saving || !name.trim() || !body.trim() || bodyError !== null}
           onClick={() => void create()}
         >
           {saving ? "Enviando a Meta…" : "Crear y enviar a aprobación"}

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -1,0 +1,51 @@
+/**
+ * Variables posicionales {{n}} del cuerpo de una plantilla de WhatsApp.
+ * Puro y sin dependencias: lo usan tanto el servicio de servidor como la UI
+ * (que necesita saber cuántos campos pintar antes de enviar).
+ */
+
+const VARIABLE_REGEX = /\{\{\s*(\d+)\s*\}\}/g;
+
+/** Máximo de parámetros posicionales por cuerpo que acepta Meta. */
+export const MAX_TEMPLATE_VARIABLES = 10;
+
+/** Índices distintos de {{n}} presentes en el cuerpo, ordenados. */
+function variableIndexes(body: string): number[] {
+  const found = new Set<number>();
+  for (const m of body.matchAll(VARIABLE_REGEX)) found.add(Number(m[1]));
+  return [...found].sort((a, b) => a - b);
+}
+
+/**
+ * Cuántos parámetros exige el cuerpo = el índice más alto. Con la numeración
+ * validada (1..N sin saltos) equivale al número de variables distintas.
+ */
+export function countVariables(body: string): number {
+  const indexes = variableIndexes(body);
+  return indexes.length ? indexes[indexes.length - 1]! : 0;
+}
+
+/**
+ * Meta acepta varias variables por cuerpo, pero exige numeración posicional
+ * contigua desde {{1}}: un salto ({{1}} y {{3}}) es rechazo seguro.
+ */
+export function validateBodyVariables(body: string): string | null {
+  const indexes = variableIndexes(body);
+  if (indexes.length === 0) return null;
+  if (indexes.length > MAX_TEMPLATE_VARIABLES) {
+    return `El cuerpo admite hasta ${MAX_TEMPLATE_VARIABLES} variables`;
+  }
+  for (let i = 0; i < indexes.length; i++) {
+    if (indexes[i] !== i + 1) {
+      return `Las variables deben ir numeradas {{1}}, {{2}}, … sin saltos (falta {{${i + 1}}})`;
+    }
+  }
+  return null;
+}
+
+/** Sustituye {{n}} por `variables[n-1]` (vacío si no hay valor). */
+export function renderBody(body: string, variables: string[] = []): string {
+  return body.replace(VARIABLE_REGEX, (_match, index: string) => {
+    return variables[Number(index) - 1] ?? "";
+  });
+}

--- a/src/server/dev/wa-mock-state.ts
+++ b/src/server/dev/wa-mock-state.ts
@@ -25,6 +25,8 @@ export type MockTemplate = {
   category: string;
   status: "PENDING" | "APPROVED" | "REJECTED";
   body: string;
+  /** Componentes tal cual los mandó el CRM: Meta valida aquí los `example`. */
+  components?: unknown[];
 };
 
 type WaMockState = {

--- a/src/server/whatsapp/templates.ts
+++ b/src/server/whatsapp/templates.ts
@@ -1,4 +1,9 @@
 import { and, eq } from "drizzle-orm";
+import {
+  countVariables,
+  renderBody,
+  validateBodyVariables,
+} from "@/lib/templates";
 import { getDb, schema } from "@/lib/db";
 import { newId } from "@/lib/db/ids";
 import { graphRequest, MetaApiError, normalizeRecipient } from "@/lib/meta/client";
@@ -43,28 +48,7 @@ export function templateErrorStatus(err: TemplateError): number {
   return TEMPLATE_ERROR_STATUS[err.code];
 }
 
-const VARIABLE_REGEX = /\{\{\s*(\d+)\s*\}\}/g;
-
-/** Cuenta variables {{n}} y valida el acotamiento v1: máximo UNA y debe ser {{1}}. */
-export function countVariables(body: string): number {
-  const matches = [...body.matchAll(VARIABLE_REGEX)];
-  return matches.length;
-}
-
-export function validateBodyVariables(body: string): string | null {
-  const matches = [...body.matchAll(VARIABLE_REGEX)];
-  if (matches.length > 1) {
-    return "v1 admite una sola variable {{1}} en el cuerpo";
-  }
-  if (matches.length === 1 && matches[0]![1] !== "1") {
-    return "La variable debe ser {{1}}";
-  }
-  return null;
-}
-
-export function renderBody(body: string, variable?: string): string {
-  return body.replace(VARIABLE_REGEX, variable ?? "");
-}
+export { countVariables, renderBody, validateBodyVariables };
 
 type TemplateRow = typeof schema.template.$inferSelect;
 
@@ -102,7 +86,12 @@ export async function createTemplate(
     .replace(/[^a-z0-9_]/g, "");
   if (!name) throw new TemplateError("invalid", "Nombre de plantilla inválido");
 
-  const hasVariable = countVariables(input.body) === 1;
+  // Meta pide un ejemplo por variable: si faltan, rechaza la plantilla.
+  const variableCount = countVariables(input.body);
+  const examples = Array.from(
+    { length: variableCount },
+    (_, i) => `ejemplo ${i + 1}`
+  );
   let waTemplateId: string | null = null;
   try {
     const res = await graphRequest<{ id?: string; status?: string }>(
@@ -118,8 +107,8 @@ export async function createTemplate(
             {
               type: "BODY",
               text: input.body,
-              ...(hasVariable
-                ? { example: { body_text: [["ejemplo"]] } }
+              ...(variableCount > 0
+                ? { example: { body_text: [examples] } }
                 : {}),
             },
           ],
@@ -285,7 +274,7 @@ export async function sendTemplate(input: {
   organizationId: string;
   conversationId: string;
   templateId: string;
-  variable?: string;
+  variables?: string[];
 }): Promise<{ messageId: string }> {
   const db = getDb();
 
@@ -305,9 +294,21 @@ export async function sendTemplate(input: {
   if (template.status !== "approved") {
     throw new TemplateError("invalid", "Solo se pueden enviar plantillas aprobadas");
   }
-  const needsVariable = countVariables(template.body) === 1;
-  if (needsVariable && !input.variable?.trim()) {
-    throw new TemplateError("invalid", "La plantilla requiere el valor de {{1}}");
+  // Meta exige EXACTAMENTE un parámetro por variable del cuerpo: si sobran o
+  // falta alguno responde 132000 (plantilla y parámetros no coinciden).
+  const variableCount = countVariables(template.body);
+  const values = (input.variables ?? [])
+    .slice(0, variableCount)
+    .map((v) => v.trim());
+  if (values.length < variableCount || values.some((v) => !v)) {
+    const missing = values.findIndex((v) => !v);
+    const n = missing === -1 ? values.length + 1 : missing + 1;
+    throw new TemplateError(
+      "invalid",
+      variableCount === 1
+        ? "La plantilla requiere el valor de {{1}}"
+        : `La plantilla requiere ${variableCount} valores: falta {{${n}}}`
+    );
   }
 
   const rows = await db
@@ -359,12 +360,12 @@ export async function sendTemplate(input: {
     template: {
       name: template.name,
       language: { code: template.language },
-      ...(needsVariable
+      ...(variableCount > 0
         ? {
             components: [
               {
                 type: "body",
-                parameters: [{ type: "text", text: input.variable!.trim() }],
+                parameters: values.map((text) => ({ type: "text", text })),
               },
             ],
           }
@@ -381,7 +382,7 @@ export async function sendTemplate(input: {
       waMessageId,
       direction: "out",
       type: "template",
-      text: renderBody(template.body, input.variable?.trim()),
+      text: renderBody(template.body, values),
       status: "pending",
       origin: "template",
     })

--- a/tests/e2e/us6-templates.md
+++ b/tests/e2e/us6-templates.md
@@ -1,4 +1,4 @@
-# Guion E2E — US6: Plantillas acotadas
+# Guion E2E — US6: Plantillas
 
 > Conducido con Playwright (MCP) contra `pnpm dev` con wa-mock.
 
@@ -45,3 +45,24 @@ modo agencia no es el de esta instancia: sin pull, la plantilla se queda
    ✅ El outbox del wa-mock registra `type: "template"` con `components`
    (`parameters[0].text` = valor de la variable).
 7. Validaciones: enviar plantilla no aprobada → 422; variable faltante → 422.
+
+## Varias variables por cuerpo (2026-08-09)
+
+> Automatizado en `scripts/e2e-templates-multivar.mjs` (21 checks) + UI con
+> Playwright. Antes el CRM rechazaba en su propia pantalla lo que Meta sí
+> acepta: "v1 admite una sola variable {{1}} en el cuerpo".
+
+11. En `/settings/templates`, cuerpo con `{{1}}`, `{{2}}` y `{{3}}`.
+    ✅ Sin aviso rojo, el botón habilitado y la pantalla anuncia "3 variables".
+    ✅ A Meta va **un `example.body_text` por variable** (sin eso responde 100).
+12. Cuerpo con salto (`{{1}}` y `{{3}}`).
+    ✅ Aviso "…sin saltos (falta {{2}})", botón deshabilitado y, si se fuerza
+    por API, 422 — la numeración posicional contigua es requisito de Meta.
+13. Con la plantilla aprobada y la ventana cerrada, el envío pide **un campo por
+    variable** (`Valor de {{1}}`…`{{3}}`).
+    ✅ El outbox del wa-mock trae los 3 `parameters` en orden y el hilo muestra
+    el texto ya sustituido.
+    ✅ Faltando un valor → 422 diciendo cuál falta; el wa-mock además replica el
+    132000 de Meta si el número de parámetros no cuadra.
+14. Compatibilidad: el payload viejo `{ templateId, variable }` (una variable)
+    sigue enviando — lo usa el cron de recordatorios de sesión.

--- a/tests/unit/templates.test.ts
+++ b/tests/unit/templates.test.ts
@@ -17,26 +17,52 @@ describe("countVariables / validateBodyVariables (FR-050)", () => {
     expect(validateBodyVariables("Hola {{1}}, ¿retomamos?")).toBeNull();
   });
 
-  it("dos variables → inválido (acotamiento v1)", () => {
-    expect(countVariables("Hola {{1}}, tu pedido {{2}} llegó")).toBe(2);
-    expect(
-      validateBodyVariables("Hola {{1}}, tu pedido {{2}} llegó")
-    ).toMatch(/una sola variable/);
+  it("varias variables numeradas en orden → válido", () => {
+    const body = "Hola {{1}}, te confirmo el {{2}} a las {{3}}.";
+    expect(countVariables(body)).toBe(3);
+    expect(validateBodyVariables(body)).toBeNull();
   });
 
-  it("variable {{2}} sola → inválida (debe ser {{1}})", () => {
+  it("la variable repetida cuenta una sola vez", () => {
+    expect(countVariables("Hola {{1}}, ¿confirmas, {{1}}?")).toBe(1);
+    expect(validateBodyVariables("Hola {{1}}, ¿confirmas, {{1}}?")).toBeNull();
+  });
+
+  it("numeración con salto → inválida", () => {
+    expect(validateBodyVariables("Hola {{1}}, tu pedido {{3}} llegó")).toMatch(
+      /sin saltos/
+    );
+  });
+
+  it("variable {{2}} sola → inválida (debe empezar en {{1}})", () => {
     expect(validateBodyVariables("Tu pedido {{2}} llegó")).toMatch(/\{\{1\}\}/);
+  });
+
+  it("más de 10 variables → inválida", () => {
+    const body = Array.from({ length: 11 }, (_, i) => `x {{${i + 1}}}`).join(" ");
+    expect(validateBodyVariables(body)).toMatch(/hasta 10/);
   });
 });
 
 describe("renderBody", () => {
   it("sustituye la variable por el valor", () => {
-    expect(renderBody("Hola {{1}}, ¿retomamos?", "María")).toBe(
+    expect(renderBody("Hola {{1}}, ¿retomamos?", ["María"])).toBe(
       "Hola María, ¿retomamos?"
     );
   });
 
-  it("sin valor → variable vacía", () => {
+  it("sustituye cada variable por su posición", () => {
+    expect(
+      renderBody("Hola {{1}}, te espero el {{2}} a las {{3}}.", [
+        "María",
+        "12 de agosto",
+        "5 pm",
+      ])
+    ).toBe("Hola María, te espero el 12 de agosto a las 5 pm.");
+  });
+
+  it("sin valores → variables vacías", () => {
     expect(renderBody("Hola {{1}}!")).toBe("Hola !");
+    expect(renderBody("Hola {{1}} el {{2}}", ["María"])).toBe("Hola María el ");
   });
 });


### PR DESCRIPTION
> Apilado sobre #15, porque el README dice "Plantillas con una variable" y este
> PR lo desmiente. Al mergear: **#15 primero**, o el trabajo se queda anidado en
> la rama base (nos pasó con la pila #10–#13).

Vocero rechazaba en su **propia pantalla** un cuerpo con `{{1}} {{2}} {{3}}`
—*"v1 admite una sola variable"*— aunque la Cloud API de Meta las acepta sin
problema. Era un acotamiento del CRM, no del canal, y dejaba fuera el caso más
común de una plantilla útil: confirmar algo con nombre, fecha y hora.

## Qué cambia

Contar, validar y renderizar las variables sale a un **módulo puro nuevo**
(`src/lib/templates.ts`, 51 líneas, cero imports) que comparten el servidor y la
UI. La pantalla necesita saber cuántos campos pintar antes de enviar; si esa
cuenta la hicieran dos implementaciones distintas, se desincronizarían el día
que Meta cambie algo.

La única regla que queda es la de Meta: **numeración contigua desde `{{1}}`**,
con tope de 10. Un salto (`{{1}}` y `{{3}}`) es rechazo seguro del lado de Meta,
así que se ataja en el alta con un 422 que dice cuál falta — en vez de dejar que
la plantilla muera en revisión tres días después sin explicación.

## Dos detalles del canal que estaban sin cubrir

Ninguno es evidente leyendo la documentación de Meta:

1. Al **dar de alta** hay que mandar un `example.body_text` **por variable**. Si
   falta, Meta responde `100`.
2. Al **enviar** van N `parameters` **en orden**. Si se desalinean, `132000`.

El wa-mock ahora replica esos dos errores reales. Un mock complaciente es
justamente lo que deja pasar este tipo de desfase hasta producción.

## Compatibilidad

El payload viejo de una sola variable (`{variable}`) sigue enviando igual, y hay
un check del arnés que lo fija para que no se rompa por descuido.

## Verificación

```
pnpm typecheck   ✓
pnpm lint        ✓
pnpm test        ✓  166 pruebas
pnpm build       ✓
```

Contra la app viva con los mocks, tres guiones:

| Guion | Resultado |
|---|---|
| `e2e-selftest.mjs` (general) | **87/87** — sin regresión |
| `e2e-templates-sync.mjs` (el que ya existía) | **13/13** |
| `e2e-templates-multivar.mjs` (nuevo) | **21/21** |

El nuevo cubre el camino entero: alta con 3 variables, un ejemplo por variable
llegando a Meta, numeración con saltos, valor faltante, envío con los 3
parámetros en su posición, el hilo mostrando el texto ya sustituido, y la
compatibilidad hacia atrás.

## README

Decía "Plantillas con una variable" y el roadmap prometía "variables múltiples".
Ambos actualizados en este PR, que es lo que lo obliga a ir apilado sobre #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
