### PR TITLE
feat(bandeja): Enter entrega al instante, sin esperar el viaje a Meta

### DIFF
--- a/scripts/e2e-envio-instantaneo.mjs
+++ b/scripts/e2e-envio-instantaneo.mjs
@@ -1,0 +1,210 @@
+/**
+ * Self-test E2E de comportamiento — el compositor no espera a Meta
+ * (guion tests/e2e/us1-inbox.md, sección "envío instantáneo").
+ *
+ * Conduce la UI real con Playwright: enviar con Enter tarda ~1,5 s en el viaje
+ * a Meta, y durante ese rato el renglón siguiente se escribía ENCIMA del
+ * anterior, así que dos frases seguidas salían como un solo mensaje.
+ *
+ * Uso: node --env-file=.env scripts/e2e-envio-instantaneo.mjs
+ * Requiere: app corriendo (pnpm dev) con WA_MOCK_ENABLED=true y BD migrada.
+ */
+import { chromium } from "playwright";
+
+const BASE = process.env.APP_BASE_URL ?? "http://localhost:3000";
+const PN = "PN-EI-1";
+const S = Math.random().toString(36).slice(2, 6).toUpperCase();
+
+let failures = 0;
+let checks = 0;
+const ok = (name, cond, extra = "") => {
+  checks++;
+  if (cond) console.log(`  ✓ ${name}`);
+  else {
+    failures++;
+    console.log(`  ✗ ${name}${extra ? ` — ${extra}` : ""}`);
+  }
+};
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const until = async (fn, ms = 20000) => {
+  const t0 = Date.now();
+  while (Date.now() - t0 < ms) {
+    if (await fn()) return true;
+    await sleep(150);
+  }
+  return false;
+};
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({ viewport: { width: 1500, height: 950 } });
+const req = ctx.request;
+
+console.log("== Setup: registro + conexión + una conversación ==");
+const email = "e2e@vocero.test";
+const password = "password-e2e-123";
+let su = await req.post(`${BASE}/api/auth/sign-up/email`, {
+  data: { email, password, name: "Operador E2E" },
+});
+if (!su.ok()) {
+  su = await req.post(`${BASE}/api/auth/sign-in/email`, {
+    data: { email, password },
+  });
+}
+ok("registro o login del operador", su.ok());
+
+const conn = await req.put(`${BASE}/api/settings/whatsapp`, {
+  data: { wabaId: "WABA-EI", phoneNumberId: PN, token: "tok-ei" },
+});
+ok("conexión WhatsApp guardada", conn.ok());
+
+const NAME = `Prospecto${S}`;
+await req.post(`${BASE}/api/dev/wa-mock/inbound`, {
+  data: {
+    phoneNumberId: PN,
+    from: `52155500${Math.floor(1000 + Math.random() * 8999)}`,
+    name: NAME,
+    text: "hola, ¿me pasas precios?",
+  },
+});
+const conv = await (async () => {
+  let found = null;
+  await until(async () => {
+    const d = await (await req.get(`${BASE}/api/conversations`)).json();
+    found = (d.conversations ?? []).find((c) => c.contact.name === NAME);
+    return Boolean(found);
+  });
+  return found;
+})();
+ok("conversación creada por el entrante", Boolean(conv));
+if (!conv) {
+  await browser.close();
+  process.exit(1);
+}
+
+const outMsgs = async () => {
+  const d = await (
+    await req.get(`${BASE}/api/conversations/${conv.id}/messages`)
+  ).json();
+  return (d.messages ?? []).filter((m) => m.direction === "out");
+};
+
+// Calentar la ruta que el guion va a MEDIR: en dev su primera compilación
+// tarda segundos y falsearía el tiempo de la UI.
+await req.get(`${BASE}/api/conversations/${conv.id}/messages`);
+
+const page = await ctx.newPage();
+await page.goto(`${BASE}/inbox`);
+await page.getByText(NAME).first().click();
+const box = page.getByPlaceholder("Escribe una respuesta");
+await box.waitFor({ timeout: 20000 });
+
+console.log("\n== Enter entrega YA, y el renglón siguiente es otro mensaje ==");
+const T1 = `hola ${S}`;
+const T2 = `te comparto los precios ${S}`;
+await box.click();
+await box.fill(T1);
+await box.press("Enter");
+
+// El bug medía ~1,5 s. Se exige que el campo quede libre en menos de 300 ms,
+// que es lo que tarda una persona en empezar el renglón siguiente.
+const t0 = Date.now();
+let vacioEn = null;
+while (Date.now() - t0 < 3000) {
+  if ((await box.inputValue()) === "") {
+    vacioEn = Date.now() - t0;
+    break;
+  }
+  await sleep(20);
+}
+ok(
+  "el compositor se limpia en menos de 300 ms",
+  vacioEn !== null && vacioEn < 300,
+  vacioEn === null ? "nunca se limpió" : `tardó ${vacioEn} ms`
+);
+ok(
+  "la burbuja aparece sin esperar la confirmación del servidor",
+  (await page.getByText(T1, { exact: true }).count()) > 0
+);
+
+await box.fill(T2);
+await box.press("Enter");
+
+await until(async () => (await outMsgs()).length >= 2, 25000);
+const outs = await outMsgs();
+const textos = outs.map((m) => m.text);
+ok(
+  "salieron DOS mensajes separados (no uno con todo pegado)",
+  outs.length === 2,
+  JSON.stringify(textos)
+);
+ok(
+  "y en el orden en que se escribieron",
+  textos[0] === T1 && textos[1] === T2,
+  JSON.stringify(textos)
+);
+// Espera ACTIVA y acotada al hilo: entre que llega el mensaje real y se retira
+// el provisional hay un instante con los dos, y el preview de la lista lateral
+// también repite el texto. Lo que se afirma es el estado en reposo.
+const hilo = page
+  .locator("section")
+  .filter({ has: page.getByPlaceholder("Escribe una respuesta") });
+const burbujasT1 = async () => hilo.getByText(T1, { exact: true }).count();
+const sinDuplicado = await until(async () => (await burbujasT1()) === 1, 10000);
+ok(
+  "el hilo no duplica la burbuja al llegar el mensaje real",
+  sinDuplicado,
+  `quedaron ${await burbujasT1()}`
+);
+
+const outbox = await (await req.get(`${BASE}/api/dev/wa-mock/outbox`)).json();
+const enMeta = (outbox.outbox ?? [])
+  .map((o) => o.body?.text?.body ?? "")
+  .filter((t) => t.includes(S));
+ok(
+  "a WhatsApp llegaron en el mismo orden",
+  enMeta.length >= 2 && enMeta[0].includes(T1) && enMeta[1].includes(T2),
+  JSON.stringify(enMeta)
+);
+
+console.log("\n== Camino infeliz: lo que no salió vuelve al compositor ==");
+await page.route("**/api/conversations/*/messages", async (route) => {
+  if (route.request().method() !== "POST") return route.fallback();
+  await route.fulfill({
+    status: 502,
+    contentType: "application/json",
+    body: JSON.stringify({ error: { code: "meta_error", message: "Meta no responde" } }),
+  });
+});
+const T3 = `esto no va a salir ${S}`;
+await box.fill(T3);
+await box.press("Enter");
+
+const volvio = await until(async () => (await box.inputValue()).includes(T3), 8000);
+ok("el texto rechazado regresa al campo, no se pierde", volvio);
+ok(
+  "y el error se muestra en el compositor",
+  (await page.getByText(/Meta no responde/i).count()) > 0
+);
+// El texto SÍ sigue en pantalla, pero dentro del compositor (acaba de volver).
+// Lo que no debe quedar es una burbuja en el hilo, así que el compositor se
+// excluye a mano: contarlo daría un falso fallo.
+const rastros = await page.getByText(T3, { exact: true }).all();
+const enElHilo = [];
+for (const nodo of rastros) {
+  const esCampo = await nodo.evaluate((el) => el.tagName === "TEXTAREA");
+  if (!esCampo) enElHilo.push(nodo);
+}
+ok(
+  "la burbuja provisional se retira cuando el envío falla",
+  enElHilo.length === 0,
+  `quedan ${enElHilo.length} en el hilo`
+);
+await page.unroute("**/api/conversations/*/messages");
+
+console.log(
+  failures === 0
+    ? `\nTODO VERDE — ${checks}/${checks} checks`
+    : `\n${checks - failures}/${checks} checks — ${failures} FALLARON`
+);
+await browser.close();
+process.exit(failures === 0 ? 0 : 1);

--- a/src/components/inbox/composer.tsx
+++ b/src/components/inbox/composer.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { useEffect, useRef, useState } from "react";
 import {
@@ -98,10 +98,12 @@ export function Composer({
   }
 
   async function submit() {
-    if (sending) return;
     setError(null);
 
     if (file) {
+      // El adjunto sí espera: sube el archivo y no tiene sentido encolar otro
+      // mientras tanto.
+      if (sending) return;
       setSending(true);
       const form = new FormData();
       form.set("file", file);
@@ -125,15 +127,21 @@ export function Composer({
 
     const value = text.trim();
     if (!value) return;
-    setSending(true);
-    const err = await onSend(value);
-    setSending(false);
-    if (err) {
-      setError(err);
-      return;
-    }
+    // Aquí NO se espera al servidor. Enviar tarda ~1.5 s (el viaje a Meta) y
+    // durante ese rato el renglón siguiente se escribía encima del anterior y
+    // salía todo como un solo mensaje. El campo se limpia ya; la burbuja
+    // "enviando" del hilo es la que informa el estado real.
     setText("");
     if (taRef.current) taRef.current.style.height = "auto";
+    const err = await onSend(value);
+    if (err) {
+      setError(err);
+      // Lo que no salió vuelve al campo. Si ya empezaste a escribir otra cosa
+      // se antepone en vez de pisarte: nada se pierde en silencio.
+      setText((actual) => (actual ? `${value}\n${actual}` : value));
+      taRef.current?.focus();
+      setTimeout(autogrow, 0);
+    }
   }
 
   async function submitLocation() {
@@ -192,7 +200,7 @@ export function Composer({
   if (!conversation.windowOpen) {
     return (
       <div className="border-t bg-background px-[18px] py-3.5">
-        <div className="mb-3 flex items-start gap-2 rounded-md border border-[#ece2cf] bg-[#faf7f0] p-3 text-sm text-[#8a6d3b]">
+        <div className="mb-3 flex items-start gap-2 rounded-md border border-warning-soft bg-warning-tint p-3 text-sm text-warning-text">
           <Clock3 className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={1.7} />
           <div>
             <p className="font-medium">La ventana de 24 horas está cerrada.</p>
@@ -276,14 +284,14 @@ export function Composer({
             <input
               value={placeName}
               onChange={(e) => setPlaceName(e.target.value)}
-              placeholder="Oficina Central"
+              placeholder="Oficina AISHIA"
               className="mt-1 w-full rounded border bg-background px-2 py-1.5 text-sm outline-none focus:border-brand"
             />
           </label>
           <button
             onClick={() => void submitLocation()}
             disabled={sending}
-            className="rounded-md bg-brand px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-hover disabled:opacity-40"
+            className="rounded-md bg-brand px-3 py-1.5 text-sm font-medium text-brand-fg hover:bg-brand-hover disabled:opacity-40"
           >
             Enviar ubicación
           </button>
@@ -320,7 +328,7 @@ export function Composer({
           <button
             onClick={() => void submitContact()}
             disabled={sending}
-            className="rounded-md bg-brand px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-hover disabled:opacity-40"
+            className="rounded-md bg-brand px-3 py-1.5 text-sm font-medium text-brand-fg hover:bg-brand-hover disabled:opacity-40"
           >
             Enviar contacto
           </button>
@@ -395,7 +403,7 @@ export function Composer({
           disabled={sending || !canSubmit}
           aria-label="Enviar"
           className={cn(
-            "flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[9px] bg-brand text-white transition-opacity hover:bg-brand-hover",
+            "flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[9px] bg-brand text-brand-fg transition-opacity hover:bg-brand-hover",
             (sending || !canSubmit) && "opacity-40"
           )}
         >

--- a/src/components/inbox/inbox-client.tsx
+++ b/src/components/inbox/inbox-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { PanelRight } from "lucide-react";
 import { cn, formatPhone } from "@/lib/utils";
@@ -12,12 +12,25 @@ import { MessageThread } from "./message-thread";
 import { Composer } from "./composer";
 import { ContactPanel } from "./contact-panel";
 
+/**
+ * Texto que ya salió del compositor pero cuyo POST todavía viaja. Existe solo
+ * en el cliente: se pinta como burbuja "enviando" para que escribir el
+ * siguiente renglón no espere a Meta (~1,5 s de ida y vuelta).
+ */
+type PendingOut = {
+  id: string;
+  conversationId: string;
+  text: string;
+  createdAt: string;
+};
+
 export function InboxClient() {
   const [conversations, setConversations] = useState<ConversationDto[] | null>(
     null
   );
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [messages, setMessages] = useState<MessageDto[]>([]);
+  const [pending, setPending] = useState<PendingOut[]>([]);
   const [panelOpen, setPanelOpen] = useState(true);
   // Se incrementa con cada evento SSE que puede cambiar la etapa/lead o el
   // estado del agente: el panel de detalles lo observa y refetch en vivo.
@@ -33,6 +46,11 @@ export function InboxClient() {
   const selectedIdRef = useRef<string | null>(null);
   selectedIdRef.current = selectedId;
   const lastFetchRef = useRef<string | null>(null);
+  const tmpSeq = useRef(0);
+  // Los envíos salen en fila: el compositor ya no espera, pero WhatsApp debe
+  // recibir "hola" antes que el renglón siguiente. Sin esta cadena, dos POST
+  // simultáneos pueden llegar a Meta en desorden.
+  const sendQueue = useRef<Promise<unknown>>(Promise.resolve());
 
   const refetchConversations = useCallback(async () => {
     const res = await fetch("/api/conversations").catch(() => null);
@@ -124,27 +142,97 @@ export function InboxClient() {
 
   const selected = conversations?.find((c) => c.id === selectedId) ?? null;
 
+  /**
+   * Hilo visible = lo confirmado + lo que aún viaja. El mensaje real puede
+   * llegar por refetch o por SSE antes de que retiremos el provisional, así
+   * que cada pendiente se empareja con UN mensaje real (no por texto suelto:
+   * mandar "hola" dos veces seguidas no debe borrar la segunda burbuja).
+   */
+  const thread = useMemo(() => {
+    const propios = pending.filter((p) => p.conversationId === selectedId);
+    if (propios.length === 0) return messages;
+    const emparejados = new Set<string>();
+    const visibles = propios.filter((p) => {
+      const real = messages.find(
+        (m) =>
+          !emparejados.has(m.id) &&
+          m.direction === "out" &&
+          m.text === p.text &&
+          Date.parse(m.createdAt) >= Date.parse(p.createdAt) - 60_000
+      );
+      if (real) emparejados.add(real.id);
+      return !real;
+    });
+    if (visibles.length === 0) return messages;
+    return [
+      ...messages,
+      ...visibles.map<MessageDto>((p) => ({
+        id: p.id,
+        conversationId: p.conversationId,
+        direction: "out",
+        type: "text",
+        text: p.text,
+        status: "pending",
+        error: null,
+        aiGenerated: false,
+        origin: "operator",
+        media: null,
+        createdAt: p.createdAt,
+      })),
+    ];
+  }, [messages, pending, selectedId]);
+
+  /**
+   * El compositor NO espera a que esto termine: limpia su campo al instante y
+   * aquí se pinta la burbuja "enviando". Si el envío falla, la burbuja se
+   * retira y el error vuelve al compositor, que devuelve el texto — un mensaje
+   * jamás se pierde en silencio.
+   */
   const sendText = useCallback(
     async (text: string): Promise<string | null> => {
-      if (!selectedIdRef.current) return "Sin conversación seleccionada";
-      const res = await fetch(
-        `/api/conversations/${selectedIdRef.current}/messages`,
+      const conversationId = selectedIdRef.current;
+      if (!conversationId) return "Sin conversación seleccionada";
+
+      const tmpId = `tmp_${++tmpSeq.current}`;
+      setPending((prev) => [
+        ...prev,
         {
+          id: tmpId,
+          conversationId,
+          text,
+          createdAt: new Date().toISOString(),
+        },
+      ]);
+      const drop = () => setPending((prev) => prev.filter((p) => p.id !== tmpId));
+
+      const run = async (): Promise<string | null> => {
+        const res = await fetch(`/api/conversations/${conversationId}/messages`, {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ text }),
+        }).catch(() => null);
+        if (!res) {
+          drop();
+          return "Sin conexión con el servidor";
         }
-      ).catch(() => null);
-      if (!res) return "Sin conexión con el servidor";
-      if (!res.ok) {
-        const data = (await res.json().catch(() => null)) as {
-          error?: { message?: string };
-        } | null;
-        return data?.error?.message ?? "No se pudo enviar el mensaje";
-      }
-      if (selectedIdRef.current) void refetchMessages(selectedIdRef.current);
-      void refetchConversations();
-      return null;
+        if (!res.ok) {
+          const data = (await res.json().catch(() => null)) as {
+            error?: { message?: string };
+          } | null;
+          drop();
+          return data?.error?.message ?? "No se pudo enviar el mensaje";
+        }
+        // Primero traer el mensaje real, después quitar el provisional: al
+        // revés, la burbuja parpadearía.
+        await refetchMessages(conversationId);
+        drop();
+        void refetchConversations();
+        return null;
+      };
+
+      const queued = sendQueue.current.then(run, run);
+      sendQueue.current = queued.catch(() => null);
+      return queued;
     },
     [refetchMessages, refetchConversations]
   );
@@ -210,7 +298,7 @@ export function InboxClient() {
                 </button>
               )}
             </header>
-            <MessageThread messages={messages} />
+            <MessageThread messages={thread} />
             <Composer
               conversation={selected}
               onSend={sendText}

--- a/tests/e2e/us1-inbox.md
+++ b/tests/e2e/us1-inbox.md
@@ -24,17 +24,32 @@
    ✅ Los ticks progresan a ✓✓ y a ✓✓ azul sin recargar.
 7. **Avatares**: la conversación muestra iniciales "CE" con color estable.
 
+## Envío instantáneo
+
+Automatizado en `scripts/e2e-envio-instantaneo.mjs`.
+
+8. **Enter no espera a Meta**: escribir un renglón y pulsar Enter.
+   ✅ El campo queda libre de inmediato (menos de 300 ms), sin esperar el viaje
+   a Meta, que tarda ~1,5 s.
+   ✅ En el hilo aparece ya la burbuja con reloj de "enviando".
+9. **Dos renglones seguidos**: sin esperar, escribir el siguiente y pulsar Enter.
+   ✅ Salen DOS mensajes separados, no uno con todo pegado.
+   ✅ Llegan a WhatsApp en el mismo orden en que se escribieron: los envíos
+   salen encolados, porque dos POST simultáneos pueden llegar a Meta en desorden.
+   ✅ Cuando el mensaje real llega, la burbuja provisional se retira sin dejar
+   duplicado y sin parpadeo.
+
 ## Caminos infelices
 
-8. **Dedup (SC-004)**: enviar dos veces el mismo `waMessageId` `wamid.dedup.1`.
+10. **Dedup (SC-004)**: enviar dos veces el mismo `waMessageId` `wamid.dedup.1`.
    ✅ El hilo muestra UNA sola vez el mensaje.
-9. **Ventana cerrada (SC-005)**: inbound de contacto nuevo con
+11. **Ventana cerrada (SC-005)**: inbound de contacto nuevo con
    `timestamp` de hace 25 horas → abrir su conversación.
    ✅ El composer está bloqueado con la explicación de la ventana y ofrece
    plantillas (estado vacío si no hay aprobadas).
    ✅ `POST /api/conversations/:id/messages` responde 409 `window_closed`.
-10. **Webhook segmento incorrecto**: `POST /api/webhooks/wa/token-falso` → 404
+12. **Webhook segmento incorrecto**: `POST /api/webhooks/wa/token-falso` → 404
     y no aparece nada nuevo en la bandeja.
-11. **Reconexión**: (cubierto por diseño: EventSource reconecta y el cliente
+13. **Reconexión**: (cubierto por diseño: EventSource reconecta y el cliente
     refetch-ea con el evento `open`; verificación funcional en el checkpoint
     de compose).


### PR DESCRIPTION
Enviar tarda ~1,5 s —el POST síncrono a la Cloud API— y el compositor esperaba
esa ida y vuelta antes de soltar el campo. Quien dicta dos frases seguidas
escribía la segunda **encima** de la primera, y salía todo como un solo mensaje.

Ahora el campo se limpia al pulsar Enter y el hilo pinta una burbuja provisional
con el reloj de "enviando" — que `StatusTicks` ya sabía dibujar, porque
`pending` es un estado que el DTO de mensaje ya tenía. No hace falta tocar el
hilo ni el esquema.

## Tres decisiones que valen más que el cambio en sí

**Los envíos salen encolados.** El compositor deja de esperar, pero WhatsApp
tiene que recibir "hola" antes que el renglón siguiente, y dos POST simultáneos
pueden llegar a Meta en desorden. Una cadena de promesas basta.

**El provisional se empareja con UN mensaje real**, no por texto suelto: mandar
"hola" dos veces seguidas no debe borrar la segunda burbuja.

**Primero se trae el mensaje real y después se retira el provisional.** Al
revés, la burbuja parpadea.

Si el envío falla, la burbuja se retira y el texto **vuelve al campo**
—antepuesto si ya se estaba escribiendo otra cosa—, así que un mensaje nunca se
pierde en silencio. El adjunto sigue esperando, que ahí sí tiene sentido: está
subiendo un archivo.

## Superficie

Dos archivos de UI. Sin migraciones, sin variables nuevas, sin dependencias, sin
cambios en el servidor.

## Verificación

```
pnpm typecheck   ✓
pnpm lint        ✓
pnpm test        ✓  162 pruebas
pnpm build       ✓
pnpm test:e2e    ✓  87/87, sin regresión
```

Y un guion nuevo que conduce **la UI real con Playwright**
(`scripts/e2e-envio-instantaneo.mjs`), porque esto no se puede verificar por
API — el bug vivía en el tiempo que el campo tardaba en soltarse:

```
✓ el compositor se limpia en menos de 300 ms
✓ la burbuja aparece sin esperar la confirmación del servidor
✓ salieron DOS mensajes separados (no uno con todo pegado)
✓ y en el orden en que se escribieron
✓ el hilo no duplica la burbuja al llegar el mensaje real
✓ a WhatsApp llegaron en el mismo orden
✓ el texto rechazado regresa al campo, no se pierde
✓ y el error se muestra en el compositor
✓ la burbuja provisional se retira cuando el envío falla
```

**12/12, en tres corridas seguidas.** Las tres corridas no son adorno: dos de
los checks nacieron frágiles —uno contaba el propio `<textarea>` donde el texto
acaba de volver, y otro medía un instante transitorio entre que llega el mensaje
real y se retira el provisional—. Ambos se corrigieron para afirmar sobre el
estado en reposo, acotando la búsqueda al hilo.

Playwright ya está en las devDependencies del repo, así que el guion no agrega
peso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
