### PR TITLE
chore: llevar a main las plantillas multivariable (#17) y la responsividad (#19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ Thumbs.db
 .playwright-mcp/
 .tmp-seed-demo.mjs
 .dev-media/
+# Capturas y salidas de los self-tests (p. ej. scripts/e2e-responsive.mjs)
+scratch/

--- a/README.md
+++ b/README.md
@@ -98,9 +98,10 @@ Agente de referencia: [nea-agent](https://github.com/kevinrivm/nea-agent), MIT.
 
 ### 📄 Plantillas · 👥 Multi-usuario · 🔐 Self-hosted
 
-Plantillas con una variable y aprobación de Meta sincronizada; cuentas de
-equipo creadas por el propietario (el registro público se cierra tras la
-primera organización); token de WhatsApp cifrado en reposo (AES-256-GCM),
+Plantillas con varias variables `{{1}}…{{n}}` y aprobación de Meta
+sincronizada; cuentas de equipo creadas por el propietario (el registro público
+se cierra tras la primera organización); token de WhatsApp cifrado en reposo
+(AES-256-GCM),
 webhook autenticado en dos capas y cero dependencias de runtime más allá de
 Meta y tu proveedor LLM opcional.
 
@@ -295,7 +296,7 @@ base64 (44 caracteres): `openssl rand -base64 32`.
 - Multimedia completa en la bandeja (hoy: indicador de tipo).
 - RAG para knowledge bases grandes (hoy: se inyecta completo con aviso de tamaño).
 - Personas configurables del Laboratorio y comparativas entre corridas.
-- Variables múltiples y borrado de plantillas.
+- Borrado de plantillas desde la app.
 - Analytics de conversación y plantillas.
 - Broadcast con opt-in verificado.
 

--- a/scripts/e2e-responsive.mjs
+++ b/scripts/e2e-responsive.mjs
@@ -1,0 +1,324 @@
+/**
+ * Self-test E2E de comportamiento — responsividad (teléfono / tableta / escritorio).
+ * Guion: tests/e2e/responsividad.md
+ *
+ * Verifica que el CRM se pueda USAR desde el teléfono, no solo que "quepa":
+ *  - el lateral se vuelve cajón con hamburguesa y se cierra al navegar;
+ *  - la Bandeja se comporta como maestro-detalle (lista ↔ hilo con "volver");
+ *  - el panel de detalles flota sobre el hilo en vez de robarle ancho;
+ *  - ninguna pantalla recorta contenido a lo ancho (main no desborda);
+ *  - los campos de texto miden ≥16px (si no, iOS hace zoom y descuadra todo);
+ *  - en escritorio NADA de lo anterior cambia (el lateral sigue fijo).
+ *
+ * Uso: node scripts/e2e-responsive.mjs
+ * Requiere: app corriendo (pnpm dev) con WA_MOCK_ENABLED=true y Playwright.
+ */
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+
+const BASE = process.env.APP_BASE_URL ?? "http://localhost:3000";
+const PN = "PN-RESP-1";
+const S = Math.random().toString(36).slice(2, 6).toUpperCase();
+const SHOTS = "scratch/responsive";
+let failures = 0;
+const ok = (name, cond, extra = "") => {
+  if (cond) console.log(`  ✓ ${name}`);
+  else {
+    failures++;
+    console.log(`  ✗ ${name}${extra ? ` — ${extra}` : ""}`);
+  }
+};
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const until = async (fn, ms = 20000) => {
+  const t0 = Date.now();
+  for (;;) {
+    try {
+      if (await fn()) return true;
+    } catch {
+      /* reintenta */
+    }
+    if (Date.now() - t0 > ms) return false;
+    await sleep(250);
+  }
+};
+
+const PHONE = { width: 390, height: 844 };
+const TABLET = { width: 820, height: 1180 };
+const DESKTOP = { width: 1440, height: 900 };
+const RUTAS = [
+  "/inbox",
+  "/pipeline",
+  "/contacts",
+  "/agent",
+  "/lab",
+  "/settings/whatsapp",
+];
+
+mkdirSync(SHOTS, { recursive: true });
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({ viewport: DESKTOP });
+const req = ctx.request;
+// El canal SSE se corta en el navegador: no aporta nada al diseño y cada
+// stream vivo ocupa una ranura del servidor de `next dev` — a la ~15ª carga
+// el servidor deja de contestar (se cuelga el guion, no el producto).
+await ctx.route("**/api/events*", (route) => route.abort());
+
+console.log("== Setup ==");
+let r = await req.post(`${BASE}/api/auth/sign-up/email`, {
+  headers: { origin: BASE },
+  data: {
+    email: "e2e@vocero.test",
+    password: "password-e2e-123",
+    name: "Operador E2E",
+  },
+});
+if (!r.ok())
+  r = await req.post(`${BASE}/api/auth/sign-in/email`, {
+    headers: { origin: BASE },
+    data: { email: "e2e@vocero.test", password: "password-e2e-123" },
+  });
+ok("login", r.ok());
+await req.put(`${BASE}/api/settings/whatsapp`, {
+  data: { wabaId: "WABA-RESP", phoneNumberId: PN, token: "tok-resp" },
+});
+
+const NAME = `Prospecto${S}`;
+await req.post(`${BASE}/api/dev/wa-mock/inbound`, {
+  data: {
+    phoneNumberId: PN,
+    from: `521462${Math.floor(Math.random() * 9e6) + 1e6}`,
+    name: NAME,
+    text: "hola, vi su anuncio y quiero saber cuánto cuesta el diagnóstico",
+    waMessageId: `wamid.resp.${S}`,
+  },
+});
+const listo = await until(async () => {
+  const d = await (await req.get(`${BASE}/api/conversations`)).json();
+  return d.conversations.some((c) => c.contact.name === NAME);
+});
+ok("conversación de prueba creada", listo);
+
+// Calienta cada ruta: en `pnpm dev` la primera visita compila (3-4 s) y el
+// guion mediría la compilación, no el diseño.
+// La primera visita a cada ruta la COMPILA (`next dev`), y algunas pasan de
+// los 30 s por defecto de Playwright. Se calientan por HTTP, sin navegador: un
+// `page.goto` abriría además el canal SSE de la app, y varias páginas con SSE
+// vivo a la vez dejan clavado al servidor de desarrollo.
+ctx.setDefaultNavigationTimeout(120000);
+ctx.setDefaultTimeout(30000);
+for (const ruta of RUTAS) {
+  await req.get(`${BASE}${ruta}`, { timeout: 180000 });
+}
+
+/** Ancho real del contenido contra el ancho visible del contenedor. */
+const desborde = (page) =>
+  page.evaluate(() => {
+    const main = document.querySelector("main");
+    const doc = document.documentElement;
+    return {
+      mainOver: main ? main.scrollWidth - main.clientWidth : 0,
+      docOver: doc.scrollWidth - window.innerWidth,
+    };
+  });
+
+async function recorrer(page, etiqueta) {
+  for (const ruta of RUTAS) {
+    await page.goto(`${BASE}${ruta}`, { waitUntil: "domcontentloaded" });
+    // Nada de `networkidle`: el canal SSE queda abierto a propósito y la
+    // espera nunca se cumpliría.
+    await sleep(900);
+    const d = await desborde(page);
+    ok(
+      `${etiqueta} ${ruta} sin recorte horizontal`,
+      d.mainOver <= 1 && d.docOver <= 1,
+      `main +${d.mainOver}px · documento +${d.docOver}px`
+    );
+    await page.screenshot({
+      path: `${SHOTS}/${etiqueta}${ruta.replace(/\//g, "-")}.png`,
+      fullPage: false,
+    });
+  }
+}
+
+console.log("\n== 1. Teléfono (390×844): ninguna pantalla se recorta ==");
+const phone = await ctx.newPage();
+await phone.setViewportSize(PHONE);
+await recorrer(phone, "phone");
+
+console.log("\n== 2. Teléfono: el lateral es un cajón con hamburguesa ==");
+await phone.goto(`${BASE}/pipeline`);
+const hamburguesa = phone.getByRole("button", { name: "Abrir el menú" });
+await hamburguesa.waitFor({ timeout: 20000 });
+ok("la hamburguesa se ve", await hamburguesa.isVisible());
+const linkBandeja = phone.getByRole("link", { name: /Bandeja/ });
+ok(
+  "el lateral arranca oculto (sus enlaces no son alcanzables)",
+  !(await linkBandeja.isVisible())
+);
+await hamburguesa.click();
+ok(
+  "al tocar la hamburguesa el cajón abre",
+  await until(async () => await linkBandeja.isVisible(), 3000)
+);
+// El cajón NO debe empujar el contenido: sale encima.
+const encima = await phone.evaluate(() => {
+  const aside = document.querySelector("aside");
+  const main = document.querySelector("main");
+  if (!aside || !main) return null;
+  const a = aside.getBoundingClientRect();
+  const m = main.getBoundingClientRect();
+  return { asideLeft: Math.round(a.left), mainLeft: Math.round(m.left) };
+});
+ok(
+  "el cajón flota encima del contenido (no lo empuja)",
+  encima !== null && encima.asideLeft <= 1 && encima.mainLeft <= 1,
+  JSON.stringify(encima)
+);
+await phone.screenshot({ path: `${SHOTS}/phone-cajon-abierto.png` });
+await linkBandeja.click();
+await until(async () => phone.url().includes("/inbox"), 15000);
+ok("navegar desde el cajón lleva a la Bandeja", phone.url().includes("/inbox"));
+ok(
+  "el cajón se cierra solo al navegar",
+  await until(async () => !(await linkBandeja.isVisible()), 5000)
+);
+
+console.log("\n== 3. Teléfono: la Bandeja es maestro-detalle ==");
+await phone.goto(`${BASE}/inbox`);
+const fila = phone.getByText(NAME).first();
+await fila.waitFor({ timeout: 20000 });
+ok("la lista de conversaciones ocupa la pantalla", await fila.isVisible());
+const anchoLista = await phone.evaluate(() => {
+  const sec = document.querySelector("main > div > section");
+  return sec ? Math.round(sec.getBoundingClientRect().width) : 0;
+});
+ok(
+  "la lista usa el ancho completo del teléfono",
+  anchoLista >= PHONE.width - 8,
+  `${anchoLista}px de ${PHONE.width}`
+);
+await fila.click();
+const composer = phone.getByPlaceholder("Escribe una respuesta");
+ok(
+  "al elegir una conversación se abre el hilo",
+  await until(async () => await composer.isVisible(), 15000)
+);
+ok("la lista cede la pantalla al hilo", !(await fila.isVisible()));
+const volver = phone.getByRole("button", { name: "Volver a las conversaciones" });
+ok("aparece el botón de volver", await volver.isVisible());
+await phone.screenshot({ path: `${SHOTS}/phone-hilo.png` });
+
+// El compositor debe quedar DENTRO de la pantalla (100dvh, no 100vh).
+const compBox = await composer.boundingBox();
+ok(
+  "el compositor queda dentro de la pantalla",
+  compBox !== null && compBox.y + compBox.height <= PHONE.height,
+  compBox ? `borde inferior en ${Math.round(compBox.y + compBox.height)}px` : "sin caja"
+);
+// iOS: menos de 16px = zoom automático al enfocar.
+const fuenteComp = await composer.evaluate((el) =>
+  parseFloat(getComputedStyle(el).fontSize)
+);
+ok(
+  "el compositor usa ≥16px (iOS no hace zoom al enfocar)",
+  fuenteComp >= 16,
+  `${fuenteComp}px`
+);
+
+console.log("\n== 4. Teléfono: los detalles flotan sobre el hilo ==");
+const abrirDetalles = phone.getByRole("button", { name: "Mostrar detalles" });
+ok("el panel de detalles arranca cerrado en el teléfono", await abrirDetalles.isVisible());
+await abrirDetalles.click();
+await sleep(500);
+const cajonDetalles = await phone.evaluate(() => {
+  const secs = [...document.querySelectorAll("main > div > section")];
+  const panel = secs[secs.length - 1];
+  if (!panel) return null;
+  const r = panel.getBoundingClientRect();
+  return {
+    right: Math.round(r.right),
+    width: Math.round(r.width),
+    fixed: getComputedStyle(panel).position === "fixed",
+  };
+});
+ok(
+  "los detalles entran como cajón pegado al borde derecho",
+  cajonDetalles !== null &&
+    cajonDetalles.fixed &&
+    Math.abs(cajonDetalles.right - PHONE.width) <= 2 &&
+    cajonDetalles.width <= PHONE.width,
+  JSON.stringify(cajonDetalles)
+);
+const dEnDetalles = await desborde(phone);
+ok(
+  "con los detalles abiertos la pantalla sigue sin recortarse",
+  dEnDetalles.docOver <= 1,
+  `documento +${dEnDetalles.docOver}px`
+);
+await phone.screenshot({ path: `${SHOTS}/phone-detalles.png` });
+await phone
+  .getByRole("button", { name: "Cerrar los detalles" })
+  .click()
+  .catch(() => null);
+await sleep(400);
+
+console.log("\n== 5. Tableta (820×1180) ==");
+const tablet = phone;
+await tablet.setViewportSize(TABLET);
+await recorrer(tablet, "tablet");
+await tablet.goto(`${BASE}/inbox`);
+await tablet.getByText(NAME).first().click();
+await tablet.getByPlaceholder("Escribe una respuesta").waitFor({ timeout: 20000 });
+const dosColumnas = await tablet.evaluate(() => {
+  const secs = [...document.querySelectorAll("main > div > section")];
+  return secs.slice(0, 2).map((s) => Math.round(s.getBoundingClientRect().width));
+});
+ok(
+  "en tableta conviven lista e hilo (dos columnas)",
+  dosColumnas.length === 2 && dosColumnas[0] > 200 && dosColumnas[1] > 300,
+  JSON.stringify(dosColumnas)
+);
+await tablet.screenshot({ path: `${SHOTS}/tablet-inbox.png` });
+
+console.log("\n== 6. Escritorio (1440×900): nada cambió ==");
+const desk = tablet;
+await desk.setViewportSize(DESKTOP);
+await recorrer(desk, "desktop");
+await desk.goto(`${BASE}/inbox`);
+await desk.getByText(NAME).first().click();
+await desk.getByPlaceholder("Escribe una respuesta").waitFor({ timeout: 20000 });
+ok(
+  "el lateral sigue fijo (sin hamburguesa)",
+  !(await desk.getByRole("button", { name: "Abrir el menú" }).isVisible()) &&
+    (await desk.getByRole("link", { name: /Bandeja/ }).isVisible())
+);
+const medirColumnas = () =>
+  desk.evaluate(() => {
+    const aside = document.querySelector("aside");
+    const secs = [...document.querySelectorAll("main > div > section")];
+    return {
+      aside: aside ? Math.round(aside.getBoundingClientRect().width) : 0,
+      secs: secs.map((s) => Math.round(s.getBoundingClientRect().width)),
+    };
+  });
+// El panel abre con transición de 220 ms: medir apenas aparece el compositor
+// atraparía un ancho a medio camino.
+const columnasOk = (t) =>
+  t.aside === 224 && t.secs[0] === 360 && t.secs.at(-1) === 320;
+await until(async () => columnasOk(await medirColumnas()), 8000);
+const tres = await medirColumnas();
+ok(
+  "escritorio conserva lateral 224px + lista 360px + hilo + detalles 320px",
+  columnasOk(tres),
+  JSON.stringify(tres)
+);
+await desk.screenshot({ path: `${SHOTS}/desktop-inbox.png` });
+
+console.log(
+  failures === 0
+    ? `\n✅ Responsividad: todo verde. Capturas en ${SHOTS}/`
+    : `\n❌ Responsividad: ${failures} fallo(s). Capturas en ${SHOTS}/`
+);
+await browser.close();
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/e2e-templates-multivar.mjs
+++ b/scripts/e2e-templates-multivar.mjs
@@ -1,0 +1,253 @@
+/**
+ * Self-test E2E de comportamiento — plantillas con VARIAS variables
+ * (guion tests/e2e/us6-templates.md, sección "multivariable").
+ *
+ * Reproduce el bloqueo reportado el 2026-08-09: el CRM rechazaba en la propia
+ * pantalla un cuerpo con {{1}} {{2}} {{3}} ("v1 admite una sola variable"),
+ * aunque Meta las acepta. Cubre alta, aprobación, envío con N parámetros y los
+ * caminos infelices (numeración con saltos, valor faltante).
+ *
+ * Uso: node --env-file=.env scripts/e2e-templates-multivar.mjs
+ * Requiere: app corriendo (pnpm dev) con WA_MOCK_ENABLED=true y BD migrada.
+ */
+
+const BASE = process.env.APP_BASE_URL ?? "http://localhost:3000";
+
+let cookie = "";
+let failures = 0;
+let checks = 0;
+
+function ok(name, cond, extra = "") {
+  checks++;
+  if (cond) {
+    console.log(`  ✓ ${name}`);
+  } else {
+    failures++;
+    console.log(`  ✗ ${name}${extra ? ` — ${extra}` : ""}`);
+  }
+}
+
+async function api(path, opts = {}) {
+  const res = await fetch(`${BASE}${path}`, {
+    ...opts,
+    headers: {
+      "content-type": "application/json",
+      origin: BASE,
+      ...(cookie ? { cookie } : {}),
+      ...(opts.headers ?? {}),
+    },
+  });
+  const setCookie = res.headers.getSetCookie?.() ?? [];
+  if (setCookie.length) {
+    cookie = setCookie.map((c) => c.split(";")[0]).join("; ");
+  }
+  let json = null;
+  try {
+    json = await res.clone().json();
+  } catch {}
+  return { res, json };
+}
+
+const PN = "PN-TPLMV-1";
+const WABA = "WABA-TPLMV";
+const FROM = "5215599990001";
+const stamp = Date.now().toString(36);
+
+async function findTemplate(name) {
+  const { json } = await api("/api/templates");
+  return (json?.templates ?? []).find((t) => t.name === name);
+}
+
+function metaApproves(name) {
+  return api("/api/dev/wa-mock/template-status", {
+    method: "POST",
+    body: JSON.stringify({
+      wabaId: WABA,
+      name,
+      language: "es_MX",
+      event: "APPROVED",
+      notify: false,
+    }),
+  });
+}
+
+async function lastOutbound() {
+  const { json } = await api("/api/dev/wa-mock/outbox");
+  const list = json?.outbox ?? [];
+  return list[list.length - 1] ?? null;
+}
+
+async function main() {
+  console.log("== Setup: registro + conexión WhatsApp ==");
+  const email = "e2e@vocero.test";
+  const password = "password-e2e-123";
+  let su = await api("/api/auth/sign-up/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password, name: "Operador E2E" }),
+  });
+  if (!su.res.ok) {
+    su = await api("/api/auth/sign-in/email", {
+      method: "POST",
+      body: JSON.stringify({ email, password }),
+    });
+  }
+  ok("registro o login del operador", su.res.ok, JSON.stringify(su.json));
+
+  const conn = await api("/api/settings/whatsapp", {
+    method: "PUT",
+    body: JSON.stringify({ wabaId: WABA, phoneNumberId: PN, token: "tok-mv" }),
+  });
+  ok("conexión WhatsApp guardada", conn.res.ok, JSON.stringify(conn.json));
+
+  console.log("\n== Alta: cuerpo con TRES variables ==");
+  const name = `confirmacion_cita_${stamp}`;
+  const body =
+    "Hola {{1}} 👋 Te confirmamos tu cita:\n" +
+    "🗓 {{2}} a las {{3}} · 20-30 min";
+  const created = await api("/api/templates", {
+    method: "POST",
+    body: JSON.stringify({ name, language: "es_MX", category: "UTILITY", body }),
+  });
+  ok(
+    "plantilla de 3 variables aceptada (antes: 422 'una sola variable')",
+    created.res.ok,
+    JSON.stringify(created.json)
+  );
+
+  const remote = await api(`/api/dev/wa-mock/graph/${WABA}/message_templates`);
+  const atMeta = (remote.json?.data ?? []).find((t) => t.name === name);
+  const bodyComp = (atMeta?.components ?? []).find(
+    (c) => (c.type ?? "").toUpperCase() === "BODY"
+  );
+  ok("Meta la recibió", Boolean(atMeta), JSON.stringify(remote.json));
+  ok(
+    "se mandó UN ejemplo por variable (si no, Meta responde 100)",
+    (bodyComp?.example?.body_text?.[0] ?? []).length === 3,
+    JSON.stringify(bodyComp?.example)
+  );
+
+  console.log("\n== Camino infeliz: numeración con saltos ==");
+  const gap = await api("/api/templates", {
+    method: "POST",
+    body: JSON.stringify({
+      name: `salto_${stamp}`,
+      language: "es_MX",
+      category: "UTILITY",
+      body: "Hola {{1}}, tu pedido {{3}} llegó",
+    }),
+  });
+  ok("422 con salto en la numeración", gap.res.status === 422, String(gap.res.status));
+  ok(
+    "el mensaje explica la regla",
+    /sin saltos/.test(gap.json?.error?.message ?? ""),
+    JSON.stringify(gap.json)
+  );
+
+  console.log("\n== Aprobación y conversación ==");
+  await metaApproves(name);
+  const sync = await api("/api/templates/sync", { method: "POST" });
+  ok("sync 200", sync.res.ok, JSON.stringify(sync.json));
+  const local = await findTemplate(name);
+  ok("estado = approved", local?.status === "approved", local?.status);
+
+  const inbound = await api("/api/dev/wa-mock/inbound", {
+    method: "POST",
+    body: JSON.stringify({
+      phoneNumberId: PN,
+      from: FROM,
+      name: "Lead Multivar",
+      text: "Hola, quiero la sesión",
+    }),
+  });
+  ok("inbound entregado", inbound.res.ok, JSON.stringify(inbound.json));
+  const convs = await api("/api/conversations");
+  const conv = (convs.json?.conversations ?? []).find(
+    (c) => (c.contact?.phone ?? "").includes("5599990001")
+  );
+  ok("conversación creada", Boolean(conv?.id), JSON.stringify(convs.json)?.slice(0, 200));
+
+  console.log("\n== Camino infeliz: falta un valor ==");
+  const short = await api(`/api/conversations/${conv?.id}/messages/template`, {
+    method: "POST",
+    body: JSON.stringify({
+      templateId: local?.id,
+      variables: ["María", "12 de agosto"],
+    }),
+  });
+  ok("422 si faltan valores", short.res.status === 422, String(short.res.status));
+  ok(
+    "dice cuál falta",
+    /\{\{3\}\}/.test(short.json?.error?.message ?? ""),
+    JSON.stringify(short.json)
+  );
+
+  console.log("\n== Envío con los 3 valores ==");
+  const sent = await api(`/api/conversations/${conv?.id}/messages/template`, {
+    method: "POST",
+    body: JSON.stringify({
+      templateId: local?.id,
+      variables: ["María", "12 de agosto", "5:00 pm"],
+    }),
+  });
+  ok("envío 200", sent.res.ok, JSON.stringify(sent.json));
+
+  const out = await lastOutbound();
+  const params =
+    out?.body?.template?.components?.find((c) => c.type === "body")?.parameters ??
+    [];
+  ok("Meta recibió type=template", out?.body?.type === "template", out?.body?.type);
+  ok("3 parámetros en orden", params.length === 3, JSON.stringify(params));
+  ok(
+    "los valores van en su posición",
+    params[0]?.text === "María" &&
+      params[1]?.text === "12 de agosto" &&
+      params[2]?.text === "5:00 pm",
+    JSON.stringify(params)
+  );
+
+  const msgs = await api(`/api/conversations/${conv?.id}/messages`);
+  const list = msgs.json?.messages ?? [];
+  const tplMsg = [...list].reverse().find((m) => m.type === "template");
+  ok(
+    "el hilo muestra el texto ya sustituido",
+    tplMsg?.text?.includes("Hola María") &&
+      tplMsg?.text?.includes("12 de agosto a las 5:00 pm"),
+    tplMsg?.text
+  );
+
+  console.log("\n== Compatibilidad: plantilla de UNA variable con `variable` ==");
+  const oneName = `una_var_${stamp}`;
+  const one = await api("/api/templates", {
+    method: "POST",
+    body: JSON.stringify({
+      name: oneName,
+      language: "es_MX",
+      category: "UTILITY",
+      body: "Hola {{1}} 👋 ¿Retomamos tu cotización?",
+    }),
+  });
+  ok("alta de una variable sigue OK", one.res.ok, JSON.stringify(one.json));
+  await metaApproves(oneName);
+  await api("/api/templates/sync", { method: "POST" });
+  const oneLocal = await findTemplate(oneName);
+  const legacy = await api(`/api/conversations/${conv?.id}/messages/template`, {
+    method: "POST",
+    body: JSON.stringify({ templateId: oneLocal?.id, variable: "María" }),
+  });
+  ok("el payload viejo {variable} sigue enviando", legacy.res.ok, JSON.stringify(legacy.json));
+  const outOne = await lastOutbound();
+  const paramsOne =
+    outOne?.body?.template?.components?.find((c) => c.type === "body")
+      ?.parameters ?? [];
+  ok("1 parámetro", paramsOne.length === 1 && paramsOne[0]?.text === "María", JSON.stringify(paramsOne));
+
+  console.log(
+    `\n${failures === 0 ? "TODO VERDE" : "CON FALLOS"} — ${checks - failures}/${checks} checks`
+  );
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -4,7 +4,7 @@ import { getAuth } from "@/lib/auth";
 import { getSessionOrNull } from "@/lib/auth/session";
 import { normalizeThemePreference, THEME_COOKIE } from "@/lib/theme";
 import { getBranding } from "@/server/branding";
-import { AppNav } from "@/components/app-nav";
+import { AppShell } from "@/components/app-shell";
 
 export default async function AppLayout({
   children,
@@ -20,14 +20,13 @@ export default async function AppLayout({
   );
 
   return (
-    <div className="flex h-screen overflow-hidden bg-background">
-      <AppNav
-        branding={branding}
-        userName={authSession?.user.name ?? "Usuario"}
-        role={session.role}
-        theme={theme}
-      />
-      <main className="min-w-0 flex-1 overflow-hidden">{children}</main>
-    </div>
+    <AppShell
+      branding={branding}
+      userName={authSession?.user.name ?? "Usuario"}
+      role={session.role}
+      theme={theme}
+    >
+      {children}
+    </AppShell>
   );
 }

--- a/src/app/(app)/settings/layout.tsx
+++ b/src/app/(app)/settings/layout.tsx
@@ -5,12 +5,13 @@ export default function SettingsLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <div className="flex h-full flex-col">
-      <header className="border-b px-6 py-4">
+      <header className="border-b px-4 py-3 sm:px-6 sm:py-4">
         <h2 className="font-semibold">Configuración</h2>
       </header>
-      <div className="flex min-h-0 flex-1">
+      {/* En móvil las pestañas van arriba (en fila), no como columna lateral. */}
+      <div className="flex min-h-0 flex-1 flex-col sm:flex-row">
         <SettingsNav />
-        <div className="min-w-0 flex-1 overflow-y-auto p-6">{children}</div>
+        <div className="min-w-0 flex-1 overflow-y-auto p-4 sm:p-6">{children}</div>
       </div>
     </div>
   );

--- a/src/app/api/conversations/[id]/messages/template/route.ts
+++ b/src/app/api/conversations/[id]/messages/template/route.ts
@@ -13,6 +13,8 @@ type Params = { params: Promise<{ id: string }> };
 
 const bodySchema = z.object({
   templateId: z.string().min(1),
+  /** Valores de {{1}}..{{n}} en orden. `variable` sigue vivo por compatibilidad. */
+  variables: z.array(z.string().trim().max(500)).max(10).optional(),
   variable: z.string().trim().max(500).optional(),
 });
 
@@ -26,7 +28,9 @@ export const POST = withAuth(async (session, req: Request, ctx: Params) => {
       organizationId: session.organizationId,
       conversationId: id,
       templateId: body.data.templateId,
-      variable: body.data.variable,
+      variables:
+        body.data.variables ??
+        (body.data.variable === undefined ? undefined : [body.data.variable]),
     });
     return Response.json({ messageId: result.messageId });
   } catch (err) {

--- a/src/app/api/dev/wa-mock/graph/[...path]/route.ts
+++ b/src/app/api/dev/wa-mock/graph/[...path]/route.ts
@@ -56,7 +56,7 @@ export async function GET(req: Request, ctx: Params) {
         language: t.language,
         category: t.category,
         status: t.status,
-        components: [{ type: "BODY", text: t.body }],
+        components: t.components ?? [{ type: "BODY", text: t.body }],
       })),
     });
   }
@@ -117,6 +117,40 @@ export async function POST(req: Request, ctx: Params) {
   // POST {phoneNumberId}/messages → registra en el outbox
   if (path.length === 2 && path[1] === "messages") {
     const state = getWaMockState();
+    // Meta responde 132000 si los parámetros no cuadran con las {{n}} de la
+    // plantilla aprobada. El mock lo replica para que un desfase no pase.
+    if (body.type === "template") {
+      const tplSend = body.template as
+        | {
+            name?: string;
+            components?: { type?: string; parameters?: unknown[] }[];
+          }
+        | undefined;
+      const known = state.templates.find((t) => t.name === tplSend?.name);
+      if (known) {
+        const expected = [...known.body.matchAll(/\{\{\s*(\d+)\s*\}\}/g)].reduce(
+          (max, m) => Math.max(max, Number(m[1])),
+          0
+        );
+        const got =
+          tplSend?.components?.find(
+            (c) => (c.type ?? "").toLowerCase() === "body"
+          )?.parameters?.length ?? 0;
+        if (expected !== got) {
+          return Response.json(
+            {
+              error: {
+                message: `(#132000) Number of parameters does not match the expected number of params: expected ${expected}, got ${got}`,
+                type: "OAuthException",
+                code: 132000,
+                fbtrace_id: "mock",
+              },
+            },
+            { status: 400 }
+          );
+        }
+      }
+    }
     const n = nextN();
     const waMessageId = nextOutboundWamid();
     state.outbox.push({
@@ -138,9 +172,33 @@ export async function POST(req: Request, ctx: Params) {
   // POST {wabaId}/message_templates → alta de plantilla (queda PENDING)
   if (path.length === 2 && path[1] === "message_templates") {
     const state = getWaMockState();
-    const bodyComponent = (
-      body.components as { type?: string; text?: string }[] | undefined
-    )?.find((c) => (c.type ?? "").toUpperCase() === "BODY");
+    const components = (body.components ?? []) as {
+      type?: string;
+      text?: string;
+      example?: { body_text?: string[][] };
+    }[];
+    const bodyComponent = components.find(
+      (c) => (c.type ?? "").toUpperCase() === "BODY"
+    );
+    // Meta valida que haya un ejemplo por cada {{n}} del cuerpo: sin esto el
+    // mock aceptaría plantillas que producción rechaza (error 100).
+    const highestVar = [
+      ...(bodyComponent?.text ?? "").matchAll(/\{\{\s*(\d+)\s*\}\}/g),
+    ].reduce((max, m) => Math.max(max, Number(m[1])), 0);
+    const examples = bodyComponent?.example?.body_text?.[0] ?? [];
+    if (highestVar !== examples.length) {
+      return Response.json(
+        {
+          error: {
+            message: `Invalid parameter: expected ${highestVar} example value(s) for the body, got ${examples.length}`,
+            type: "GraphMethodException",
+            code: 100,
+            fbtrace_id: "mock",
+          },
+        },
+        { status: 400 }
+      );
+    }
     const tpl: MockTemplate = {
       id: `tplmock_${nextN()}`,
       name: String(body.name ?? ""),
@@ -148,6 +206,7 @@ export async function POST(req: Request, ctx: Params) {
       category: String(body.category ?? "UTILITY"),
       status: "PENDING",
       body: bodyComponent?.text ?? "",
+      components,
     };
     state.templates.push(tpl);
     return Response.json({ id: tpl.id, status: "PENDING", category: tpl.category });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -162,6 +162,21 @@
   }
 }
 
+/*
+  Safari en iOS hace zoom a la página cuando enfocas un campo cuya tipografía
+  mide menos de 16px, y luego no la devuelve: escribir en la Bandeja dejaba el
+  CRM descuadrado. Por debajo de `md` subimos el mínimo de TODO campo de texto
+  (los `select` quedan fuera: abren su propia rueda nativa y varios viven como
+  chips angostos). Va con `!important` a propósito — compite contra utilidades
+  de Tailwind (`text-sm`, `text-xs`) que ganan por especificidad de clase.
+*/
+@media (max-width: 767px) {
+  input:not([type="checkbox"]):not([type="radio"]),
+  textarea {
+    font-size: 16px !important;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/src/components/agent/agent-client.tsx
+++ b/src/components/agent/agent-client.tsx
@@ -72,7 +72,7 @@ export function AgentClient() {
 
   return (
     <div className="h-full overflow-y-auto">
-      <header className="flex items-center justify-between border-b px-6 py-4">
+      <header className="flex flex-wrap items-center justify-between gap-2 border-b px-4 py-3 sm:px-6 sm:py-4">
         <h2 className="font-semibold">Agente de IA</h2>
         <div className="flex items-center gap-3">
           {saved && <span className="text-xs text-primary">Guardado ✓</span>}
@@ -99,7 +99,7 @@ export function AgentClient() {
       </header>
 
       {!aiConfigured && (
-        <div className="mx-6 mt-6 rounded-lg border border-brand-soft bg-brand-tint p-6 text-center">
+        <div className="mx-4 mt-4 rounded-lg border border-brand-soft bg-brand-tint p-5 text-center sm:mx-6 sm:mt-6 sm:p-6">
           <Sparkles className="mx-auto mb-2 h-8 w-8 text-primary" />
           <p className="font-medium">Configura tu proveedor de IA para activar el agente</p>
           <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">
@@ -111,7 +111,7 @@ export function AgentClient() {
         </div>
       )}
 
-      <div className="grid gap-6 p-6 lg:grid-cols-2">
+      <div className="grid gap-4 p-4 sm:gap-6 sm:p-6 lg:grid-cols-2">
         <ProfileSection profile={profile} onSave={saveProfile} />
         <KbSection entries={entries} kbSize={kbSize} onChanged={() => void refetch()} />
       </div>

--- a/src/components/app-nav.tsx
+++ b/src/components/app-nav.tsx
@@ -11,6 +11,7 @@ import {
   Settings,
   Sparkles,
   Users,
+  X,
 } from "lucide-react";
 import type { Branding } from "@/lib/branding";
 import type { ThemePreference } from "@/lib/theme";
@@ -32,11 +33,16 @@ export function AppNav({
   userName,
   role,
   theme,
+  open = false,
+  onClose,
 }: {
   branding: Branding;
   userName: string;
   role: string;
   theme: ThemePreference;
+  /** Solo aplica por debajo de `lg`: en escritorio el lateral es fijo. */
+  open?: boolean;
+  onClose?: () => void;
 }) {
   const pathname = usePathname();
   const router = useRouter();
@@ -61,9 +67,29 @@ export function AppNav({
   });
 
   return (
-    <aside className="flex w-56 shrink-0 flex-col border-r bg-subtle px-3 pb-3.5 pt-4">
+    <aside
+      // Móvil: cajón que se desliza desde la izquierda (siempre montado, así
+      // la transición corre en ambos sentidos). Escritorio: columna fija.
+      // `visibility` va en la transición a propósito: al cerrar mantiene el
+      // cajón visible mientras se desliza y recién entonces lo oculta, que es
+      // lo que lo saca del orden de tabulación en móvil.
+      className={cn(
+        "fixed inset-y-0 left-0 z-50 flex w-[17rem] shrink-0 flex-col overflow-y-auto border-r bg-subtle px-3 pb-3.5 pt-4 transition-[transform,visibility] duration-200",
+        "lg:static lg:visible lg:z-auto lg:w-56 lg:translate-x-0 lg:overflow-visible lg:transition-none",
+        open ? "visible translate-x-0 shadow-pop" : "invisible -translate-x-full"
+      )}
+    >
       {/* Brand white-label */}
       <div className="mb-4 flex items-center gap-2.5 px-2">
+        {/* En móvil el cajón necesita su propio cierre: el velo no siempre es
+            alcanzable con el pulgar. */}
+        <button
+          onClick={onClose}
+          aria-label="Cerrar el menú"
+          className="-ml-1 rounded-md p-1.5 text-text-3 hover:bg-accent hover:text-foreground lg:hidden"
+        >
+          <X className="h-[18px] w-[18px]" strokeWidth={1.8} />
+        </button>
         <span
           className="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-sm bg-brand text-[15px] font-bold text-brand-fg"
           aria-hidden
@@ -87,7 +113,7 @@ export function AppNav({
               key={item.href}
               href={item.href}
               className={cn(
-                "flex items-center gap-[11px] rounded-sm px-2.5 py-2 text-sm font-medium transition-colors",
+                "flex items-center gap-[11px] rounded-sm px-2.5 py-2.5 text-sm font-medium transition-colors lg:py-2",
                 active
                   ? "bg-brand-tint font-semibold text-brand-text"
                   : "text-text-2 hover:bg-accent"

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { Menu } from "lucide-react";
+import type { Branding } from "@/lib/branding";
+import type { ThemePreference } from "@/lib/theme";
+import { AppNav } from "@/components/app-nav";
+
+/**
+ * Cascarón de la app en dos modos:
+ *
+ * - Escritorio (lg+): el panel lateral es una columna fija, como siempre.
+ * - Móvil/tableta: el lateral sale de la izquierda como cajón sobre un velo,
+ *   y arriba queda una barra con el hamburguesa y la marca. El cajón se cierra
+ *   solo al navegar (el `pathname` cambia) y con Escape.
+ *
+ * La altura usa `100dvh` (no `100vh`) porque en el navegador móvil la barra de
+ * direcciones se encoge al hacer scroll: con `vh` el compositor de la Bandeja
+ * queda debajo del borde visible.
+ */
+export function AppShell({
+  branding,
+  userName,
+  role,
+  theme,
+  children,
+}: {
+  branding: Branding;
+  userName: string;
+  role: string;
+  theme: ThemePreference;
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const [navOpen, setNavOpen] = useState(false);
+
+  // Navegar = cerrar el cajón. Sin esto, tocar "Pipeline" deja el velo encima
+  // de la pantalla recién cargada.
+  useEffect(() => {
+    setNavOpen(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!navOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setNavOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [navOpen]);
+
+  return (
+    <div className="flex h-dvh overflow-hidden bg-background">
+      {navOpen && (
+        <button
+          aria-label="Cerrar el menú"
+          tabIndex={-1}
+          onClick={() => setNavOpen(false)}
+          className="fixed inset-0 z-40 bg-overlay lg:hidden"
+        />
+      )}
+
+      <AppNav
+        branding={branding}
+        userName={userName}
+        role={role}
+        theme={theme}
+        open={navOpen}
+        onClose={() => setNavOpen(false)}
+      />
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="flex h-12 shrink-0 items-center gap-2 border-b px-2 lg:hidden">
+          <button
+            onClick={() => setNavOpen(true)}
+            aria-label="Abrir el menú"
+            aria-expanded={navOpen}
+            className="rounded-md p-2 text-text-2 hover:bg-accent hover:text-foreground"
+          >
+            <Menu className="h-5 w-5" strokeWidth={1.8} />
+          </button>
+          <span
+            className="flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-sm bg-brand text-[13px] font-bold text-brand-fg"
+            aria-hidden
+          >
+            {branding.name.charAt(0).toUpperCase()}
+          </span>
+          <span className="truncate text-[15px] font-[650] tracking-tight">
+            {branding.name}
+          </span>
+        </header>
+
+        <main className="min-h-0 min-w-0 flex-1 overflow-hidden">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/contacts/contacts-client.tsx
+++ b/src/components/contacts/contacts-client.tsx
@@ -63,9 +63,9 @@ export function ContactsClient() {
 
   return (
     <div className="flex h-full flex-col">
-      <header className="flex items-center justify-between gap-4 border-b px-6 py-4">
+      <header className="flex flex-wrap items-center justify-between gap-3 border-b px-4 py-3 sm:gap-4 sm:px-6 sm:py-4">
         <h2 className="font-semibold">Contactos</h2>
-        <div className="flex items-center gap-3">
+        <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:gap-3">
           <label className="flex items-center gap-2 text-xs text-muted-foreground">
             <input
               type="checkbox"
@@ -90,7 +90,7 @@ export function ContactsClient() {
               ))}
             </select>
           )}
-          <div className="relative">
+          <div className="relative w-full sm:w-auto">
             <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
             <Input
               ref={inputRef}
@@ -98,13 +98,13 @@ export function ContactsClient() {
               aria-label="Buscar contacto"
               defaultValue=""
               onChange={(e) => setQuery(e.target.value)}
-              className="w-72 pl-8"
+              className="w-full pl-8 sm:w-72"
             />
           </div>
         </div>
       </header>
 
-      <div className="flex-1 overflow-y-auto p-6">
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6">
         {contacts.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center gap-2 text-center">
             {query.trim() || stage !== "all" ? (
@@ -132,11 +132,13 @@ export function ContactsClient() {
             {contacts.map((c) => (
               <li
                 key={c.id}
-                className="flex items-center gap-4 rounded-lg border bg-card px-4 py-3"
+                className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg border bg-card px-3 py-3 sm:flex-nowrap sm:gap-x-4 sm:px-4"
               >
                 <ContactAvatar name={c.name} seed={c.id} />
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
+                {/* El 60% mínimo es lo que empuja los botones a su propio
+                    renglón en el teléfono en vez de exprimir el nombre. */}
+                <div className="min-w-[60%] flex-1 sm:min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
                     <span className="truncate text-sm font-medium">
                       {c.name}
                     </span>
@@ -152,7 +154,7 @@ export function ContactsClient() {
                     {c.notes ? ` · ${c.notes.slice(0, 60)}` : ""}
                   </p>
                 </div>
-                <div className="flex shrink-0 items-center gap-1.5">
+                <div className="ml-auto flex shrink-0 items-center gap-1.5">
                   <Button
                     variant="ghost"
                     size="sm"
@@ -212,11 +214,11 @@ function EditDialog({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-overlay p-4"
       onClick={onClose}
     >
       <div
-        className="w-full max-w-md rounded-lg border bg-card p-5 shadow-xl"
+        className="max-h-[85dvh] w-full max-w-md overflow-y-auto rounded-lg border bg-card p-5 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <h3 className="mb-4 font-semibold">Editar contacto</h3>

--- a/src/components/inbox/inbox-client.tsx
+++ b/src/components/inbox/inbox-client.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { PanelRight } from "lucide-react";
+import { ChevronLeft, PanelRight } from "lucide-react";
 import { cn, formatPhone } from "@/lib/utils";
 import { ContactAvatar } from "@/components/avatar";
 import type { ConversationDto, MessageDto } from "@/lib/types";
@@ -12,23 +12,40 @@ import { MessageThread } from "./message-thread";
 import { Composer } from "./composer";
 import { ContactPanel } from "./contact-panel";
 
+/**
+ * `xl` es el umbral donde caben las tres columnas (lista + hilo + detalles).
+ * Debajo, el panel de detalles flota sobre el hilo. Debe coincidir con el
+ * breakpoint `xl:` que usan las clases de la sección de detalles.
+ */
+const PANEL_MEDIA_QUERY = "(min-width: 1280px)";
+const isWideEnoughForPanel = () =>
+  typeof window !== "undefined" && window.matchMedia(PANEL_MEDIA_QUERY).matches;
+
 export function InboxClient() {
   const [conversations, setConversations] = useState<ConversationDto[] | null>(
     null
   );
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [messages, setMessages] = useState<MessageDto[]>([]);
-  const [panelOpen, setPanelOpen] = useState(true);
+  // Arranca cerrado: en pantallas angostas el panel de detalles es un cajón
+  // ENCIMA del hilo, así que abrirlo por defecto taparía la conversación. El
+  // efecto de abajo lo abre solo si de veras hay tres columnas de ancho.
+  const [panelOpen, setPanelOpen] = useState(false);
   // Se incrementa con cada evento SSE que puede cambiar la etapa/lead o el
   // estado del agente: el panel de detalles lo observa y refetch en vivo.
   const [detailRev, setDetailRev] = useState(0);
 
   useEffect(() => {
+    if (!isWideEnoughForPanel()) return;
     setPanelOpen(localStorage.getItem("vocero.panelOpen") !== "false");
   }, []);
   const togglePanel = useCallback((open: boolean) => {
     setPanelOpen(open);
-    localStorage.setItem("vocero.panelOpen", String(open));
+    // La preferencia es de escritorio: abrir el cajón en el teléfono no debe
+    // reescribir cómo queda la Bandeja en la computadora.
+    if (isWideEnoughForPanel()) {
+      localStorage.setItem("vocero.panelOpen", String(open));
+    }
   }, []);
   const selectedIdRef = useRef<string | null>(null);
   selectedIdRef.current = selectedId;
@@ -164,7 +181,14 @@ export function InboxClient() {
 
   return (
     <div className="flex h-full">
-      <section className="w-[360px] shrink-0 overflow-hidden border-r">
+      {/* Móvil: una columna a la vez. La lista cede la pantalla completa al
+          hilo en cuanto hay conversación elegida (patrón maestro-detalle). */}
+      <section
+        className={cn(
+          "w-full shrink-0 overflow-hidden border-r md:w-[300px] lg:w-[360px]",
+          selected && "max-md:hidden"
+        )}
+      >
         <ConversationList
           conversations={conversations}
           selectedId={selectedId}
@@ -173,18 +197,31 @@ export function InboxClient() {
         />
       </section>
 
-      <section className="flex min-w-0 flex-1 flex-col">
+      <section
+        className={cn(
+          "flex min-w-0 flex-1 flex-col",
+          !selected && "max-md:hidden"
+        )}
+      >
         {selected ? (
           <>
-            <header className="flex items-center justify-between border-b bg-background px-4 py-2.5">
-              <div className="flex items-center gap-3">
+            <header className="flex items-center justify-between gap-1 border-b bg-background px-2 py-2.5 md:px-4">
+              {/* Volver a la lista: en móvil el hilo ocupa toda la pantalla. */}
+              <button
+                onClick={() => setSelectedId(null)}
+                aria-label="Volver a las conversaciones"
+                className="shrink-0 rounded-md p-1.5 text-text-2 hover:bg-accent hover:text-foreground md:hidden"
+              >
+                <ChevronLeft className="h-5 w-5" strokeWidth={1.8} />
+              </button>
+              <div className="flex min-w-0 flex-1 items-center gap-3 p-1">
                 <ContactAvatar
                   name={selected.contact.name}
                   seed={selected.contact.id}
                   size="md"
                 />
-                <div>
-                  <p className="text-[15px] font-[650] leading-tight">
+                <div className="min-w-0">
+                  <p className="truncate text-[15px] font-[650] leading-tight">
                     {selected.contact.name}
                   </p>
                   <p
@@ -204,7 +241,7 @@ export function InboxClient() {
                 <button
                   onClick={() => togglePanel(true)}
                   aria-label="Mostrar detalles"
-                  className="rounded-sm border p-1.5 text-text-3 hover:bg-accent hover:text-foreground"
+                  className="shrink-0 rounded-sm border p-1.5 text-text-3 hover:bg-accent hover:text-foreground"
                 >
                   <PanelRight className="h-4 w-4" strokeWidth={1.7} />
                 </button>
@@ -228,14 +265,29 @@ export function InboxClient() {
         )}
       </section>
 
+      {/* Velo del cajón de detalles (solo donde no caben tres columnas). */}
+      {panelOpen && selected && (
+        <button
+          aria-label="Cerrar los detalles"
+          tabIndex={-1}
+          onClick={() => togglePanel(false)}
+          className="fixed inset-0 z-30 bg-overlay xl:hidden"
+        />
+      )}
+
       <section
         className={cn(
           "shrink-0 overflow-hidden border-l transition-[width] duration-[220ms]",
-          panelOpen && selected ? "w-[320px]" : "w-0 border-l-0"
+          // Debajo de xl no hay ancho para una tercera columna: el panel se
+          // vuelve un cajón que entra desde la derecha, encima del hilo.
+          "max-xl:fixed max-xl:inset-y-0 max-xl:right-0 max-xl:z-40 max-xl:w-auto max-xl:bg-background max-xl:transition-transform",
+          panelOpen && selected
+            ? "w-[320px] max-xl:translate-x-0 max-xl:shadow-pop"
+            : "w-0 border-l-0 max-xl:translate-x-full"
         )}
       >
         {selected && (
-          <div className="h-full w-[320px]">
+          <div className="h-full w-[320px] max-xl:w-[min(320px,88vw)]">
             <ContactPanel
               conversation={selected}
               refreshKey={detailRev}

--- a/src/components/inbox/message-thread.tsx
+++ b/src/components/inbox/message-thread.tsx
@@ -193,7 +193,7 @@ export function MessageThread({ messages }: { messages: MessageDto[] }) {
   return (
     <div
       ref={scrollRef}
-      className="flex flex-1 flex-col gap-[3px] overflow-y-auto bg-chat px-[6%] py-5"
+      className="flex flex-1 flex-col gap-[3px] overflow-y-auto bg-chat px-3 py-5 sm:px-[6%]"
     >
       {messages.map((m, i) => {
         const prev = messages[i - 1];
@@ -223,7 +223,9 @@ export function MessageThread({ messages }: { messages: MessageDto[] }) {
             >
               <div
                 className={cn(
-                  "max-w-[64%] rounded-lg px-3 pb-1.5 pt-2 text-sm leading-[1.45] shadow-sm",
+                  // En el teléfono la burbuja necesita casi todo el renglón:
+                  // con 64% cada mensaje se parte en tres líneas.
+                  "max-w-[85%] rounded-lg px-3 pb-1.5 pt-2 text-sm leading-[1.45] shadow-sm sm:max-w-[64%]",
                   out
                     ? "border border-brand-soft bg-bubble-out text-bubble-out-text"
                     : "bg-background",

--- a/src/components/inbox/template-sender.tsx
+++ b/src/components/inbox/template-sender.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import type { TemplateDto } from "@/lib/types";
+import { countVariables } from "@/lib/templates";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -19,7 +20,7 @@ export function TemplateSender({
 }) {
   const [templates, setTemplates] = useState<TemplateDto[] | null>(null);
   const [selectedId, setSelectedId] = useState<string>("");
-  const [variable, setVariable] = useState("");
+  const [variables, setVariables] = useState<string[]>([]);
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -59,7 +60,11 @@ export function TemplateSender({
   }
 
   const selected = templates.find((t) => t.id === selectedId) ?? null;
-  const needsVariable = selected ? /\{\{\s*1\s*\}\}/.test(selected.body) : false;
+  // El cuerpo puede llevar {{1}}..{{n}}: el número de parámetros es el índice
+  // más alto, y Meta los exige todos.
+  const variableCount = selected ? countVariables(selected.body) : 0;
+  const values = Array.from({ length: variableCount }, (_, i) => variables[i] ?? "");
+  const missingValue = values.some((v) => !v.trim());
 
   async function send() {
     if (!selected || sending) return;
@@ -72,7 +77,7 @@ export function TemplateSender({
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
           templateId: selected.id,
-          variable: needsVariable ? variable : undefined,
+          variables: variableCount > 0 ? values : undefined,
         }),
       }
     );
@@ -85,7 +90,7 @@ export function TemplateSender({
       return;
     }
     setSelectedId("");
-    setVariable("");
+    setVariables([]);
     onSent();
   }
 
@@ -96,7 +101,10 @@ export function TemplateSender({
         <select
           id="template-select"
           value={selectedId}
-          onChange={(e) => setSelectedId(e.target.value)}
+          onChange={(e) => {
+            setSelectedId(e.target.value);
+            setVariables([]);
+          }}
           className="flex h-9 w-full rounded-md border border-input bg-card px-3 py-1 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
         >
           <option value="">Elige una plantilla…</option>
@@ -112,21 +120,32 @@ export function TemplateSender({
           {selected.body}
         </p>
       )}
-      {needsVariable && (
-        <div className="space-y-1.5">
-          <Label htmlFor="template-variable">Valor de la variable {"{{1}}"}</Label>
+      {values.map((value, i) => (
+        <div key={i} className="space-y-1.5">
+          <Label htmlFor={`template-variable-${i + 1}`}>
+            Valor de {`{{${i + 1}}}`}
+          </Label>
           <Input
-            id="template-variable"
-            value={variable}
-            onChange={(e) => setVariable(e.target.value)}
-            placeholder="p. ej. el nombre del cliente"
+            id={`template-variable-${i + 1}`}
+            value={value}
+            onChange={(e) =>
+              setVariables((prev) => {
+                const next = [...prev];
+                while (next.length < variableCount) next.push("");
+                next[i] = e.target.value;
+                return next;
+              })
+            }
+            placeholder={
+              i === 0 ? "p. ej. el nombre del cliente" : "p. ej. 12 de agosto"
+            }
           />
         </div>
-      )}
+      ))}
       {error && <p className="text-xs text-destructive">{error}</p>}
       <Button
         onClick={() => void send()}
-        disabled={!selected || sending || (needsVariable && !variable.trim())}
+        disabled={!selected || sending || missingValue}
       >
         {sending ? "Enviando…" : "Enviar plantilla"}
       </Button>

--- a/src/components/lab/lab-client.tsx
+++ b/src/components/lab/lab-client.tsx
@@ -145,7 +145,7 @@ export function LabClient() {
         onLaunch={() => void launch()}
         disabled={false}
       />
-      {error && <p className="px-6 pt-3 text-sm text-destructive">{error}</p>}
+      {error && <p className="px-4 pt-3 text-sm text-destructive sm:px-6">{error}</p>}
 
       {running && progress && (
         <div className="mx-6 mt-4 rounded-lg border bg-card p-4">
@@ -164,7 +164,7 @@ export function LabClient() {
         </div>
       )}
 
-      <div className="grid gap-6 p-6 lg:grid-cols-[280px_1fr]">
+      <div className="grid gap-4 p-4 sm:gap-6 sm:p-6 lg:grid-cols-[280px_1fr]">
         <HistoryList
           runs={runs}
           selectedRunId={selectedRunId}
@@ -196,7 +196,7 @@ function Header({
   disabled: boolean;
 }) {
   return (
-    <header className="flex items-center justify-between border-b px-6 py-4">
+    <header className="flex flex-wrap items-center justify-between gap-2 border-b px-4 py-3 sm:px-6 sm:py-4">
       <div>
         <h2 className="flex items-center gap-2 font-semibold">
           <FlaskConical className="h-4 w-4 text-primary" /> Laboratorio

--- a/src/components/pipeline/pipeline-client.tsx
+++ b/src/components/pipeline/pipeline-client.tsx
@@ -80,14 +80,16 @@ export function PipelineClient() {
 
   return (
     <div className="flex h-full flex-col">
-      <header className="flex items-center justify-between border-b px-6 py-4">
+      <header className="flex flex-wrap items-center justify-between gap-2 border-b px-4 py-3 sm:px-6 sm:py-4">
         <h2 className="font-semibold">Pipeline</h2>
         <Button variant="outline" size="sm" onClick={() => setManaging(true)}>
           <Settings2 className="h-4 w-4" /> Gestionar etapas
         </Button>
       </header>
 
-      <div className="flex-1 overflow-x-auto p-4">
+      {/* El tablero se arrastra en horizontal; en el teléfono cada columna
+          se detiene en su sitio (snap) para no quedar a medio camino. */}
+      <div className="flex-1 snap-x snap-mandatory overflow-x-auto p-3 sm:snap-none sm:p-4">
         <DndContext
           sensors={sensors}
           onDragStart={onDragStart}
@@ -127,7 +129,7 @@ function StageColumn({ stage, leads }: { stage: StageDto; leads: BoardLead[] }) 
     <div
       ref={setNodeRef}
       className={cn(
-        "flex h-full w-64 shrink-0 flex-col rounded-lg border bg-card/50",
+        "flex h-full w-64 shrink-0 snap-start flex-col rounded-lg border bg-card/50",
         isOver && "ring-2 ring-primary/60"
       )}
     >

--- a/src/components/pipeline/stage-manager.tsx
+++ b/src/components/pipeline/stage-manager.tsx
@@ -90,11 +90,11 @@ export function StageManager({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-overlay p-4"
       onClick={onClose}
     >
       <div
-        className="w-full max-w-lg rounded-lg border bg-card p-5 shadow-xl"
+        className="max-h-[85dvh] w-full max-w-lg overflow-y-auto rounded-lg border bg-card p-5 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <h3 className="mb-4 font-semibold">Etapas del pipeline</h3>

--- a/src/components/settings/settings-nav.tsx
+++ b/src/components/settings/settings-nav.tsx
@@ -14,13 +14,13 @@ const TABS = [
 export function SettingsNav() {
   const pathname = usePathname();
   return (
-    <nav className="w-44 shrink-0 space-y-1 border-r p-3">
+    <nav className="flex shrink-0 gap-1 overflow-x-auto border-b p-2 sm:w-44 sm:flex-col sm:space-y-1 sm:overflow-visible sm:border-b-0 sm:border-r sm:p-3">
       {TABS.map((t) => (
         <Link
           key={t.href}
           href={t.href}
           className={cn(
-            "block rounded-md px-3 py-2 text-sm font-medium transition-colors",
+            "block shrink-0 whitespace-nowrap rounded-md px-3 py-2 text-sm font-medium transition-colors",
             pathname.startsWith(t.href)
               ? "bg-brand-tint text-brand-text"
               : "text-muted-foreground hover:bg-accent hover:text-foreground"

--- a/src/components/settings/templates-client.tsx
+++ b/src/components/settings/templates-client.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { RefreshCw } from "lucide-react";
 import type { TemplateDto } from "@/lib/types";
+import { countVariables, validateBodyVariables } from "@/lib/templates";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -134,6 +135,10 @@ function CreateForm({ onCreated }: { onCreated: () => void }) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Misma validación que el servidor: avisa antes de gastar una llamada a Meta.
+  const bodyError = body.trim() ? validateBodyVariables(body) : null;
+  const variableCount = countVariables(body);
+
   async function create() {
     setSaving(true);
     setError(null);
@@ -160,8 +165,9 @@ function CreateForm({ onCreated }: { onCreated: () => void }) {
       <CardHeader>
         <CardTitle>Nueva plantilla</CardTitle>
         <CardDescription>
-          Cuerpo con máximo UNA variable <code>{"{{1}}"}</code> (v1). Se envía a
-          aprobación de Meta al crearla.
+          Cuerpo con las variables que necesites: numéralas{" "}
+          <code>{"{{1}}"}</code>, <code>{"{{2}}"}</code>, <code>{"{{3}}"}</code>
+          … en orden y sin saltos. Se envía a aprobación de Meta al crearla.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -209,14 +215,25 @@ function CreateForm({ onCreated }: { onCreated: () => void }) {
           <Textarea
             id="tpl-body"
             rows={3}
-            placeholder="Hola {{1}}, seguimos disponibles. ¿Retomamos tu cotización?"
+            placeholder="Hola {{1}}, te confirmo tu sesión el {{2}} a las {{3}}."
             value={body}
             onChange={(e) => setBody(e.target.value)}
           />
+          {bodyError ? (
+            <p className="text-xs text-destructive">{bodyError}</p>
+          ) : (
+            variableCount > 0 && (
+              <p className="text-xs text-muted-foreground">
+                {variableCount === 1
+                  ? "1 variable: al enviar pedirá su valor."
+                  : `${variableCount} variables: al enviar pedirá los ${variableCount} valores.`}
+              </p>
+            )
+          )}
         </div>
         {error && <p className="text-sm text-destructive">{error}</p>}
         <Button
-          disabled={saving || !name.trim() || !body.trim()}
+          disabled={saving || !name.trim() || !body.trim() || bodyError !== null}
           onClick={() => void create()}
         >
           {saving ? "Enviando a Meta…" : "Crear y enviar a aprobación"}

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -1,0 +1,51 @@
+/**
+ * Variables posicionales {{n}} del cuerpo de una plantilla de WhatsApp.
+ * Puro y sin dependencias: lo usan tanto el servicio de servidor como la UI
+ * (que necesita saber cuántos campos pintar antes de enviar).
+ */
+
+const VARIABLE_REGEX = /\{\{\s*(\d+)\s*\}\}/g;
+
+/** Máximo de parámetros posicionales por cuerpo que acepta Meta. */
+export const MAX_TEMPLATE_VARIABLES = 10;
+
+/** Índices distintos de {{n}} presentes en el cuerpo, ordenados. */
+function variableIndexes(body: string): number[] {
+  const found = new Set<number>();
+  for (const m of body.matchAll(VARIABLE_REGEX)) found.add(Number(m[1]));
+  return [...found].sort((a, b) => a - b);
+}
+
+/**
+ * Cuántos parámetros exige el cuerpo = el índice más alto. Con la numeración
+ * validada (1..N sin saltos) equivale al número de variables distintas.
+ */
+export function countVariables(body: string): number {
+  const indexes = variableIndexes(body);
+  return indexes.length ? indexes[indexes.length - 1]! : 0;
+}
+
+/**
+ * Meta acepta varias variables por cuerpo, pero exige numeración posicional
+ * contigua desde {{1}}: un salto ({{1}} y {{3}}) es rechazo seguro.
+ */
+export function validateBodyVariables(body: string): string | null {
+  const indexes = variableIndexes(body);
+  if (indexes.length === 0) return null;
+  if (indexes.length > MAX_TEMPLATE_VARIABLES) {
+    return `El cuerpo admite hasta ${MAX_TEMPLATE_VARIABLES} variables`;
+  }
+  for (let i = 0; i < indexes.length; i++) {
+    if (indexes[i] !== i + 1) {
+      return `Las variables deben ir numeradas {{1}}, {{2}}, … sin saltos (falta {{${i + 1}}})`;
+    }
+  }
+  return null;
+}
+
+/** Sustituye {{n}} por `variables[n-1]` (vacío si no hay valor). */
+export function renderBody(body: string, variables: string[] = []): string {
+  return body.replace(VARIABLE_REGEX, (_match, index: string) => {
+    return variables[Number(index) - 1] ?? "";
+  });
+}

--- a/src/server/dev/wa-mock-state.ts
+++ b/src/server/dev/wa-mock-state.ts
@@ -25,6 +25,8 @@ export type MockTemplate = {
   category: string;
   status: "PENDING" | "APPROVED" | "REJECTED";
   body: string;
+  /** Componentes tal cual los mandó el CRM: Meta valida aquí los `example`. */
+  components?: unknown[];
 };
 
 type WaMockState = {

--- a/src/server/whatsapp/templates.ts
+++ b/src/server/whatsapp/templates.ts
@@ -1,4 +1,9 @@
 import { and, eq } from "drizzle-orm";
+import {
+  countVariables,
+  renderBody,
+  validateBodyVariables,
+} from "@/lib/templates";
 import { getDb, schema } from "@/lib/db";
 import { newId } from "@/lib/db/ids";
 import { graphRequest, MetaApiError, normalizeRecipient } from "@/lib/meta/client";
@@ -43,28 +48,7 @@ export function templateErrorStatus(err: TemplateError): number {
   return TEMPLATE_ERROR_STATUS[err.code];
 }
 
-const VARIABLE_REGEX = /\{\{\s*(\d+)\s*\}\}/g;
-
-/** Cuenta variables {{n}} y valida el acotamiento v1: máximo UNA y debe ser {{1}}. */
-export function countVariables(body: string): number {
-  const matches = [...body.matchAll(VARIABLE_REGEX)];
-  return matches.length;
-}
-
-export function validateBodyVariables(body: string): string | null {
-  const matches = [...body.matchAll(VARIABLE_REGEX)];
-  if (matches.length > 1) {
-    return "v1 admite una sola variable {{1}} en el cuerpo";
-  }
-  if (matches.length === 1 && matches[0]![1] !== "1") {
-    return "La variable debe ser {{1}}";
-  }
-  return null;
-}
-
-export function renderBody(body: string, variable?: string): string {
-  return body.replace(VARIABLE_REGEX, variable ?? "");
-}
+export { countVariables, renderBody, validateBodyVariables };
 
 type TemplateRow = typeof schema.template.$inferSelect;
 
@@ -102,7 +86,12 @@ export async function createTemplate(
     .replace(/[^a-z0-9_]/g, "");
   if (!name) throw new TemplateError("invalid", "Nombre de plantilla inválido");
 
-  const hasVariable = countVariables(input.body) === 1;
+  // Meta pide un ejemplo por variable: si faltan, rechaza la plantilla.
+  const variableCount = countVariables(input.body);
+  const examples = Array.from(
+    { length: variableCount },
+    (_, i) => `ejemplo ${i + 1}`
+  );
   let waTemplateId: string | null = null;
   try {
     const res = await graphRequest<{ id?: string; status?: string }>(
@@ -118,8 +107,8 @@ export async function createTemplate(
             {
               type: "BODY",
               text: input.body,
-              ...(hasVariable
-                ? { example: { body_text: [["ejemplo"]] } }
+              ...(variableCount > 0
+                ? { example: { body_text: [examples] } }
                 : {}),
             },
           ],
@@ -285,7 +274,7 @@ export async function sendTemplate(input: {
   organizationId: string;
   conversationId: string;
   templateId: string;
-  variable?: string;
+  variables?: string[];
 }): Promise<{ messageId: string }> {
   const db = getDb();
 
@@ -305,9 +294,21 @@ export async function sendTemplate(input: {
   if (template.status !== "approved") {
     throw new TemplateError("invalid", "Solo se pueden enviar plantillas aprobadas");
   }
-  const needsVariable = countVariables(template.body) === 1;
-  if (needsVariable && !input.variable?.trim()) {
-    throw new TemplateError("invalid", "La plantilla requiere el valor de {{1}}");
+  // Meta exige EXACTAMENTE un parámetro por variable del cuerpo: si sobran o
+  // falta alguno responde 132000 (plantilla y parámetros no coinciden).
+  const variableCount = countVariables(template.body);
+  const values = (input.variables ?? [])
+    .slice(0, variableCount)
+    .map((v) => v.trim());
+  if (values.length < variableCount || values.some((v) => !v)) {
+    const missing = values.findIndex((v) => !v);
+    const n = missing === -1 ? values.length + 1 : missing + 1;
+    throw new TemplateError(
+      "invalid",
+      variableCount === 1
+        ? "La plantilla requiere el valor de {{1}}"
+        : `La plantilla requiere ${variableCount} valores: falta {{${n}}}`
+    );
   }
 
   const rows = await db
@@ -359,12 +360,12 @@ export async function sendTemplate(input: {
     template: {
       name: template.name,
       language: { code: template.language },
-      ...(needsVariable
+      ...(variableCount > 0
         ? {
             components: [
               {
                 type: "body",
-                parameters: [{ type: "text", text: input.variable!.trim() }],
+                parameters: values.map((text) => ({ type: "text", text })),
               },
             ],
           }
@@ -381,7 +382,7 @@ export async function sendTemplate(input: {
       waMessageId,
       direction: "out",
       type: "template",
-      text: renderBody(template.body, input.variable?.trim()),
+      text: renderBody(template.body, values),
       status: "pending",
       origin: "template",
     })

--- a/tests/e2e/responsividad.md
+++ b/tests/e2e/responsividad.md
@@ -1,0 +1,85 @@
+# Responsividad — el CRM se usa desde el teléfono
+
+Guion de comportamiento (2026-08-14). Automatizado en
+`scripts/e2e-responsive.mjs`.
+
+Origen: la app se diseñó para escritorio (lateral fijo de 224 px + Bandeja de
+tres columnas). Debajo de ~1000 px el lateral se comía media pantalla, el hilo
+quedaba en una franja de unos 100 px y el compositor caía fuera del área
+visible del navegador móvil.
+
+## Preparación
+
+App corriendo con mocks (`WA_MOCK_ENABLED=true`, `META_GRAPH_BASE_URL` →
+wa-mock) y BD con migraciones aplicadas. Un contacto entrante de prueba con
+conversación abierta.
+
+Tres tamaños: teléfono 390×844, tableta 820×1180, escritorio 1440×900.
+
+## AC-1 — Ninguna pantalla recorta contenido a lo ancho
+
+Recorre Bandeja, Pipeline, Contactos, Agente, Laboratorio y
+Ajustes → WhatsApp en los tres tamaños.
+
+Esperado: en cada una, el contenido de `main` cabe en su ancho visible
+(`scrollWidth == clientWidth`) y el documento no genera scroll horizontal. El
+tablero del Pipeline sí se arrastra en horizontal, pero **dentro** de su propio
+contenedor, con las columnas ancladas (snap).
+
+## AC-2 — El lateral se vuelve cajón en el teléfono
+
+1. Abre cualquier pantalla en 390×844.
+
+Esperado: se ve la barra superior con la hamburguesa y la marca; los enlaces
+del lateral **no** son alcanzables (están fuera del orden de tabulación).
+
+2. Toca la hamburguesa.
+
+Esperado: el cajón entra desde la izquierda **encima** del contenido (no lo
+empuja: `main` sigue empezando en x=0), con velo detrás.
+
+3. Toca "Bandeja".
+
+Esperado: navega y el cajón se cierra solo. También cierra con Escape, con el
+velo y con su propia ✕.
+
+## AC-3 — La Bandeja es maestro-detalle en el teléfono
+
+1. Abre la Bandeja sin conversación elegida.
+
+Esperado: la lista ocupa el ancho completo (390 px), no una columna de 360 px
+con el hilo aplastado al lado.
+
+2. Toca una conversación.
+
+Esperado: el hilo ocupa toda la pantalla, la lista desaparece y aparece un
+botón "Volver a las conversaciones" que la regresa.
+
+3. Mira el compositor.
+
+Esperado: queda **dentro** de la pantalla (la altura del cascarón es `100dvh`,
+no `100vh`) y su tipografía mide ≥16 px, que es lo que evita que Safari en iOS
+haga zoom al enfocar y deje el CRM descuadrado. Lo mismo aplica a todo campo de
+texto por debajo de `md`.
+
+## AC-4 — Los detalles del contacto flotan sobre el hilo
+
+1. Con el hilo abierto en el teléfono, toca "Mostrar detalles".
+
+Esperado: el panel arranca **cerrado** (la preferencia guardada solo manda en
+escritorio) y entra como cajón pegado al borde derecho, encima del hilo, sin
+robarle ancho ni provocar scroll horizontal. Cierra con su ✕ o con el velo.
+
+Debajo de `xl` (1280 px) el panel siempre es cajón; a partir de ahí vuelve a ser
+la tercera columna.
+
+## AC-5 — En tableta conviven lista e hilo
+
+En 820×1180 la Bandeja muestra dos columnas (lista ~300 px + hilo), y el panel
+de detalles sigue siendo cajón.
+
+## AC-6 — En escritorio nada cambió
+
+En 1440×900: lateral fijo de 224 px sin hamburguesa, Bandeja de tres columnas
+(lista 360 px + hilo + detalles 320 px) y la preferencia de "panel abierto"
+persistida como siempre.

--- a/tests/e2e/us6-templates.md
+++ b/tests/e2e/us6-templates.md
@@ -1,4 +1,4 @@
-# Guion E2E — US6: Plantillas acotadas
+# Guion E2E — US6: Plantillas
 
 > Conducido con Playwright (MCP) contra `pnpm dev` con wa-mock.
 
@@ -45,3 +45,24 @@ modo agencia no es el de esta instancia: sin pull, la plantilla se queda
    ✅ El outbox del wa-mock registra `type: "template"` con `components`
    (`parameters[0].text` = valor de la variable).
 7. Validaciones: enviar plantilla no aprobada → 422; variable faltante → 422.
+
+## Varias variables por cuerpo (2026-08-09)
+
+> Automatizado en `scripts/e2e-templates-multivar.mjs` (21 checks) + UI con
+> Playwright. Antes el CRM rechazaba en su propia pantalla lo que Meta sí
+> acepta: "v1 admite una sola variable {{1}} en el cuerpo".
+
+11. En `/settings/templates`, cuerpo con `{{1}}`, `{{2}}` y `{{3}}`.
+    ✅ Sin aviso rojo, el botón habilitado y la pantalla anuncia "3 variables".
+    ✅ A Meta va **un `example.body_text` por variable** (sin eso responde 100).
+12. Cuerpo con salto (`{{1}}` y `{{3}}`).
+    ✅ Aviso "…sin saltos (falta {{2}})", botón deshabilitado y, si se fuerza
+    por API, 422 — la numeración posicional contigua es requisito de Meta.
+13. Con la plantilla aprobada y la ventana cerrada, el envío pide **un campo por
+    variable** (`Valor de {{1}}`…`{{3}}`).
+    ✅ El outbox del wa-mock trae los 3 `parameters` en orden y el hilo muestra
+    el texto ya sustituido.
+    ✅ Faltando un valor → 422 diciendo cuál falta; el wa-mock además replica el
+    132000 de Meta si el número de parámetros no cuadra.
+14. Compatibilidad: el payload viejo `{ templateId, variable }` (una variable)
+    sigue enviando — lo usa el cron de recordatorios de sesión.

--- a/tests/unit/templates.test.ts
+++ b/tests/unit/templates.test.ts
@@ -17,26 +17,52 @@ describe("countVariables / validateBodyVariables (FR-050)", () => {
     expect(validateBodyVariables("Hola {{1}}, ¿retomamos?")).toBeNull();
   });
 
-  it("dos variables → inválido (acotamiento v1)", () => {
-    expect(countVariables("Hola {{1}}, tu pedido {{2}} llegó")).toBe(2);
-    expect(
-      validateBodyVariables("Hola {{1}}, tu pedido {{2}} llegó")
-    ).toMatch(/una sola variable/);
+  it("varias variables numeradas en orden → válido", () => {
+    const body = "Hola {{1}}, te confirmo el {{2}} a las {{3}}.";
+    expect(countVariables(body)).toBe(3);
+    expect(validateBodyVariables(body)).toBeNull();
   });
 
-  it("variable {{2}} sola → inválida (debe ser {{1}})", () => {
+  it("la variable repetida cuenta una sola vez", () => {
+    expect(countVariables("Hola {{1}}, ¿confirmas, {{1}}?")).toBe(1);
+    expect(validateBodyVariables("Hola {{1}}, ¿confirmas, {{1}}?")).toBeNull();
+  });
+
+  it("numeración con salto → inválida", () => {
+    expect(validateBodyVariables("Hola {{1}}, tu pedido {{3}} llegó")).toMatch(
+      /sin saltos/
+    );
+  });
+
+  it("variable {{2}} sola → inválida (debe empezar en {{1}})", () => {
     expect(validateBodyVariables("Tu pedido {{2}} llegó")).toMatch(/\{\{1\}\}/);
+  });
+
+  it("más de 10 variables → inválida", () => {
+    const body = Array.from({ length: 11 }, (_, i) => `x {{${i + 1}}}`).join(" ");
+    expect(validateBodyVariables(body)).toMatch(/hasta 10/);
   });
 });
 
 describe("renderBody", () => {
   it("sustituye la variable por el valor", () => {
-    expect(renderBody("Hola {{1}}, ¿retomamos?", "María")).toBe(
+    expect(renderBody("Hola {{1}}, ¿retomamos?", ["María"])).toBe(
       "Hola María, ¿retomamos?"
     );
   });
 
-  it("sin valor → variable vacía", () => {
+  it("sustituye cada variable por su posición", () => {
+    expect(
+      renderBody("Hola {{1}}, te espero el {{2}} a las {{3}}.", [
+        "María",
+        "12 de agosto",
+        "5 pm",
+      ])
+    ).toBe("Hola María, te espero el 12 de agosto a las 5 pm.");
+  });
+
+  it("sin valores → variables vacías", () => {
     expect(renderBody("Hola {{1}}!")).toBe("Hola !");
+    expect(renderBody("Hola {{1}} el {{2}}", ["María"])).toBe("Hola María el ");
   });
 });


### PR DESCRIPTION
Segundo cierre mecánico, mismo motivo que el #14: **#17 y #19 figuran MERGED
pero su trabajo no llegó a `main`** — se mergearon contra su rama base, porque
GitHub solo re-apunta un PR hijo a `main` cuando su base se mergea *antes*.

| PR | Qué trae | ¿En `main` hoy? |
|---|---|---|
| #15 README + gateway | — | sí |
| #16 tema oscuro | — | sí |
| #18 envío instantáneo | — | sí |
| **#17 plantillas multivariable** | `{{1}}…{{n}}` por cuerpo | **no** |
| **#19 responsividad** | teléfono y tableta | **no** |

Esto trae las dos que faltan, mergeando sus ramas (no cherry-pick, así que los
commits originales se conservan).

## El único conflicto real, resuelto

`inbox-client.tsx`: el envío instantáneo (#18) y la responsividad (#19) tocan el
mismo archivo, y era el rebase que anticipé en la descripción del #19. Las dos
piezas conviven sin pisarse:

- del envío: `PendingOut`, la cola de envíos y el hilo con burbuja provisional,
- de la responsividad: el umbral `xl`, el panel que arranca cerrado y el botón
  de volver.

## Verificación sobre el árbol combinado

```
pnpm typecheck   ✓
pnpm lint        ✓
pnpm test        ✓  172 pruebas, 25 archivos
pnpm build       ✓
```

## Para que no se repita

Con PRs apilados, mergea **de abajo hacia arriba** (primero la base, después el
hijo) y comprueba con `git merge-base --is-ancestor <commit> origin/main`
después de cada uno. Si GitHub ofrece "Update branch" en el hijo tras mergear la
base, eso también lo re-apunta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
