### PR TITLE
feat(ui): el CRM se usa desde el telefono y la tableta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ Thumbs.db
 .playwright-mcp/
 .tmp-seed-demo.mjs
 .dev-media/
+# Capturas y salidas de los self-tests (p. ej. scripts/e2e-responsive.mjs)
+scratch/

--- a/scripts/e2e-responsive.mjs
+++ b/scripts/e2e-responsive.mjs
@@ -1,0 +1,324 @@
+/**
+ * Self-test E2E de comportamiento — responsividad (teléfono / tableta / escritorio).
+ * Guion: tests/e2e/responsividad.md
+ *
+ * Verifica que el CRM se pueda USAR desde el teléfono, no solo que "quepa":
+ *  - el lateral se vuelve cajón con hamburguesa y se cierra al navegar;
+ *  - la Bandeja se comporta como maestro-detalle (lista ↔ hilo con "volver");
+ *  - el panel de detalles flota sobre el hilo en vez de robarle ancho;
+ *  - ninguna pantalla recorta contenido a lo ancho (main no desborda);
+ *  - los campos de texto miden ≥16px (si no, iOS hace zoom y descuadra todo);
+ *  - en escritorio NADA de lo anterior cambia (el lateral sigue fijo).
+ *
+ * Uso: node scripts/e2e-responsive.mjs
+ * Requiere: app corriendo (pnpm dev) con WA_MOCK_ENABLED=true y Playwright.
+ */
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+
+const BASE = process.env.APP_BASE_URL ?? "http://localhost:3000";
+const PN = "PN-RESP-1";
+const S = Math.random().toString(36).slice(2, 6).toUpperCase();
+const SHOTS = "scratch/responsive";
+let failures = 0;
+const ok = (name, cond, extra = "") => {
+  if (cond) console.log(`  ✓ ${name}`);
+  else {
+    failures++;
+    console.log(`  ✗ ${name}${extra ? ` — ${extra}` : ""}`);
+  }
+};
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const until = async (fn, ms = 20000) => {
+  const t0 = Date.now();
+  for (;;) {
+    try {
+      if (await fn()) return true;
+    } catch {
+      /* reintenta */
+    }
+    if (Date.now() - t0 > ms) return false;
+    await sleep(250);
+  }
+};
+
+const PHONE = { width: 390, height: 844 };
+const TABLET = { width: 820, height: 1180 };
+const DESKTOP = { width: 1440, height: 900 };
+const RUTAS = [
+  "/inbox",
+  "/pipeline",
+  "/contacts",
+  "/agent",
+  "/lab",
+  "/settings/whatsapp",
+];
+
+mkdirSync(SHOTS, { recursive: true });
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({ viewport: DESKTOP });
+const req = ctx.request;
+// El canal SSE se corta en el navegador: no aporta nada al diseño y cada
+// stream vivo ocupa una ranura del servidor de `next dev` — a la ~15ª carga
+// el servidor deja de contestar (se cuelga el guion, no el producto).
+await ctx.route("**/api/events*", (route) => route.abort());
+
+console.log("== Setup ==");
+let r = await req.post(`${BASE}/api/auth/sign-up/email`, {
+  headers: { origin: BASE },
+  data: {
+    email: "e2e@vocero.test",
+    password: "password-e2e-123",
+    name: "Operador E2E",
+  },
+});
+if (!r.ok())
+  r = await req.post(`${BASE}/api/auth/sign-in/email`, {
+    headers: { origin: BASE },
+    data: { email: "e2e@vocero.test", password: "password-e2e-123" },
+  });
+ok("login", r.ok());
+await req.put(`${BASE}/api/settings/whatsapp`, {
+  data: { wabaId: "WABA-RESP", phoneNumberId: PN, token: "tok-resp" },
+});
+
+const NAME = `Prospecto${S}`;
+await req.post(`${BASE}/api/dev/wa-mock/inbound`, {
+  data: {
+    phoneNumberId: PN,
+    from: `521462${Math.floor(Math.random() * 9e6) + 1e6}`,
+    name: NAME,
+    text: "hola, vi su anuncio y quiero saber cuánto cuesta el diagnóstico",
+    waMessageId: `wamid.resp.${S}`,
+  },
+});
+const listo = await until(async () => {
+  const d = await (await req.get(`${BASE}/api/conversations`)).json();
+  return d.conversations.some((c) => c.contact.name === NAME);
+});
+ok("conversación de prueba creada", listo);
+
+// Calienta cada ruta: en `pnpm dev` la primera visita compila (3-4 s) y el
+// guion mediría la compilación, no el diseño.
+// La primera visita a cada ruta la COMPILA (`next dev`), y algunas pasan de
+// los 30 s por defecto de Playwright. Se calientan por HTTP, sin navegador: un
+// `page.goto` abriría además el canal SSE de la app, y varias páginas con SSE
+// vivo a la vez dejan clavado al servidor de desarrollo.
+ctx.setDefaultNavigationTimeout(120000);
+ctx.setDefaultTimeout(30000);
+for (const ruta of RUTAS) {
+  await req.get(`${BASE}${ruta}`, { timeout: 180000 });
+}
+
+/** Ancho real del contenido contra el ancho visible del contenedor. */
+const desborde = (page) =>
+  page.evaluate(() => {
+    const main = document.querySelector("main");
+    const doc = document.documentElement;
+    return {
+      mainOver: main ? main.scrollWidth - main.clientWidth : 0,
+      docOver: doc.scrollWidth - window.innerWidth,
+    };
+  });
+
+async function recorrer(page, etiqueta) {
+  for (const ruta of RUTAS) {
+    await page.goto(`${BASE}${ruta}`, { waitUntil: "domcontentloaded" });
+    // Nada de `networkidle`: el canal SSE queda abierto a propósito y la
+    // espera nunca se cumpliría.
+    await sleep(900);
+    const d = await desborde(page);
+    ok(
+      `${etiqueta} ${ruta} sin recorte horizontal`,
+      d.mainOver <= 1 && d.docOver <= 1,
+      `main +${d.mainOver}px · documento +${d.docOver}px`
+    );
+    await page.screenshot({
+      path: `${SHOTS}/${etiqueta}${ruta.replace(/\//g, "-")}.png`,
+      fullPage: false,
+    });
+  }
+}
+
+console.log("\n== 1. Teléfono (390×844): ninguna pantalla se recorta ==");
+const phone = await ctx.newPage();
+await phone.setViewportSize(PHONE);
+await recorrer(phone, "phone");
+
+console.log("\n== 2. Teléfono: el lateral es un cajón con hamburguesa ==");
+await phone.goto(`${BASE}/pipeline`);
+const hamburguesa = phone.getByRole("button", { name: "Abrir el menú" });
+await hamburguesa.waitFor({ timeout: 20000 });
+ok("la hamburguesa se ve", await hamburguesa.isVisible());
+const linkBandeja = phone.getByRole("link", { name: /Bandeja/ });
+ok(
+  "el lateral arranca oculto (sus enlaces no son alcanzables)",
+  !(await linkBandeja.isVisible())
+);
+await hamburguesa.click();
+ok(
+  "al tocar la hamburguesa el cajón abre",
+  await until(async () => await linkBandeja.isVisible(), 3000)
+);
+// El cajón NO debe empujar el contenido: sale encima.
+const encima = await phone.evaluate(() => {
+  const aside = document.querySelector("aside");
+  const main = document.querySelector("main");
+  if (!aside || !main) return null;
+  const a = aside.getBoundingClientRect();
+  const m = main.getBoundingClientRect();
+  return { asideLeft: Math.round(a.left), mainLeft: Math.round(m.left) };
+});
+ok(
+  "el cajón flota encima del contenido (no lo empuja)",
+  encima !== null && encima.asideLeft <= 1 && encima.mainLeft <= 1,
+  JSON.stringify(encima)
+);
+await phone.screenshot({ path: `${SHOTS}/phone-cajon-abierto.png` });
+await linkBandeja.click();
+await until(async () => phone.url().includes("/inbox"), 15000);
+ok("navegar desde el cajón lleva a la Bandeja", phone.url().includes("/inbox"));
+ok(
+  "el cajón se cierra solo al navegar",
+  await until(async () => !(await linkBandeja.isVisible()), 5000)
+);
+
+console.log("\n== 3. Teléfono: la Bandeja es maestro-detalle ==");
+await phone.goto(`${BASE}/inbox`);
+const fila = phone.getByText(NAME).first();
+await fila.waitFor({ timeout: 20000 });
+ok("la lista de conversaciones ocupa la pantalla", await fila.isVisible());
+const anchoLista = await phone.evaluate(() => {
+  const sec = document.querySelector("main > div > section");
+  return sec ? Math.round(sec.getBoundingClientRect().width) : 0;
+});
+ok(
+  "la lista usa el ancho completo del teléfono",
+  anchoLista >= PHONE.width - 8,
+  `${anchoLista}px de ${PHONE.width}`
+);
+await fila.click();
+const composer = phone.getByPlaceholder("Escribe una respuesta");
+ok(
+  "al elegir una conversación se abre el hilo",
+  await until(async () => await composer.isVisible(), 15000)
+);
+ok("la lista cede la pantalla al hilo", !(await fila.isVisible()));
+const volver = phone.getByRole("button", { name: "Volver a las conversaciones" });
+ok("aparece el botón de volver", await volver.isVisible());
+await phone.screenshot({ path: `${SHOTS}/phone-hilo.png` });
+
+// El compositor debe quedar DENTRO de la pantalla (100dvh, no 100vh).
+const compBox = await composer.boundingBox();
+ok(
+  "el compositor queda dentro de la pantalla",
+  compBox !== null && compBox.y + compBox.height <= PHONE.height,
+  compBox ? `borde inferior en ${Math.round(compBox.y + compBox.height)}px` : "sin caja"
+);
+// iOS: menos de 16px = zoom automático al enfocar.
+const fuenteComp = await composer.evaluate((el) =>
+  parseFloat(getComputedStyle(el).fontSize)
+);
+ok(
+  "el compositor usa ≥16px (iOS no hace zoom al enfocar)",
+  fuenteComp >= 16,
+  `${fuenteComp}px`
+);
+
+console.log("\n== 4. Teléfono: los detalles flotan sobre el hilo ==");
+const abrirDetalles = phone.getByRole("button", { name: "Mostrar detalles" });
+ok("el panel de detalles arranca cerrado en el teléfono", await abrirDetalles.isVisible());
+await abrirDetalles.click();
+await sleep(500);
+const cajonDetalles = await phone.evaluate(() => {
+  const secs = [...document.querySelectorAll("main > div > section")];
+  const panel = secs[secs.length - 1];
+  if (!panel) return null;
+  const r = panel.getBoundingClientRect();
+  return {
+    right: Math.round(r.right),
+    width: Math.round(r.width),
+    fixed: getComputedStyle(panel).position === "fixed",
+  };
+});
+ok(
+  "los detalles entran como cajón pegado al borde derecho",
+  cajonDetalles !== null &&
+    cajonDetalles.fixed &&
+    Math.abs(cajonDetalles.right - PHONE.width) <= 2 &&
+    cajonDetalles.width <= PHONE.width,
+  JSON.stringify(cajonDetalles)
+);
+const dEnDetalles = await desborde(phone);
+ok(
+  "con los detalles abiertos la pantalla sigue sin recortarse",
+  dEnDetalles.docOver <= 1,
+  `documento +${dEnDetalles.docOver}px`
+);
+await phone.screenshot({ path: `${SHOTS}/phone-detalles.png` });
+await phone
+  .getByRole("button", { name: "Cerrar los detalles" })
+  .click()
+  .catch(() => null);
+await sleep(400);
+
+console.log("\n== 5. Tableta (820×1180) ==");
+const tablet = phone;
+await tablet.setViewportSize(TABLET);
+await recorrer(tablet, "tablet");
+await tablet.goto(`${BASE}/inbox`);
+await tablet.getByText(NAME).first().click();
+await tablet.getByPlaceholder("Escribe una respuesta").waitFor({ timeout: 20000 });
+const dosColumnas = await tablet.evaluate(() => {
+  const secs = [...document.querySelectorAll("main > div > section")];
+  return secs.slice(0, 2).map((s) => Math.round(s.getBoundingClientRect().width));
+});
+ok(
+  "en tableta conviven lista e hilo (dos columnas)",
+  dosColumnas.length === 2 && dosColumnas[0] > 200 && dosColumnas[1] > 300,
+  JSON.stringify(dosColumnas)
+);
+await tablet.screenshot({ path: `${SHOTS}/tablet-inbox.png` });
+
+console.log("\n== 6. Escritorio (1440×900): nada cambió ==");
+const desk = tablet;
+await desk.setViewportSize(DESKTOP);
+await recorrer(desk, "desktop");
+await desk.goto(`${BASE}/inbox`);
+await desk.getByText(NAME).first().click();
+await desk.getByPlaceholder("Escribe una respuesta").waitFor({ timeout: 20000 });
+ok(
+  "el lateral sigue fijo (sin hamburguesa)",
+  !(await desk.getByRole("button", { name: "Abrir el menú" }).isVisible()) &&
+    (await desk.getByRole("link", { name: /Bandeja/ }).isVisible())
+);
+const medirColumnas = () =>
+  desk.evaluate(() => {
+    const aside = document.querySelector("aside");
+    const secs = [...document.querySelectorAll("main > div > section")];
+    return {
+      aside: aside ? Math.round(aside.getBoundingClientRect().width) : 0,
+      secs: secs.map((s) => Math.round(s.getBoundingClientRect().width)),
+    };
+  });
+// El panel abre con transición de 220 ms: medir apenas aparece el compositor
+// atraparía un ancho a medio camino.
+const columnasOk = (t) =>
+  t.aside === 224 && t.secs[0] === 360 && t.secs.at(-1) === 320;
+await until(async () => columnasOk(await medirColumnas()), 8000);
+const tres = await medirColumnas();
+ok(
+  "escritorio conserva lateral 224px + lista 360px + hilo + detalles 320px",
+  columnasOk(tres),
+  JSON.stringify(tres)
+);
+await desk.screenshot({ path: `${SHOTS}/desktop-inbox.png` });
+
+console.log(
+  failures === 0
+    ? `\n✅ Responsividad: todo verde. Capturas en ${SHOTS}/`
+    : `\n❌ Responsividad: ${failures} fallo(s). Capturas en ${SHOTS}/`
+);
+await browser.close();
+process.exit(failures === 0 ? 0 : 1);

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -4,7 +4,7 @@ import { getAuth } from "@/lib/auth";
 import { getSessionOrNull } from "@/lib/auth/session";
 import { normalizeThemePreference, THEME_COOKIE } from "@/lib/theme";
 import { getBranding } from "@/server/branding";
-import { AppNav } from "@/components/app-nav";
+import { AppShell } from "@/components/app-shell";
 
 export default async function AppLayout({
   children,
@@ -20,14 +20,13 @@ export default async function AppLayout({
   );
 
   return (
-    <div className="flex h-screen overflow-hidden bg-background">
-      <AppNav
-        branding={branding}
-        userName={authSession?.user.name ?? "Usuario"}
-        role={session.role}
-        theme={theme}
-      />
-      <main className="min-w-0 flex-1 overflow-hidden">{children}</main>
-    </div>
+    <AppShell
+      branding={branding}
+      userName={authSession?.user.name ?? "Usuario"}
+      role={session.role}
+      theme={theme}
+    >
+      {children}
+    </AppShell>
   );
 }

--- a/src/app/(app)/settings/layout.tsx
+++ b/src/app/(app)/settings/layout.tsx
@@ -5,12 +5,13 @@ export default function SettingsLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <div className="flex h-full flex-col">
-      <header className="border-b px-6 py-4">
+      <header className="border-b px-4 py-3 sm:px-6 sm:py-4">
         <h2 className="font-semibold">Configuración</h2>
       </header>
-      <div className="flex min-h-0 flex-1">
+      {/* En móvil las pestañas van arriba (en fila), no como columna lateral. */}
+      <div className="flex min-h-0 flex-1 flex-col sm:flex-row">
         <SettingsNav />
-        <div className="min-w-0 flex-1 overflow-y-auto p-6">{children}</div>
+        <div className="min-w-0 flex-1 overflow-y-auto p-4 sm:p-6">{children}</div>
       </div>
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -162,6 +162,21 @@
   }
 }
 
+/*
+  Safari en iOS hace zoom a la página cuando enfocas un campo cuya tipografía
+  mide menos de 16px, y luego no la devuelve: escribir en la Bandeja dejaba el
+  CRM descuadrado. Por debajo de `md` subimos el mínimo de TODO campo de texto
+  (los `select` quedan fuera: abren su propia rueda nativa y varios viven como
+  chips angostos). Va con `!important` a propósito — compite contra utilidades
+  de Tailwind (`text-sm`, `text-xs`) que ganan por especificidad de clase.
+*/
+@media (max-width: 767px) {
+  input:not([type="checkbox"]):not([type="radio"]),
+  textarea {
+    font-size: 16px !important;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/src/components/agent/agent-client.tsx
+++ b/src/components/agent/agent-client.tsx
@@ -72,7 +72,7 @@ export function AgentClient() {
 
   return (
     <div className="h-full overflow-y-auto">
-      <header className="flex items-center justify-between border-b px-6 py-4">
+      <header className="flex flex-wrap items-center justify-between gap-2 border-b px-4 py-3 sm:px-6 sm:py-4">
         <h2 className="font-semibold">Agente de IA</h2>
         <div className="flex items-center gap-3">
           {saved && <span className="text-xs text-primary">Guardado ✓</span>}
@@ -99,7 +99,7 @@ export function AgentClient() {
       </header>
 
       {!aiConfigured && (
-        <div className="mx-6 mt-6 rounded-lg border border-brand-soft bg-brand-tint p-6 text-center">
+        <div className="mx-4 mt-4 rounded-lg border border-brand-soft bg-brand-tint p-5 text-center sm:mx-6 sm:mt-6 sm:p-6">
           <Sparkles className="mx-auto mb-2 h-8 w-8 text-primary" />
           <p className="font-medium">Configura tu proveedor de IA para activar el agente</p>
           <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">
@@ -111,7 +111,7 @@ export function AgentClient() {
         </div>
       )}
 
-      <div className="grid gap-6 p-6 lg:grid-cols-2">
+      <div className="grid gap-4 p-4 sm:gap-6 sm:p-6 lg:grid-cols-2">
         <ProfileSection profile={profile} onSave={saveProfile} />
         <KbSection entries={entries} kbSize={kbSize} onChanged={() => void refetch()} />
       </div>

--- a/src/components/app-nav.tsx
+++ b/src/components/app-nav.tsx
@@ -11,6 +11,7 @@ import {
   Settings,
   Sparkles,
   Users,
+  X,
 } from "lucide-react";
 import type { Branding } from "@/lib/branding";
 import type { ThemePreference } from "@/lib/theme";
@@ -32,11 +33,16 @@ export function AppNav({
   userName,
   role,
   theme,
+  open = false,
+  onClose,
 }: {
   branding: Branding;
   userName: string;
   role: string;
   theme: ThemePreference;
+  /** Solo aplica por debajo de `lg`: en escritorio el lateral es fijo. */
+  open?: boolean;
+  onClose?: () => void;
 }) {
   const pathname = usePathname();
   const router = useRouter();
@@ -61,9 +67,29 @@ export function AppNav({
   });
 
   return (
-    <aside className="flex w-56 shrink-0 flex-col border-r bg-subtle px-3 pb-3.5 pt-4">
+    <aside
+      // Móvil: cajón que se desliza desde la izquierda (siempre montado, así
+      // la transición corre en ambos sentidos). Escritorio: columna fija.
+      // `visibility` va en la transición a propósito: al cerrar mantiene el
+      // cajón visible mientras se desliza y recién entonces lo oculta, que es
+      // lo que lo saca del orden de tabulación en móvil.
+      className={cn(
+        "fixed inset-y-0 left-0 z-50 flex w-[17rem] shrink-0 flex-col overflow-y-auto border-r bg-subtle px-3 pb-3.5 pt-4 transition-[transform,visibility] duration-200",
+        "lg:static lg:visible lg:z-auto lg:w-56 lg:translate-x-0 lg:overflow-visible lg:transition-none",
+        open ? "visible translate-x-0 shadow-pop" : "invisible -translate-x-full"
+      )}
+    >
       {/* Brand white-label */}
       <div className="mb-4 flex items-center gap-2.5 px-2">
+        {/* En móvil el cajón necesita su propio cierre: el velo no siempre es
+            alcanzable con el pulgar. */}
+        <button
+          onClick={onClose}
+          aria-label="Cerrar el menú"
+          className="-ml-1 rounded-md p-1.5 text-text-3 hover:bg-accent hover:text-foreground lg:hidden"
+        >
+          <X className="h-[18px] w-[18px]" strokeWidth={1.8} />
+        </button>
         <span
           className="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-sm bg-brand text-[15px] font-bold text-brand-fg"
           aria-hidden
@@ -87,7 +113,7 @@ export function AppNav({
               key={item.href}
               href={item.href}
               className={cn(
-                "flex items-center gap-[11px] rounded-sm px-2.5 py-2 text-sm font-medium transition-colors",
+                "flex items-center gap-[11px] rounded-sm px-2.5 py-2.5 text-sm font-medium transition-colors lg:py-2",
                 active
                   ? "bg-brand-tint font-semibold text-brand-text"
                   : "text-text-2 hover:bg-accent"

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { Menu } from "lucide-react";
+import type { Branding } from "@/lib/branding";
+import type { ThemePreference } from "@/lib/theme";
+import { AppNav } from "@/components/app-nav";
+
+/**
+ * Cascarón de la app en dos modos:
+ *
+ * - Escritorio (lg+): el panel lateral es una columna fija, como siempre.
+ * - Móvil/tableta: el lateral sale de la izquierda como cajón sobre un velo,
+ *   y arriba queda una barra con el hamburguesa y la marca. El cajón se cierra
+ *   solo al navegar (el `pathname` cambia) y con Escape.
+ *
+ * La altura usa `100dvh` (no `100vh`) porque en el navegador móvil la barra de
+ * direcciones se encoge al hacer scroll: con `vh` el compositor de la Bandeja
+ * queda debajo del borde visible.
+ */
+export function AppShell({
+  branding,
+  userName,
+  role,
+  theme,
+  children,
+}: {
+  branding: Branding;
+  userName: string;
+  role: string;
+  theme: ThemePreference;
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const [navOpen, setNavOpen] = useState(false);
+
+  // Navegar = cerrar el cajón. Sin esto, tocar "Pipeline" deja el velo encima
+  // de la pantalla recién cargada.
+  useEffect(() => {
+    setNavOpen(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!navOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setNavOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [navOpen]);
+
+  return (
+    <div className="flex h-dvh overflow-hidden bg-background">
+      {navOpen && (
+        <button
+          aria-label="Cerrar el menú"
+          tabIndex={-1}
+          onClick={() => setNavOpen(false)}
+          className="fixed inset-0 z-40 bg-overlay lg:hidden"
+        />
+      )}
+
+      <AppNav
+        branding={branding}
+        userName={userName}
+        role={role}
+        theme={theme}
+        open={navOpen}
+        onClose={() => setNavOpen(false)}
+      />
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="flex h-12 shrink-0 items-center gap-2 border-b px-2 lg:hidden">
+          <button
+            onClick={() => setNavOpen(true)}
+            aria-label="Abrir el menú"
+            aria-expanded={navOpen}
+            className="rounded-md p-2 text-text-2 hover:bg-accent hover:text-foreground"
+          >
+            <Menu className="h-5 w-5" strokeWidth={1.8} />
+          </button>
+          <span
+            className="flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-sm bg-brand text-[13px] font-bold text-brand-fg"
+            aria-hidden
+          >
+            {branding.name.charAt(0).toUpperCase()}
+          </span>
+          <span className="truncate text-[15px] font-[650] tracking-tight">
+            {branding.name}
+          </span>
+        </header>
+
+        <main className="min-h-0 min-w-0 flex-1 overflow-hidden">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/contacts/contacts-client.tsx
+++ b/src/components/contacts/contacts-client.tsx
@@ -63,9 +63,9 @@ export function ContactsClient() {
 
   return (
     <div className="flex h-full flex-col">
-      <header className="flex items-center justify-between gap-4 border-b px-6 py-4">
+      <header className="flex flex-wrap items-center justify-between gap-3 border-b px-4 py-3 sm:gap-4 sm:px-6 sm:py-4">
         <h2 className="font-semibold">Contactos</h2>
-        <div className="flex items-center gap-3">
+        <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:gap-3">
           <label className="flex items-center gap-2 text-xs text-muted-foreground">
             <input
               type="checkbox"
@@ -90,7 +90,7 @@ export function ContactsClient() {
               ))}
             </select>
           )}
-          <div className="relative">
+          <div className="relative w-full sm:w-auto">
             <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
             <Input
               ref={inputRef}
@@ -98,13 +98,13 @@ export function ContactsClient() {
               aria-label="Buscar contacto"
               defaultValue=""
               onChange={(e) => setQuery(e.target.value)}
-              className="w-72 pl-8"
+              className="w-full pl-8 sm:w-72"
             />
           </div>
         </div>
       </header>
 
-      <div className="flex-1 overflow-y-auto p-6">
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6">
         {contacts.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center gap-2 text-center">
             {query.trim() || stage !== "all" ? (
@@ -132,11 +132,13 @@ export function ContactsClient() {
             {contacts.map((c) => (
               <li
                 key={c.id}
-                className="flex items-center gap-4 rounded-lg border bg-card px-4 py-3"
+                className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg border bg-card px-3 py-3 sm:flex-nowrap sm:gap-x-4 sm:px-4"
               >
                 <ContactAvatar name={c.name} seed={c.id} />
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
+                {/* El 60% mínimo es lo que empuja los botones a su propio
+                    renglón en el teléfono en vez de exprimir el nombre. */}
+                <div className="min-w-[60%] flex-1 sm:min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
                     <span className="truncate text-sm font-medium">
                       {c.name}
                     </span>
@@ -152,7 +154,7 @@ export function ContactsClient() {
                     {c.notes ? ` · ${c.notes.slice(0, 60)}` : ""}
                   </p>
                 </div>
-                <div className="flex shrink-0 items-center gap-1.5">
+                <div className="ml-auto flex shrink-0 items-center gap-1.5">
                   <Button
                     variant="ghost"
                     size="sm"
@@ -212,11 +214,11 @@ function EditDialog({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-overlay p-4"
       onClick={onClose}
     >
       <div
-        className="w-full max-w-md rounded-lg border bg-card p-5 shadow-xl"
+        className="max-h-[85dvh] w-full max-w-md overflow-y-auto rounded-lg border bg-card p-5 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <h3 className="mb-4 font-semibold">Editar contacto</h3>

--- a/src/components/inbox/inbox-client.tsx
+++ b/src/components/inbox/inbox-client.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { PanelRight } from "lucide-react";
+import { ChevronLeft, PanelRight } from "lucide-react";
 import { cn, formatPhone } from "@/lib/utils";
 import { ContactAvatar } from "@/components/avatar";
 import type { ConversationDto, MessageDto } from "@/lib/types";
@@ -12,23 +12,40 @@ import { MessageThread } from "./message-thread";
 import { Composer } from "./composer";
 import { ContactPanel } from "./contact-panel";
 
+/**
+ * `xl` es el umbral donde caben las tres columnas (lista + hilo + detalles).
+ * Debajo, el panel de detalles flota sobre el hilo. Debe coincidir con el
+ * breakpoint `xl:` que usan las clases de la sección de detalles.
+ */
+const PANEL_MEDIA_QUERY = "(min-width: 1280px)";
+const isWideEnoughForPanel = () =>
+  typeof window !== "undefined" && window.matchMedia(PANEL_MEDIA_QUERY).matches;
+
 export function InboxClient() {
   const [conversations, setConversations] = useState<ConversationDto[] | null>(
     null
   );
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [messages, setMessages] = useState<MessageDto[]>([]);
-  const [panelOpen, setPanelOpen] = useState(true);
+  // Arranca cerrado: en pantallas angostas el panel de detalles es un cajón
+  // ENCIMA del hilo, así que abrirlo por defecto taparía la conversación. El
+  // efecto de abajo lo abre solo si de veras hay tres columnas de ancho.
+  const [panelOpen, setPanelOpen] = useState(false);
   // Se incrementa con cada evento SSE que puede cambiar la etapa/lead o el
   // estado del agente: el panel de detalles lo observa y refetch en vivo.
   const [detailRev, setDetailRev] = useState(0);
 
   useEffect(() => {
+    if (!isWideEnoughForPanel()) return;
     setPanelOpen(localStorage.getItem("vocero.panelOpen") !== "false");
   }, []);
   const togglePanel = useCallback((open: boolean) => {
     setPanelOpen(open);
-    localStorage.setItem("vocero.panelOpen", String(open));
+    // La preferencia es de escritorio: abrir el cajón en el teléfono no debe
+    // reescribir cómo queda la Bandeja en la computadora.
+    if (isWideEnoughForPanel()) {
+      localStorage.setItem("vocero.panelOpen", String(open));
+    }
   }, []);
   const selectedIdRef = useRef<string | null>(null);
   selectedIdRef.current = selectedId;
@@ -164,7 +181,14 @@ export function InboxClient() {
 
   return (
     <div className="flex h-full">
-      <section className="w-[360px] shrink-0 overflow-hidden border-r">
+      {/* Móvil: una columna a la vez. La lista cede la pantalla completa al
+          hilo en cuanto hay conversación elegida (patrón maestro-detalle). */}
+      <section
+        className={cn(
+          "w-full shrink-0 overflow-hidden border-r md:w-[300px] lg:w-[360px]",
+          selected && "max-md:hidden"
+        )}
+      >
         <ConversationList
           conversations={conversations}
           selectedId={selectedId}
@@ -173,18 +197,31 @@ export function InboxClient() {
         />
       </section>
 
-      <section className="flex min-w-0 flex-1 flex-col">
+      <section
+        className={cn(
+          "flex min-w-0 flex-1 flex-col",
+          !selected && "max-md:hidden"
+        )}
+      >
         {selected ? (
           <>
-            <header className="flex items-center justify-between border-b bg-background px-4 py-2.5">
-              <div className="flex items-center gap-3">
+            <header className="flex items-center justify-between gap-1 border-b bg-background px-2 py-2.5 md:px-4">
+              {/* Volver a la lista: en móvil el hilo ocupa toda la pantalla. */}
+              <button
+                onClick={() => setSelectedId(null)}
+                aria-label="Volver a las conversaciones"
+                className="shrink-0 rounded-md p-1.5 text-text-2 hover:bg-accent hover:text-foreground md:hidden"
+              >
+                <ChevronLeft className="h-5 w-5" strokeWidth={1.8} />
+              </button>
+              <div className="flex min-w-0 flex-1 items-center gap-3 p-1">
                 <ContactAvatar
                   name={selected.contact.name}
                   seed={selected.contact.id}
                   size="md"
                 />
-                <div>
-                  <p className="text-[15px] font-[650] leading-tight">
+                <div className="min-w-0">
+                  <p className="truncate text-[15px] font-[650] leading-tight">
                     {selected.contact.name}
                   </p>
                   <p
@@ -204,7 +241,7 @@ export function InboxClient() {
                 <button
                   onClick={() => togglePanel(true)}
                   aria-label="Mostrar detalles"
-                  className="rounded-sm border p-1.5 text-text-3 hover:bg-accent hover:text-foreground"
+                  className="shrink-0 rounded-sm border p-1.5 text-text-3 hover:bg-accent hover:text-foreground"
                 >
                   <PanelRight className="h-4 w-4" strokeWidth={1.7} />
                 </button>
@@ -228,14 +265,29 @@ export function InboxClient() {
         )}
       </section>
 
+      {/* Velo del cajón de detalles (solo donde no caben tres columnas). */}
+      {panelOpen && selected && (
+        <button
+          aria-label="Cerrar los detalles"
+          tabIndex={-1}
+          onClick={() => togglePanel(false)}
+          className="fixed inset-0 z-30 bg-overlay xl:hidden"
+        />
+      )}
+
       <section
         className={cn(
           "shrink-0 overflow-hidden border-l transition-[width] duration-[220ms]",
-          panelOpen && selected ? "w-[320px]" : "w-0 border-l-0"
+          // Debajo de xl no hay ancho para una tercera columna: el panel se
+          // vuelve un cajón que entra desde la derecha, encima del hilo.
+          "max-xl:fixed max-xl:inset-y-0 max-xl:right-0 max-xl:z-40 max-xl:w-auto max-xl:bg-background max-xl:transition-transform",
+          panelOpen && selected
+            ? "w-[320px] max-xl:translate-x-0 max-xl:shadow-pop"
+            : "w-0 border-l-0 max-xl:translate-x-full"
         )}
       >
         {selected && (
-          <div className="h-full w-[320px]">
+          <div className="h-full w-[320px] max-xl:w-[min(320px,88vw)]">
             <ContactPanel
               conversation={selected}
               refreshKey={detailRev}

--- a/src/components/inbox/message-thread.tsx
+++ b/src/components/inbox/message-thread.tsx
@@ -193,7 +193,7 @@ export function MessageThread({ messages }: { messages: MessageDto[] }) {
   return (
     <div
       ref={scrollRef}
-      className="flex flex-1 flex-col gap-[3px] overflow-y-auto bg-chat px-[6%] py-5"
+      className="flex flex-1 flex-col gap-[3px] overflow-y-auto bg-chat px-3 py-5 sm:px-[6%]"
     >
       {messages.map((m, i) => {
         const prev = messages[i - 1];
@@ -223,7 +223,9 @@ export function MessageThread({ messages }: { messages: MessageDto[] }) {
             >
               <div
                 className={cn(
-                  "max-w-[64%] rounded-lg px-3 pb-1.5 pt-2 text-sm leading-[1.45] shadow-sm",
+                  // En el teléfono la burbuja necesita casi todo el renglón:
+                  // con 64% cada mensaje se parte en tres líneas.
+                  "max-w-[85%] rounded-lg px-3 pb-1.5 pt-2 text-sm leading-[1.45] shadow-sm sm:max-w-[64%]",
                   out
                     ? "border border-brand-soft bg-bubble-out text-bubble-out-text"
                     : "bg-background",

--- a/src/components/lab/lab-client.tsx
+++ b/src/components/lab/lab-client.tsx
@@ -145,7 +145,7 @@ export function LabClient() {
         onLaunch={() => void launch()}
         disabled={false}
       />
-      {error && <p className="px-6 pt-3 text-sm text-destructive">{error}</p>}
+      {error && <p className="px-4 pt-3 text-sm text-destructive sm:px-6">{error}</p>}
 
       {running && progress && (
         <div className="mx-6 mt-4 rounded-lg border bg-card p-4">
@@ -164,7 +164,7 @@ export function LabClient() {
         </div>
       )}
 
-      <div className="grid gap-6 p-6 lg:grid-cols-[280px_1fr]">
+      <div className="grid gap-4 p-4 sm:gap-6 sm:p-6 lg:grid-cols-[280px_1fr]">
         <HistoryList
           runs={runs}
           selectedRunId={selectedRunId}
@@ -196,7 +196,7 @@ function Header({
   disabled: boolean;
 }) {
   return (
-    <header className="flex items-center justify-between border-b px-6 py-4">
+    <header className="flex flex-wrap items-center justify-between gap-2 border-b px-4 py-3 sm:px-6 sm:py-4">
       <div>
         <h2 className="flex items-center gap-2 font-semibold">
           <FlaskConical className="h-4 w-4 text-primary" /> Laboratorio

--- a/src/components/pipeline/pipeline-client.tsx
+++ b/src/components/pipeline/pipeline-client.tsx
@@ -80,14 +80,16 @@ export function PipelineClient() {
 
   return (
     <div className="flex h-full flex-col">
-      <header className="flex items-center justify-between border-b px-6 py-4">
+      <header className="flex flex-wrap items-center justify-between gap-2 border-b px-4 py-3 sm:px-6 sm:py-4">
         <h2 className="font-semibold">Pipeline</h2>
         <Button variant="outline" size="sm" onClick={() => setManaging(true)}>
           <Settings2 className="h-4 w-4" /> Gestionar etapas
         </Button>
       </header>
 
-      <div className="flex-1 overflow-x-auto p-4">
+      {/* El tablero se arrastra en horizontal; en el teléfono cada columna
+          se detiene en su sitio (snap) para no quedar a medio camino. */}
+      <div className="flex-1 snap-x snap-mandatory overflow-x-auto p-3 sm:snap-none sm:p-4">
         <DndContext
           sensors={sensors}
           onDragStart={onDragStart}
@@ -127,7 +129,7 @@ function StageColumn({ stage, leads }: { stage: StageDto; leads: BoardLead[] }) 
     <div
       ref={setNodeRef}
       className={cn(
-        "flex h-full w-64 shrink-0 flex-col rounded-lg border bg-card/50",
+        "flex h-full w-64 shrink-0 snap-start flex-col rounded-lg border bg-card/50",
         isOver && "ring-2 ring-primary/60"
       )}
     >

--- a/src/components/pipeline/stage-manager.tsx
+++ b/src/components/pipeline/stage-manager.tsx
@@ -90,11 +90,11 @@ export function StageManager({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-overlay p-4"
       onClick={onClose}
     >
       <div
-        className="w-full max-w-lg rounded-lg border bg-card p-5 shadow-xl"
+        className="max-h-[85dvh] w-full max-w-lg overflow-y-auto rounded-lg border bg-card p-5 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <h3 className="mb-4 font-semibold">Etapas del pipeline</h3>

--- a/src/components/settings/settings-nav.tsx
+++ b/src/components/settings/settings-nav.tsx
@@ -14,13 +14,13 @@ const TABS = [
 export function SettingsNav() {
   const pathname = usePathname();
   return (
-    <nav className="w-44 shrink-0 space-y-1 border-r p-3">
+    <nav className="flex shrink-0 gap-1 overflow-x-auto border-b p-2 sm:w-44 sm:flex-col sm:space-y-1 sm:overflow-visible sm:border-b-0 sm:border-r sm:p-3">
       {TABS.map((t) => (
         <Link
           key={t.href}
           href={t.href}
           className={cn(
-            "block rounded-md px-3 py-2 text-sm font-medium transition-colors",
+            "block shrink-0 whitespace-nowrap rounded-md px-3 py-2 text-sm font-medium transition-colors",
             pathname.startsWith(t.href)
               ? "bg-brand-tint text-brand-text"
               : "text-muted-foreground hover:bg-accent hover:text-foreground"

--- a/tests/e2e/responsividad.md
+++ b/tests/e2e/responsividad.md
@@ -1,0 +1,85 @@
+# Responsividad — el CRM se usa desde el teléfono
+
+Guion de comportamiento (2026-08-14). Automatizado en
+`scripts/e2e-responsive.mjs`.
+
+Origen: la app se diseñó para escritorio (lateral fijo de 224 px + Bandeja de
+tres columnas). Debajo de ~1000 px el lateral se comía media pantalla, el hilo
+quedaba en una franja de unos 100 px y el compositor caía fuera del área
+visible del navegador móvil.
+
+## Preparación
+
+App corriendo con mocks (`WA_MOCK_ENABLED=true`, `META_GRAPH_BASE_URL` →
+wa-mock) y BD con migraciones aplicadas. Un contacto entrante de prueba con
+conversación abierta.
+
+Tres tamaños: teléfono 390×844, tableta 820×1180, escritorio 1440×900.
+
+## AC-1 — Ninguna pantalla recorta contenido a lo ancho
+
+Recorre Bandeja, Pipeline, Contactos, Agente, Laboratorio y
+Ajustes → WhatsApp en los tres tamaños.
+
+Esperado: en cada una, el contenido de `main` cabe en su ancho visible
+(`scrollWidth == clientWidth`) y el documento no genera scroll horizontal. El
+tablero del Pipeline sí se arrastra en horizontal, pero **dentro** de su propio
+contenedor, con las columnas ancladas (snap).
+
+## AC-2 — El lateral se vuelve cajón en el teléfono
+
+1. Abre cualquier pantalla en 390×844.
+
+Esperado: se ve la barra superior con la hamburguesa y la marca; los enlaces
+del lateral **no** son alcanzables (están fuera del orden de tabulación).
+
+2. Toca la hamburguesa.
+
+Esperado: el cajón entra desde la izquierda **encima** del contenido (no lo
+empuja: `main` sigue empezando en x=0), con velo detrás.
+
+3. Toca "Bandeja".
+
+Esperado: navega y el cajón se cierra solo. También cierra con Escape, con el
+velo y con su propia ✕.
+
+## AC-3 — La Bandeja es maestro-detalle en el teléfono
+
+1. Abre la Bandeja sin conversación elegida.
+
+Esperado: la lista ocupa el ancho completo (390 px), no una columna de 360 px
+con el hilo aplastado al lado.
+
+2. Toca una conversación.
+
+Esperado: el hilo ocupa toda la pantalla, la lista desaparece y aparece un
+botón "Volver a las conversaciones" que la regresa.
+
+3. Mira el compositor.
+
+Esperado: queda **dentro** de la pantalla (la altura del cascarón es `100dvh`,
+no `100vh`) y su tipografía mide ≥16 px, que es lo que evita que Safari en iOS
+haga zoom al enfocar y deje el CRM descuadrado. Lo mismo aplica a todo campo de
+texto por debajo de `md`.
+
+## AC-4 — Los detalles del contacto flotan sobre el hilo
+
+1. Con el hilo abierto en el teléfono, toca "Mostrar detalles".
+
+Esperado: el panel arranca **cerrado** (la preferencia guardada solo manda en
+escritorio) y entra como cajón pegado al borde derecho, encima del hilo, sin
+robarle ancho ni provocar scroll horizontal. Cierra con su ✕ o con el velo.
+
+Debajo de `xl` (1280 px) el panel siempre es cajón; a partir de ahí vuelve a ser
+la tercera columna.
+
+## AC-5 — En tableta conviven lista e hilo
+
+En 820×1180 la Bandeja muestra dos columnas (lista ~300 px + hilo), y el panel
+de detalles sigue siendo cajón.
+
+## AC-6 — En escritorio nada cambió
+
+En 1440×900: lateral fijo de 224 px sin hamburguesa, Bandeja de tres columnas
+(lista 360 px + hilo + detalles 320 px) y la preferencia de "panel abierto"
+persistida como siempre.


### PR DESCRIPTION
> Apilado sobre #16 (tema oscuro): usa los tokens `bg-overlay` y `text-brand-fg`
> que ese PR introduce. Sin ellos, Tailwind no emite las reglas y el velo del
> cajón se pinta transparente — **sin romper el build**. Al mergear: #16 primero.

Vocero se diseñó para escritorio: lateral fijo de 224 px y Bandeja de tres
columnas. Debajo de ~1000 px el hilo quedaba en una franja inservible, y en un
teléfono el lateral se comía media pantalla — justo cuando más falta hace
contestar, que es fuera del escritorio.

## Qué cambia

Un cascarón nuevo (`app-shell.tsx`, 98 líneas) con barra superior y hamburguesa:

- El **lateral** pasa a cajón sobre velo por debajo de `lg`, y se cierra solo al
  navegar.
- La **Bandeja** se vuelve maestro-detalle por debajo de `md`: la lista ocupa la
  pantalla, elegir una conversación abre el hilo, y hay botón de volver.
- El **panel de detalles** entra como cajón por debajo de `xl`, y arranca
  **cerrado** para no tapar la conversación. La preferencia sigue siendo de
  escritorio: abrir el cajón en el teléfono no reescribe cómo queda en la
  computadora.

## Dos detalles que no son evidentes y sí se notan

**`100dvh`, no `100vh`.** Con la barra del navegador móvil, `vh` deja el
compositor fuera del borde visible: escribes y no ves lo que escribes.

**Todo campo de texto mide al menos 16 px.** Safari en iOS hace zoom automático
al enfocar un campo con tipografía menor, y ese zoom descuadra el layout entero
sin volver atrás. Es la clase de regla que se pierde en un refactor si no está
escrita.

El tablero del Pipeline sigue arrastrándose en horizontal, pero **dentro** de su
contenedor y con las columnas ancladas (snap), no haciendo scrollear la página.

## Verificación

```
pnpm typecheck   ✓
pnpm lint        ✓
pnpm test        ✓  168 pruebas
pnpm build       ✓
pnpm test:e2e    ✓  87/87, sin regresión
```

Y un guion nuevo con Playwright en **tres tamaños reales**
(`scripts/e2e-responsive.mjs`), porque esto no se verifica leyendo CSS:

| Tamaño | Qué se comprobó |
|---|---|
| 390×844 (teléfono) | las 6 pantallas sin recorte horizontal · el cajón abre, flota, navega y se cierra solo · la Bandeja alterna lista↔hilo con botón de volver · el compositor dentro de la pantalla y con ≥16 px · los detalles como cajón sin desbordar |
| 820×1180 (tableta) | sin recorte, y conviven lista e hilo en dos columnas |
| 1440×900 (escritorio) | **nada cambió**: lateral 224 + lista 360 + hilo + detalles 320, sin hamburguesa |

El guion deja capturas en `scratch/`, que se añade al `.gitignore`.

## Nota de revisión

Si #18 (envío instantáneo) se mergea antes que esto, el rebase toca
`inbox-client.tsx`. Los cambios están en zonas distintas del archivo —aquel
reescribe `sendText`, este el JSX del layout— así que git debería resolverlo
solo; si no, es un hunk manual de un minuto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
