### PR TITLE
feat(pipeline): bitacora de movimientos de etapa y motivo de perdida

### DIFF
--- a/drizzle/0004_reflective_the_enforcers.sql
+++ b/drizzle/0004_reflective_the_enforcers.sql
@@ -1,0 +1,90 @@
+CREATE TABLE "lead_stage_event" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"lead_id" text NOT NULL,
+	"contact_id" text NOT NULL,
+	"from_stage_id" text,
+	"from_stage_name" text,
+	"to_stage_id" text,
+	"to_stage_name" text NOT NULL,
+	"to_stage_kind" text DEFAULT 'open' NOT NULL,
+	"occurred_at" timestamp DEFAULT now() NOT NULL,
+	"actor_user_id" text,
+	"source" text DEFAULT 'dueno' NOT NULL,
+	"approximate" boolean DEFAULT false NOT NULL,
+	"loss_reason" text,
+	"loss_note" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "lse_loss_reason_ck" CHECK ("lead_stage_event"."to_stage_kind" <> 'lost' OR "lead_stage_event"."approximate" = true OR "lead_stage_event"."loss_reason" IS NOT NULL)
+);
+--> statement-breakpoint
+ALTER TABLE "lead_stage_event" ADD CONSTRAINT "lead_stage_event_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "lead_stage_event" ADD CONSTRAINT "lead_stage_event_lead_id_lead_id_fk" FOREIGN KEY ("lead_id") REFERENCES "public"."lead"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "lead_stage_event" ADD CONSTRAINT "lead_stage_event_contact_id_contact_id_fk" FOREIGN KEY ("contact_id") REFERENCES "public"."contact"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "lead_stage_event" ADD CONSTRAINT "lead_stage_event_from_stage_id_pipeline_stage_id_fk" FOREIGN KEY ("from_stage_id") REFERENCES "public"."pipeline_stage"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "lead_stage_event" ADD CONSTRAINT "lead_stage_event_to_stage_id_pipeline_stage_id_fk" FOREIGN KEY ("to_stage_id") REFERENCES "public"."pipeline_stage"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "lead_stage_event" ADD CONSTRAINT "lead_stage_event_actor_user_id_user_id_fk" FOREIGN KEY ("actor_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "lse_org_occurred_idx" ON "lead_stage_event" USING btree ("organization_id","occurred_at");--> statement-breakpoint
+CREATE INDEX "lse_lead_occurred_idx" ON "lead_stage_event" USING btree ("lead_id","occurred_at");--> statement-breakpoint
+CREATE INDEX "lse_org_kind_occurred_idx" ON "lead_stage_event" USING btree ("organization_id","to_stage_kind","occurred_at");--> statement-breakpoint
+-- Siembra de la bitácora para los leads que ya existían.
+-- El pasado NO se reconstruye: se marca `approximate = true` para que estos
+-- eventos cuenten en los TOTALES pero nunca en los promedios de tiempo.
+-- Idempotente: el id se deriva del lead con md5, así que re-ejecutar la
+-- migración no duplica.
+--
+-- 1) "Nació aquí": todo lead entra por la primera etapa del tablero, que es
+--    exactamente donde lo pone la ingesta. La fecha SÍ es confiable
+--    (`created_at` no se pisa).
+INSERT INTO "lead_stage_event" (
+  "id","organization_id","lead_id","contact_id",
+  "from_stage_id","from_stage_name","to_stage_id","to_stage_name","to_stage_kind",
+  "occurred_at","actor_user_id","source","approximate","created_at"
+)
+SELECT
+  'lse_' || substr(md5(l."id" || ':nacio'), 1, 20),
+  l."organization_id", l."id", l."contact_id",
+  NULL, NULL,
+  primera."id", primera."name", primera."kind",
+  l."created_at", NULL, 'migracion', true, now()
+FROM "lead" l
+CROSS JOIN LATERAL (
+  SELECT s."id", s."name", s."kind"
+  FROM "pipeline_stage" s
+  WHERE s."organization_id" = l."organization_id"
+  ORDER BY s."position" ASC
+  LIMIT 1
+) AS primera
+WHERE NOT EXISTS (
+  SELECT 1 FROM "lead_stage_event" e
+  WHERE e."id" = 'lse_' || substr(md5(l."id" || ':nacio'), 1, 20)
+);--> statement-breakpoint
+-- 2) "Llegó hasta aquí": un segundo evento hacia la etapa ACTUAL para los
+--    leads que ya no están en la primera. Sin él, el embudo diría que ningún
+--    lead viejo pasó de la primera columna. La fecha es `updated_at`, que
+--    cualquier edición pisa: por eso va como aproximada.
+INSERT INTO "lead_stage_event" (
+  "id","organization_id","lead_id","contact_id",
+  "from_stage_id","from_stage_name","to_stage_id","to_stage_name","to_stage_kind",
+  "occurred_at","actor_user_id","source","approximate","created_at"
+)
+SELECT
+  'lse_' || substr(md5(l."id" || ':actual'), 1, 20),
+  l."organization_id", l."id", l."contact_id",
+  primera."id", primera."name",
+  actual."id", actual."name", actual."kind",
+  GREATEST(l."updated_at", l."created_at"), NULL, 'migracion', true, now()
+FROM "lead" l
+JOIN "pipeline_stage" actual ON actual."id" = l."stage_id"
+CROSS JOIN LATERAL (
+  SELECT s."id", s."name"
+  FROM "pipeline_stage" s
+  WHERE s."organization_id" = l."organization_id"
+  ORDER BY s."position" ASC
+  LIMIT 1
+) AS primera
+WHERE actual."id" <> primera."id"
+AND NOT EXISTS (
+  SELECT 1 FROM "lead_stage_event" e
+  WHERE e."id" = 'lse_' || substr(md5(l."id" || ':actual'), 1, 20)
+);

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,2395 @@
+{
+  "id": "02ee9517-0e47-4ab4-899e-37258269025f",
+  "prevId": "f8d220d4-2f13-4063-bfc2-a1bc88b746d3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_profile": {
+      "name": "agent_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asistente'"
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalation_rules": {
+          "name": "escalation_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_profile_org_uq": {
+          "name": "agent_profile_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_profile_organization_id_organization_id_fk": {
+          "name": "agent_profile_organization_id_organization_id_fk",
+          "tableFrom": "agent_profile",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_case": {
+      "name": "agent_test_case",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "veredicto": {
+          "name": "veredicto",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hallazgos": {
+          "name": "hallazgos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_case_run_idx": {
+          "name": "test_case_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_case_organization_id_organization_id_fk": {
+          "name": "agent_test_case_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_run_id_agent_test_run_id_fk": {
+          "name": "agent_test_case_run_id_agent_test_run_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "agent_test_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_conversation_id_conversation_id_fk": {
+          "name": "agent_test_case_conversation_id_conversation_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_run": {
+      "name": "agent_test_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "test_run_org_running_uq": {
+          "name": "test_run_org_running_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_test_run\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_run_org_idx": {
+          "name": "test_run_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_run_organization_id_organization_id_fk": {
+          "name": "agent_test_run_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact": {
+      "name": "contact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_identity": {
+          "name": "wa_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_user_id": {
+          "name": "wa_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ficha": {
+          "name": "ficha",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_org_wa_identity_uq": {
+          "name": "contact_org_wa_identity_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_wa_user_id_idx": {
+          "name": "contact_org_wa_user_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_name_idx": {
+          "name": "contact_org_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_organization_id_organization_id_fk": {
+          "name": "contact_organization_id_organization_id_fk",
+          "tableFrom": "contact",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_test": {
+          "name": "is_test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ai_enabled": {
+          "name": "ai_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handoff_at": {
+          "name": "handoff_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_reason": {
+          "name": "handoff_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_inbound_at": {
+          "name": "last_inbound_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_org_contact_real_uq": {
+          "name": "conversation_org_contact_real_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation\".\"is_test\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_org_last_idx": {
+          "name": "conversation_org_last_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_organization_id_organization_id_fk": {
+          "name": "conversation_organization_id_organization_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_contact_id_contact_id_fk": {
+          "name": "conversation_contact_id_contact_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_entry": {
+      "name": "kb_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kb_org_idx": {
+          "name": "kb_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_entry_organization_id_organization_id_fk": {
+          "name": "kb_entry_organization_id_organization_id_fk",
+          "tableFrom": "kb_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead": {
+      "name": "lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lead_contact_uq": {
+          "name": "lead_contact_uq",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lead_org_stage_idx": {
+          "name": "lead_org_stage_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_organization_id_organization_id_fk": {
+          "name": "lead_organization_id_organization_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_contact_id_contact_id_fk": {
+          "name": "lead_contact_id_contact_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead_stage_event": {
+      "name": "lead_stage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_stage_id": {
+          "name": "from_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_stage_name": {
+          "name": "from_stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage_id": {
+          "name": "to_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage_name": {
+          "name": "to_stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_stage_kind": {
+          "name": "to_stage_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dueno'"
+        },
+        "approximate": {
+          "name": "approximate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "loss_reason": {
+          "name": "loss_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loss_note": {
+          "name": "loss_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lse_org_occurred_idx": {
+          "name": "lse_org_occurred_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lse_lead_occurred_idx": {
+          "name": "lse_lead_occurred_idx",
+          "columns": [
+            {
+              "expression": "lead_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lse_org_kind_occurred_idx": {
+          "name": "lse_org_kind_occurred_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_stage_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_stage_event_organization_id_organization_id_fk": {
+          "name": "lead_stage_event_organization_id_organization_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_lead_id_lead_id_fk": {
+          "name": "lead_stage_event_lead_id_lead_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "lead",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_contact_id_contact_id_fk": {
+          "name": "lead_stage_event_contact_id_contact_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_from_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_event_from_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "from_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_to_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_event_to_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "to_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_actor_user_id_user_id_fk": {
+          "name": "lead_stage_event_actor_user_id_user_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lse_loss_reason_ck": {
+          "name": "lse_loss_reason_ck",
+          "value": "\"lead_stage_event\".\"to_stage_kind\" <> 'lost' OR \"lead_stage_event\".\"approximate\" = true OR \"lead_stage_event\".\"loss_reason\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_asset": {
+      "name": "media_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_media_id": {
+          "name": "wa_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_status": {
+          "name": "fetch_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_asset_org_idx": {
+          "name": "media_asset_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_asset_wa_media_idx": {
+          "name": "media_asset_wa_media_idx",
+          "columns": [
+            {
+              "expression": "wa_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_asset_organization_id_organization_id_fk": {
+          "name": "media_asset_organization_id_organization_id_fk",
+          "tableFrom": "media_asset",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_message_id": {
+          "name": "wa_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated": {
+          "name": "ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'operator'"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_timestamp": {
+          "name": "wa_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_org_conv_idx": {
+          "name": "message_org_conv_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_organization_id_organization_id_fk": {
+          "name": "message_organization_id_organization_id_fk",
+          "tableFrom": "message",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_media_asset_id_media_asset_id_fk": {
+          "name": "message_media_asset_id_media_asset_id_fk",
+          "tableFrom": "message",
+          "tableTo": "media_asset",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_wa_message_id_unique": {
+          "name": "message_wa_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wa_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_credentials": {
+      "name": "meta_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waba_id": {
+          "name": "waba_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number_id": {
+          "name": "phone_number_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_phone_number": {
+          "name": "display_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_name": {
+          "name": "verified_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_cipher": {
+          "name": "token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meta_credentials_org_uq": {
+          "name": "meta_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meta_credentials_phone_uq": {
+          "name": "meta_credentials_phone_uq",
+          "columns": [
+            {
+              "expression": "phone_number_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meta_credentials_organization_id_organization_id_fk": {
+          "name": "meta_credentials_organization_id_organization_id_fk",
+          "tableFrom": "meta_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_stage": {
+      "name": "pipeline_stage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stage_org_pos_idx": {
+          "name": "stage_org_pos_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_stage_organization_id_organization_id_fk": {
+          "name": "pipeline_stage_organization_id_organization_id_fk",
+          "tableFrom": "pipeline_stage",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_template_id": {
+          "name": "wa_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_org_name_lang_uq": {
+          "name": "template_org_name_lang_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_organization_id_organization_id_fk": {
+          "name": "template_organization_id_organization_id_fk",
+          "tableFrom": "template",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1786835958011,
       "tag": "0003_flippant_mastermind",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1786849014992,
+      "tag": "0004_reflective_the_enforcers",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/e2e-bitacora-etapas.mjs
+++ b/scripts/e2e-bitacora-etapas.mjs
@@ -1,0 +1,248 @@
+/**
+ * Self-test E2E de comportamiento — bitácora de movimientos de etapa
+ * (guion tests/e2e/us2-pipeline.md, sección "bitácora").
+ *
+ * Conduce la app por HTTP y verifica la tabla `lead_stage_event` directo en la
+ * base: todavía no hay endpoint que la exponga (llega con la analítica), y lo
+ * que este PR promete es justamente que NINGÚN camino mueva un lead sin dejar
+ * su renglón.
+ *
+ * Uso: node --env-file=.env scripts/e2e-bitacora-etapas.mjs
+ * Requiere: app corriendo (pnpm dev) con WA_MOCK_ENABLED=true y BD migrada.
+ */
+import postgres from "postgres";
+
+const BASE = process.env.APP_BASE_URL ?? "http://localhost:3000";
+const PN = "PN-BIT-1";
+const S = Math.random().toString(36).slice(2, 6).toUpperCase();
+
+let cookie = "";
+let failures = 0;
+let checks = 0;
+const ok = (name, cond, extra = "") => {
+  checks++;
+  if (cond) console.log(`  ✓ ${name}`);
+  else {
+    failures++;
+    console.log(`  ✗ ${name}${extra ? ` — ${extra}` : ""}`);
+  }
+};
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const until = async (fn, ms = 20000) => {
+  const t0 = Date.now();
+  while (Date.now() - t0 < ms) {
+    if (await fn()) return true;
+    await sleep(200);
+  }
+  return false;
+};
+
+async function api(path, opts = {}) {
+  const res = await fetch(`${BASE}${path}`, {
+    ...opts,
+    headers: {
+      "content-type": "application/json",
+      origin: BASE,
+      ...(cookie ? { cookie } : {}),
+      ...(opts.headers ?? {}),
+    },
+  });
+  const set = res.headers.getSetCookie?.() ?? [];
+  if (set.length) cookie = set.map((c) => c.split(";")[0]).join("; ");
+  let json = null;
+  try {
+    json = await res.clone().json();
+  } catch {}
+  return { res, json };
+}
+
+const sql = postgres(process.env.DATABASE_URL, { max: 1, onnotice: () => {} });
+const eventosDe = (leadId) =>
+  sql`select * from lead_stage_event where lead_id = ${leadId} order by occurred_at asc, created_at asc`;
+
+console.log("== Setup ==");
+const email = "e2e@vocero.test";
+const password = "password-e2e-123";
+let su = await api("/api/auth/sign-up/email", {
+  method: "POST",
+  body: JSON.stringify({ email, password, name: "Operador E2E" }),
+});
+if (!su.res.ok) {
+  su = await api("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+}
+ok("registro o login del operador", su.res.ok);
+
+const conn = await api("/api/settings/whatsapp", {
+  method: "PUT",
+  body: JSON.stringify({ wabaId: "WABA-BIT", phoneNumberId: PN, token: "tok-bit" }),
+});
+ok("conexión WhatsApp guardada", conn.res.ok);
+
+console.log("\n== El lead nace con su evento ==");
+const NAME = `Prospecto${S}`;
+await api("/api/dev/wa-mock/inbound", {
+  method: "POST",
+  body: JSON.stringify({
+    phoneNumberId: PN,
+    from: `52155600${Math.floor(1000 + Math.random() * 8999)}`,
+    name: NAME,
+    text: "hola, me interesa",
+  }),
+});
+let lead = null;
+await until(async () => {
+  const board = (await api("/api/pipeline/board")).json;
+  lead = (board?.leads ?? []).find((l) => l.contact.name === NAME);
+  return Boolean(lead);
+});
+ok("el lead se creó al entrar el mensaje", Boolean(lead));
+
+let eventos = await eventosDe(lead.id);
+ok(
+  "quedó su evento de nacimiento",
+  eventos.length === 1 && eventos[0].from_stage_id === null,
+  JSON.stringify(eventos.map((e) => e.to_stage_name))
+);
+ok(
+  "y NO viene marcado como aproximado (pasó de verdad)",
+  eventos[0]?.approximate === false
+);
+
+console.log("\n== Mover una tarjeta deja su renglón ==");
+const board = (await api("/api/pipeline/board")).json;
+const abierta = board.stages.find(
+  (s) => s.kind === "open" && s.id !== lead.stageId
+);
+const mov = await api(`/api/pipeline/leads/${lead.id}`, {
+  method: "PATCH",
+  body: JSON.stringify({ stageId: abierta.id, position: 0 }),
+});
+ok("el PATCH del tablero responde 200", mov.res.ok, JSON.stringify(mov.json));
+eventos = await eventosDe(lead.id);
+ok(
+  "la bitácora tiene DOS eventos y el segundo trae de dónde venía",
+  eventos.length === 2 && eventos[1].from_stage_id !== null,
+  JSON.stringify(eventos.map((e) => `${e.from_stage_name ?? "—"}→${e.to_stage_name}`))
+);
+ok(
+  "y guarda quién lo movió y por qué camino",
+  eventos[1].source === "dueno" && eventos[1].actor_user_id !== null,
+  JSON.stringify({ source: eventos[1].source, actor: eventos[1].actor_user_id })
+);
+
+console.log("\n== Reordenar en la MISMA etapa no inventa un movimiento ==");
+await api(`/api/pipeline/leads/${lead.id}`, {
+  method: "PATCH",
+  body: JSON.stringify({ stageId: abierta.id, position: 3 }),
+});
+eventos = await eventosDe(lead.id);
+ok("siguen siendo dos eventos", eventos.length === 2, `hay ${eventos.length}`);
+
+console.log("\n== Perder un trato exige motivo ==");
+const perdida = board.stages.find((s) => s.kind === "lost");
+const sinMotivo = await api(`/api/pipeline/leads/${lead.id}`, {
+  method: "PATCH",
+  body: JSON.stringify({ stageId: perdida.id, position: 0 }),
+});
+ok(
+  "sin motivo → 422 loss_reason_required",
+  sinMotivo.res.status === 422 &&
+    sinMotivo.json?.error?.code === "loss_reason_required",
+  JSON.stringify(sinMotivo.json)
+);
+const board2 = (await api("/api/pipeline/board")).json;
+const sigueIgual = board2.leads.find((l) => l.id === lead.id);
+ok(
+  "y la tarjeta NO se movió: el rechazo no deja el tablero a medias",
+  sigueIgual?.stageId === abierta.id,
+  `quedó en ${sigueIgual?.stageId}`
+);
+
+const conMotivo = await api(`/api/pipeline/leads/${lead.id}`, {
+  method: "PATCH",
+  body: JSON.stringify({
+    stageId: perdida.id,
+    position: 0,
+    lossReason: "precio",
+    lossNote: "Se fue con una cotización más barata",
+  }),
+});
+ok("con motivo → 200", conMotivo.res.ok, JSON.stringify(conMotivo.json));
+eventos = await eventosDe(lead.id);
+const ultimo = eventos.at(-1);
+ok(
+  "el motivo y la nota quedan en la bitácora",
+  ultimo.loss_reason === "precio" &&
+    ultimo.loss_note?.includes("más barata") &&
+    ultimo.to_stage_kind === "lost",
+  JSON.stringify({ reason: ultimo.loss_reason, kind: ultimo.to_stage_kind })
+);
+
+console.log("\n== La base tampoco lo permite (no depende de la ruta) ==");
+let rechazadoPorLaBase = false;
+try {
+  await sql`
+    insert into lead_stage_event (id, organization_id, lead_id, contact_id,
+      to_stage_name, to_stage_kind, source, approximate)
+    values (${"lse_probe_" + S}, ${ultimo.organization_id}, ${lead.id},
+      ${ultimo.contact_id}, 'Perdido', 'lost', 'dueno', false)`;
+} catch (err) {
+  rechazadoPorLaBase = String(err).includes("lse_loss_reason_ck");
+}
+ok(
+  "un INSERT directo de 'perdido' sin motivo lo rechaza el CHECK",
+  rechazadoPorLaBase
+);
+
+console.log("\n== El bot también pasa por la puerta ==");
+const convs = (await api("/api/conversations")).json?.conversations ?? [];
+const conv = convs.find((c) => c.contact.name === NAME);
+const reset = await api("/api/bot/reset", {
+  method: "POST",
+  headers: { "x-api-key": process.env.BOT_API_KEY ?? "" },
+  body: JSON.stringify({ conversationId: conv.id }),
+});
+ok("POST /api/bot/reset → 200", reset.res.ok);
+await sleep(400);
+eventos = await eventosDe(lead.id);
+ok(
+  "el regreso al inicio quedó registrado como 'sistema'",
+  eventos.at(-1).source === "sistema",
+  JSON.stringify(eventos.map((e) => e.source))
+);
+
+console.log("\n== Borrar una etapa registra un evento por lead ==");
+const nueva = await api("/api/pipeline/stages", {
+  method: "POST",
+  body: JSON.stringify({ name: `Temporal ${S}` }),
+});
+const stageTemp = nueva.json?.stage;
+ok("etapa temporal creada", Boolean(stageTemp), JSON.stringify(nueva.json));
+await api(`/api/pipeline/leads/${lead.id}`, {
+  method: "PATCH",
+  body: JSON.stringify({ stageId: stageTemp.id, position: 0 }),
+});
+const antesDeBorrar = (await eventosDe(lead.id)).length;
+const destino = board.stages.find((s) => s.kind === "open");
+const borrada = await api(
+  `/api/pipeline/stages/${stageTemp.id}?moveTo=${destino.id}`,
+  { method: "DELETE" }
+);
+ok("etapa borrada con reubicación", borrada.res.ok, JSON.stringify(borrada.json));
+eventos = await eventosDe(lead.id);
+ok(
+  "la reubicación dejó su propio evento",
+  eventos.length === antesDeBorrar + 1 && eventos.at(-1).source === "sistema",
+  `antes ${antesDeBorrar}, ahora ${eventos.length}`
+);
+
+console.log(
+  failures === 0
+    ? `\nTODO VERDE — ${checks}/${checks} checks`
+    : `\n${checks - failures}/${checks} checks — ${failures} FALLARON`
+);
+await sql.end();
+process.exit(failures === 0 ? 0 : 1);

--- a/src/app/api/bot/reset/route.ts
+++ b/src/app/api/bot/reset/route.ts
@@ -4,6 +4,7 @@ import { getDb, schema } from "@/lib/db";
 import { apiError, parseBody } from "@/lib/api";
 import { requireBotKey, resolveInstanceOrg } from "@/server/bot/auth";
 import { publish } from "@/server/events/bus";
+import { moveLeadToStage } from "@/server/leads/stage-history";
 
 export const dynamic = "force-dynamic";
 
@@ -74,10 +75,15 @@ export async function POST(req: Request) {
       )
       .limit(1);
     if (first && leadRows[0]) {
-      await db
-        .update(schema.lead)
-        .set({ stageId: first.id, updatedAt: new Date() })
-        .where(eq(schema.lead.id, leadRows[0].id));
+      // Por la puerta única: devolver la conversación de pruebas al inicio
+      // también es un movimiento, y la bitácora tiene que poder explicar por
+      // qué un lead retrocedió de etapa.
+      await moveLeadToStage({
+        organizationId,
+        leadId: leadRows[0].id,
+        toStageId: first.id,
+        source: "sistema",
+      });
     }
   } catch (err) {
     console.warn(`[bot/reset] reinicio de etapa falló: ${err}`);

--- a/src/app/api/pipeline/leads/[id]/route.ts
+++ b/src/app/api/pipeline/leads/[id]/route.ts
@@ -2,8 +2,8 @@ import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { apiError, parseBody, withAuth } from "@/lib/api";
 import { getDb, schema } from "@/lib/db";
-import { scoped } from "@/lib/db/tenant";
 import { publish } from "@/server/events/bus";
+import { moveLeadToStage } from "@/server/leads/stage-history";
 
 export const dynamic = "force-dynamic";
 
@@ -12,6 +12,22 @@ type Params = { params: Promise<{ id: string }> };
 const patchSchema = z.object({
   stageId: z.string().min(1),
   position: z.number().int().min(0),
+  /**
+   * Obligatorio al ENTRAR a una etapa perdida. No se valida aquí sino en la
+   * puerta: la regla es del dominio, no de esta ruta, y hay más caminos que
+   * mueven tarjetas.
+   */
+  lossReason: z
+    .enum([
+      "precio",
+      "no_es_perfil",
+      "sin_presupuesto",
+      "eligio_otro",
+      "nunca_contesto",
+      "otro",
+    ])
+    .optional(),
+  lossNote: z.string().max(500).optional(),
 });
 
 export const PATCH = withAuth(async (session, req: Request, ctx: Params) => {
@@ -19,37 +35,34 @@ export const PATCH = withAuth(async (session, req: Request, ctx: Params) => {
   const body = await parseBody(req, patchSchema);
   if (!body.ok) return body.response;
 
+  const res = await moveLeadToStage({
+    organizationId: session.organizationId,
+    leadId: id,
+    toStageId: body.data.stageId,
+    position: body.data.position,
+    actorUserId: session.userId,
+    source: "dueno",
+    lossReason: body.data.lossReason ?? null,
+    lossNote: body.data.lossNote ?? null,
+  });
+
+  if (!res.ok) {
+    if (res.reason === "lead_not_found") {
+      return apiError(404, "not_found", "Lead no encontrado");
+    }
+    if (res.reason === "stage_not_found") {
+      return apiError(422, "invalid_stage", "Etapa inexistente");
+    }
+    // El tablero abre su diálogo con este código: perder un trato sin decir
+    // por qué deja el embudo sin la mitad que importa.
+    return apiError(
+      422,
+      "loss_reason_required",
+      "Falta el motivo de la pérdida"
+    );
+  }
+
   const db = getDb();
-  const stage = await db
-    .select({ id: schema.pipelineStage.id })
-    .from(schema.pipelineStage)
-    .where(
-      scoped(
-        schema.pipelineStage.organizationId,
-        session.organizationId,
-        eq(schema.pipelineStage.id, body.data.stageId)
-      )
-    )
-    .limit(1);
-  if (!stage[0]) return apiError(422, "invalid_stage", "Etapa inexistente");
-
-  const updated = await db
-    .update(schema.lead)
-    .set({
-      stageId: body.data.stageId,
-      position: body.data.position,
-      updatedAt: new Date(),
-    })
-    .where(
-      scoped(
-        schema.lead.organizationId,
-        session.organizationId,
-        eq(schema.lead.id, id)
-      )
-    )
-    .returning();
-  if (!updated[0]) return apiError(404, "not_found", "Lead no encontrado");
-
   // Notifica a la bandeja para que la etapa se refleje en vivo (panel de
   // detalles y punto de etapa de la lista) sin recargar.
   const convRows = await db
@@ -58,7 +71,7 @@ export const PATCH = withAuth(async (session, req: Request, ctx: Params) => {
     .where(
       and(
         eq(schema.conversation.organizationId, session.organizationId),
-        eq(schema.conversation.contactId, updated[0].contactId),
+        eq(schema.conversation.contactId, res.lead.contactId),
         eq(schema.conversation.isTest, false)
       )
     )
@@ -70,5 +83,5 @@ export const PATCH = withAuth(async (session, req: Request, ctx: Params) => {
     });
   }
 
-  return Response.json({ lead: updated[0] });
+  return Response.json({ lead: res.lead });
 });

--- a/src/app/api/pipeline/stages/[id]/route.ts
+++ b/src/app/api/pipeline/stages/[id]/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { apiError, parseBody, withAuth } from "@/lib/api";
 import { getDb, schema } from "@/lib/db";
 import { scoped } from "@/lib/db/tenant";
+import { relocateLeadsFromStage } from "@/server/leads/stage-history";
 
 export const dynamic = "force-dynamic";
 
@@ -100,16 +101,14 @@ export const DELETE = withAuth(async (session, req: Request, ctx: Params) => {
     if (!dest[0] || moveTo === id) {
       return apiError(422, "invalid_move_to", "Etapa destino inválida");
     }
-    await db
-      .update(schema.lead)
-      .set({ stageId: moveTo, updatedAt: new Date() })
-      .where(
-        scoped(
-          schema.lead.organizationId,
-          session.organizationId,
-          eq(schema.lead.stageId, id)
-        )
-      );
+    // Por la puerta única, un evento por lead: el embudo debe poder explicar
+    // por qué treinta tarjetas cambiaron de columna el mismo minuto.
+    await relocateLeadsFromStage({
+      organizationId: session.organizationId,
+      fromStageId: id,
+      toStageId: moveTo,
+      actorUserId: session.userId,
+    });
   }
 
   await db

--- a/src/components/pipeline/loss-reason-dialog.tsx
+++ b/src/components/pipeline/loss-reason-dialog.tsx
@@ -1,0 +1,91 @@
+﻿"use client";
+
+import { useState } from "react";
+import { LOSS_REASON_LABEL, type LossReason } from "@/lib/types";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+const REASONS = Object.keys(LOSS_REASON_LABEL) as LossReason[];
+
+/**
+ * Motivo de pérdida. Se pide al ENTRAR a la etapa perdida y es
+ * obligatorio: sin él el trato no se marca como perdido, ni aquí ni en la API,
+ * ni en la base (hay un CHECK). Es la métrica que dice qué cambiar en la oferta
+ * o en el anuncio, y solo se puede capturar en el momento en que se sabe.
+ */
+export function LossReasonDialog({
+  leadName,
+  onCancel,
+  onConfirm,
+}: {
+  leadName: string;
+  onCancel: () => void;
+  onConfirm: (reason: LossReason, note: string) => void;
+}) {
+  const [reason, setReason] = useState<LossReason | null>(null);
+  const [note, setNote] = useState("");
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4"
+      onClick={onCancel}
+    >
+      <div
+        role="dialog"
+        aria-label="Motivo de pérdida"
+        className="w-full max-w-md rounded-lg border bg-card p-5 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="mb-1 font-semibold">¿Por qué se perdió?</h3>
+        <p className="mb-4 text-xs text-text-3">
+          {leadName} pasa a Perdido. El motivo es lo único que después explica
+          qué cambiar: sin él, la gráfica de pérdidas no dice nada.
+        </p>
+
+        <div className="space-y-2">
+          {REASONS.map((r) => (
+            <button
+              key={r}
+              type="button"
+              onClick={() => setReason(r)}
+              aria-pressed={reason === r}
+              className={
+                reason === r
+                  ? "w-full rounded-md border border-brand bg-brand-tint px-3 py-2 text-left text-sm font-medium"
+                  : "w-full rounded-md border px-3 py-2 text-left text-sm hover:bg-subtle"
+              }
+            >
+              {LOSS_REASON_LABEL[r]}
+            </button>
+          ))}
+        </div>
+
+        <div className="mt-3 space-y-1.5">
+          <label className="text-sm font-medium" htmlFor="loss-note">
+            Nota (opcional)
+          </label>
+          <Textarea
+            id="loss-note"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            rows={2}
+            maxLength={500}
+            placeholder="Se fue con una agencia local por la mitad del precio"
+          />
+        </div>
+
+        <div className="mt-4 flex justify-end gap-2">
+          <Button variant="ghost" onClick={onCancel}>
+            Cancelar
+          </Button>
+          <Button
+            disabled={!reason}
+            onClick={() => reason && onConfirm(reason, note.trim())}
+          >
+            Marcar como perdido
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pipeline/pipeline-client.tsx
+++ b/src/components/pipeline/pipeline-client.tsx
@@ -14,12 +14,13 @@ import {
   type DragStartEvent,
 } from "@dnd-kit/core";
 import { MessageSquareText, Settings2, Trophy, XCircle } from "lucide-react";
-import type { StageDto } from "@/lib/types";
+import type { LossReason, StageDto } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { ContactAvatar } from "@/components/avatar";
 import { Button } from "@/components/ui/button";
 import { formatTime } from "@/components/inbox/helpers";
 import { StageManager } from "./stage-manager";
+import { LossReasonDialog } from "./loss-reason-dialog";
 
 export type BoardLead = {
   id: string;
@@ -35,6 +36,12 @@ export function PipelineClient() {
   const [leads, setLeads] = useState<BoardLead[]>([]);
   const [activeLead, setActiveLead] = useState<BoardLead | null>(null);
   const [managing, setManaging] = useState(false);
+  /** Arrastre hacia una etapa perdida, esperando el motivo. */
+  const [pendingLoss, setPendingLoss] = useState<{
+    leadId: string;
+    stageId: string;
+    name: string;
+  } | null>(null);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } })
@@ -57,14 +64,11 @@ export function PipelineClient() {
     setActiveLead(lead ?? null);
   }
 
-  async function onDragEnd(event: DragEndEvent) {
-    setActiveLead(null);
-    const leadId = String(event.active.id);
-    const overStage = event.over ? String(event.over.id) : null;
-    if (!overStage) return;
-    const lead = leads.find((l) => l.id === leadId);
-    if (!lead || lead.stageId === overStage) return;
-
+  async function moverLead(
+    leadId: string,
+    overStage: string,
+    loss?: { reason: LossReason; note: string }
+  ) {
     const position = leads.filter((l) => l.stageId === overStage).length;
     // Optimista + persistencia
     setLeads((prev) =>
@@ -73,9 +77,34 @@ export function PipelineClient() {
     await fetch(`/api/pipeline/leads/${leadId}`, {
       method: "PATCH",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ stageId: overStage, position }),
+      body: JSON.stringify({
+        stageId: overStage,
+        position,
+        ...(loss
+          ? { lossReason: loss.reason, ...(loss.note ? { lossNote: loss.note } : {}) }
+          : {}),
+      }),
     }).catch(() => null);
     void refetch();
+  }
+
+  async function onDragEnd(event: DragEndEvent) {
+    setActiveLead(null);
+    const leadId = String(event.active.id);
+    const overStage = event.over ? String(event.over.id) : null;
+    if (!overStage) return;
+    const lead = leads.find((l) => l.id === leadId);
+    if (!lead || lead.stageId === overStage) return;
+
+    // Perder un trato exige motivo. Se pregunta ANTES de mover: si el dueño
+    // cancela, la tarjeta ni siquiera parpadea fuera de su columna.
+    const destino = stages.find((s) => s.id === overStage);
+    if (destino?.kind === "lost") {
+      setPendingLoss({ leadId, stageId: overStage, name: lead.contact.name });
+      return;
+    }
+
+    await moverLead(leadId, overStage);
   }
 
   return (
@@ -117,6 +146,18 @@ export function PipelineClient() {
           stages={stages}
           onClose={() => setManaging(false)}
           onChanged={() => void refetch()}
+        />
+      )}
+
+      {pendingLoss && (
+        <LossReasonDialog
+          leadName={pendingLoss.name}
+          onCancel={() => setPendingLoss(null)}
+          onConfirm={(reason, note) => {
+            const { leadId, stageId } = pendingLoss;
+            setPendingLoss(null);
+            void moverLead(leadId, stageId, { reason, note });
+          }}
         />
       )}
     </div>

--- a/src/lib/db/ids.ts
+++ b/src/lib/db/ids.ts
@@ -11,6 +11,7 @@ const prefixes = {
   message: "msg",
   lead: "ld",
   stage: "stg",
+  leadStageEvent: "lse",
   credentials: "cred",
   agentProfile: "agp",
   kbEntry: "kb",

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,5 +1,6 @@
 import {
   boolean,
+  check,
   index,
   integer,
   jsonb,
@@ -181,6 +182,92 @@ export const lead = pgTable(
   (t) => [
     uniqueIndex("lead_contact_uq").on(t.contactId),
     index("lead_org_stage_idx").on(t.organizationId, t.stageId, t.position),
+  ]
+);
+
+/**
+ * Bitácora de movimientos de etapa: append-only. Nada se actualiza ni se borra;
+ * corregir un dato es agregar un movimiento nuevo.
+ *
+ * Es el cimiento de todo lo histórico: sin ella el CRM solo sabe dónde está
+ * cada lead HOY, y "¿cuánto cerré en julio?" no tiene respuesta.
+ *
+ * Regla dura: la ÚNICA puerta que escribe aquí —y que escribe `lead.stage_id`—
+ * es `src/server/leads/stage-history.ts`. Un unit test de vigilancia falla si
+ * aparece otra escritura, porque un camino que mueva el lead sin registrar el
+ * evento no truena: solo hace que las gráficas mientan meses después.
+ */
+export const leadStageEvent = pgTable(
+  "lead_stage_event",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    leadId: text("lead_id")
+      .notNull()
+      .references(() => lead.id, { onDelete: "cascade" }),
+    /** Denormalizado a propósito: casi toda agregación cruza con el contacto,
+     *  y el join extra se pagaría en cada consulta. */
+    contactId: text("contact_id")
+      .notNull()
+      .references(() => contact.id, { onDelete: "cascade" }),
+    /** NULL = el lead nació en `toStage` (evento de creación). */
+    fromStageId: text("from_stage_id").references(() => pipelineStage.id, {
+      onDelete: "set null",
+    }),
+    fromStageName: text("from_stage_name"),
+    toStageId: text("to_stage_id").references(() => pipelineStage.id, {
+      onDelete: "set null",
+    }),
+    /** Snapshots: sobreviven al renombre y al borrado de la etapa, para que
+     *  reorganizar el tablero de hoy no reescriba el embudo del pasado. */
+    toStageName: text("to_stage_name").notNull(),
+    toStageKind: text("to_stage_kind", { enum: ["open", "won", "lost"] })
+      .notNull()
+      .default("open"),
+    /** Cuándo PASÓ (no cuándo se registró). */
+    occurredAt: timestamp("occurred_at").notNull().defaultNow(),
+    /** NULL = no lo movió una persona (bot, sistema, migración). */
+    actorUserId: text("actor_user_id").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    source: text("source", {
+      enum: ["dueno", "bot", "sistema", "migracion"],
+    })
+      .notNull()
+      .default("dueno"),
+    /** true = fecha SEMBRADA en la migración, no observada. Cuenta para los
+     *  totales pero jamás para promedios de tiempo. */
+    approximate: boolean("approximate").notNull().default(false),
+    lossReason: text("loss_reason", {
+      enum: [
+        "precio",
+        "no_es_perfil",
+        "sin_presupuesto",
+        "eligio_otro",
+        "nunca_contesto",
+        "otro",
+      ],
+    }),
+    lossNote: text("loss_note"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (t) => [
+    index("lse_org_occurred_idx").on(t.organizationId, t.occurredAt),
+    index("lse_lead_occurred_idx").on(t.leadId, t.occurredAt),
+    index("lse_org_kind_occurred_idx").on(
+      t.organizationId,
+      t.toStageKind,
+      t.occurredAt
+    ),
+    // Perder un trato sin motivo es imposible a nivel de BASE, no por
+    // disciplina de cada ruta. La excepción es la siembra de la migración: no
+    // puede inventar un motivo que nadie capturó.
+    check(
+      "lse_loss_reason_ck",
+      sql`${t.toStageKind} <> 'lost' OR ${t.approximate} = true OR ${t.lossReason} IS NOT NULL`
+    ),
   ]
 );
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -78,3 +78,29 @@ export type ContactDto = {
   stageName: string | null;
   archivedAt: string | null;
 };
+
+/* ============================================================
+ * Bitácora de etapas
+ * ============================================================ */
+
+/** Por qué se perdió un trato. Lista corta a propósito: una taxonomía larga
+ *  se responde "otro" y deja de informar. */
+export type LossReason =
+  | "precio"
+  | "no_es_perfil"
+  | "sin_presupuesto"
+  | "eligio_otro"
+  | "nunca_contesto"
+  | "otro";
+
+export const LOSS_REASON_LABEL: Record<LossReason, string> = {
+  precio: "Le pareció caro",
+  no_es_perfil: "No era el perfil",
+  sin_presupuesto: "Sin presupuesto ahora",
+  eligio_otro: "Se fue con otro",
+  nunca_contesto: "Nunca contestó",
+  otro: "Otro",
+};
+
+/** Quién provocó un movimiento de etapa. */
+export type StageChangeSource = "dueno" | "bot" | "sistema" | "migracion";

--- a/src/server/ai/pipeline.ts
+++ b/src/server/ai/pipeline.ts
@@ -1,6 +1,8 @@
 import { asc, desc, eq } from "drizzle-orm";
 import { getDb, schema } from "@/lib/db";
 import { newId } from "@/lib/db/ids";
+import { scoped } from "@/lib/db/tenant";
+import { moveLeadToStage as moveLeadThroughHistory } from "@/server/leads/stage-history";
 import { getEnv, isAiConfigured } from "@/lib/env";
 import { chatJson, type ChatMessage } from "@/lib/ai";
 import { publish } from "@/server/events/bus";
@@ -280,10 +282,33 @@ async function moveLeadToStage(
   stageId: string
 ): Promise<void> {
   const db = getDb();
-  await db
-    .update(schema.lead)
-    .set({ stageId, updatedAt: new Date(), lastActivityAt: new Date() })
-    .where(eq(schema.lead.contactId, contactId));
+  const rows = await db
+    .select({ id: schema.lead.id })
+    .from(schema.lead)
+    .where(
+      scoped(
+        schema.lead.organizationId,
+        organizationId,
+        eq(schema.lead.contactId, contactId)
+      )
+    )
+    .limit(1);
+  const leadId = rows[0]?.id;
+  if (!leadId) return;
+
+  // Por la puerta única: el agente mueve tarjetas igual que el dueño, y su
+  // movimiento tiene que quedar en la bitácora o el embudo mentirá sobre
+  // quién hizo avanzar cada lead.
+  await moveLeadThroughHistory({
+    organizationId,
+    leadId,
+    toStageId: stageId,
+    source: "bot",
+    extra: { lastActivityAt: new Date() },
+    // El agente no clasifica pérdidas: si su etapa destino resultara ser la
+    // perdida, la puerta lo rechaza y el lead se queda donde está — mejor eso
+    // que un motivo inventado.
+  });
 }
 
 async function appendLeadNote(

--- a/src/server/inbox/lead-activity.ts
+++ b/src/server/inbox/lead-activity.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, sql } from "drizzle-orm";
 import { getDb, schema } from "@/lib/db";
 import { newId } from "@/lib/db/ids";
+import { recordLeadCreated } from "@/server/leads/stage-history";
 
 /**
  * Actividad de lead al recibir un mensaje (US2): si el contacto no tiene lead,
@@ -51,7 +52,7 @@ export async function onLeadActivity(
       )
     );
 
-  await db
+  const creado = await db
     .insert(schema.lead)
     .values({
       id: newId("lead"),
@@ -61,5 +62,21 @@ export async function onLeadActivity(
       position: (maxPos[0]?.max ?? -1) + 1,
       lastActivityAt: at,
     })
-    .onConflictDoNothing({ target: [schema.lead.contactId] });
+    .onConflictDoNothing({ target: [schema.lead.contactId] })
+    .returning({ id: schema.lead.id });
+
+  // El nacimiento del lead es el primer evento del embudo: sin él, "prospectos
+  // que entraron en el periodo" no se podría contar desde la bitácora. Va
+  // DENTRO del `if (creado)` porque `onConflictDoNothing` no devuelve fila
+  // cuando otro webhook simultáneo ganó la carrera — y ese ya anotó el suyo.
+  if (creado[0]) {
+    await recordLeadCreated({
+      organizationId,
+      leadId: creado[0].id,
+      contactId,
+      stageId: firstStage[0].id,
+      occurredAt: at,
+      source: "sistema",
+    });
+  }
 }

--- a/src/server/leads/stage-history.ts
+++ b/src/server/leads/stage-history.ts
@@ -1,0 +1,289 @@
+﻿import { and, asc, eq } from "drizzle-orm";
+import { getDb, schema } from "@/lib/db";
+import { newId } from "@/lib/db/ids";
+import { scoped } from "@/lib/db/tenant";
+import type { LossReason, StageChangeSource } from "@/lib/types";
+
+/**
+ * La ÚNICA puerta que escribe `lead.stage_id`.
+ *
+ * Regla dura: mover un lead y registrar el movimiento son
+ * la misma operación, en la misma transacción. Hoy hay cuatro caminos que
+ * cambian de etapa (el dueño arrastra, el bot avanza, el agente in-process, la
+ * reubicación al borrar una etapa); si cada uno copiara el "anota el evento",
+ * el quinto que alguien agregue lo olvidaría. Y olvidarlo NO truena: solo hace
+ * que las gráficas mientan meses después.
+ *
+ * Un unit test de vigilancia (`tests/unit/stage-history-guard.test.ts`) escanea
+ * `src/` y falla si aparece una escritura de `stageId` fuera de este archivo.
+ * No lo "arregles" moviendo el UPDATE a otro lado: es un guardarraíl.
+ */
+
+type LeadRow = typeof schema.lead.$inferSelect;
+
+export type MoveResult =
+  | { ok: true; lead: LeadRow; changed: boolean }
+  | {
+      ok: false;
+      reason: "lead_not_found" | "stage_not_found" | "loss_reason_required";
+    };
+
+export type MoveInput = {
+  organizationId: string;
+  leadId: string;
+  toStageId: string;
+  /** Posición dentro de la columna destino. */
+  position?: number;
+  /** Quién lo movió; NULL cuando no fue una persona. */
+  actorUserId?: string | null;
+  source: StageChangeSource;
+  /** Obligatorio al ENTRAR a una etapa perdida. */
+  lossReason?: LossReason | null;
+  lossNote?: string | null;
+  /** Por defecto, ahora. */
+  occurredAt?: Date;
+  /**
+   * Otros campos del lead que se escriben en el MISMO update. Existe para que
+   * el PATCH del Pipeline no tenga que hacer dos viajes cuando el dueño mueve
+   * la tarjeta y toca el monto en la misma acción.
+   */
+  extra?: Record<string, unknown>;
+};
+
+export async function moveLeadToStage(input: MoveInput): Promise<MoveResult> {
+  const db = getDb();
+  const occurredAt = input.occurredAt ?? new Date();
+
+  return db.transaction(async (tx) => {
+    const leadRows = await tx
+      .select({ lead: schema.lead, stage: schema.pipelineStage })
+      .from(schema.lead)
+      .leftJoin(
+        schema.pipelineStage,
+        eq(schema.lead.stageId, schema.pipelineStage.id)
+      )
+      .where(
+        scoped(
+          schema.lead.organizationId,
+          input.organizationId,
+          eq(schema.lead.id, input.leadId)
+        )
+      )
+      .limit(1);
+
+    const current = leadRows[0];
+    if (!current) return { ok: false as const, reason: "lead_not_found" as const };
+
+    const targetRows = await tx
+      .select()
+      .from(schema.pipelineStage)
+      .where(
+        scoped(
+          schema.pipelineStage.organizationId,
+          input.organizationId,
+          eq(schema.pipelineStage.id, input.toStageId)
+        )
+      )
+      .limit(1);
+
+    const target = targetRows[0];
+    if (!target) return { ok: false as const, reason: "stage_not_found" as const };
+
+    const changed = current.lead.stageId !== target.id;
+
+    // El motivo se exige al ENTRAR a la etapa perdida. Reordenar una tarjeta
+    // que ya estaba ahí no vuelve a preguntar.
+    if (changed && target.kind === "lost" && !input.lossReason) {
+      return { ok: false as const, reason: "loss_reason_required" as const };
+    }
+
+    const updated = await tx
+      .update(schema.lead)
+      .set({
+        ...(input.extra ?? {}),
+        stageId: target.id,
+        ...(input.position !== undefined ? { position: input.position } : {}),
+        updatedAt: new Date(),
+      })
+      .where(
+        scoped(
+          schema.lead.organizationId,
+          input.organizationId,
+          eq(schema.lead.id, input.leadId)
+        )
+      )
+      .returning();
+
+    const leadRow = updated[0];
+    if (!leadRow) return { ok: false as const, reason: "lead_not_found" as const };
+
+    if (changed) {
+      await tx.insert(schema.leadStageEvent).values({
+        id: newId("leadStageEvent"),
+        organizationId: input.organizationId,
+        leadId: leadRow.id,
+        contactId: leadRow.contactId,
+        fromStageId: current.stage?.id ?? null,
+        fromStageName: current.stage?.name ?? null,
+        toStageId: target.id,
+        toStageName: target.name,
+        toStageKind: target.kind,
+        occurredAt,
+        actorUserId: input.actorUserId ?? null,
+        source: input.source,
+        approximate: false,
+        lossReason: target.kind === "lost" ? input.lossReason ?? null : null,
+        lossNote: target.kind === "lost" ? input.lossNote ?? null : null,
+      });
+    }
+
+    return { ok: true as const, lead: leadRow, changed };
+  });
+}
+
+/**
+ * Evento de nacimiento del lead. Sin él, el embudo no tendría de dónde arrancar
+ * y "prospectos que entraron" no podría contarse desde la bitácora.
+ *
+ * Best-effort a propósito: quien lo llama viene de crear un lead (a veces desde
+ * la ingesta de un mensaje de WhatsApp), y un fallo aquí jamás debe tumbar esa
+ * ruta. El lead sin evento aparecería con su fecha de creación de todos modos.
+ */
+export async function recordLeadCreated(input: {
+  organizationId: string;
+  leadId: string;
+  contactId: string;
+  stageId: string;
+  occurredAt?: Date;
+  actorUserId?: string | null;
+  source?: StageChangeSource;
+}): Promise<void> {
+  const db = getDb();
+  const stage = await db
+    .select({
+      id: schema.pipelineStage.id,
+      name: schema.pipelineStage.name,
+      kind: schema.pipelineStage.kind,
+    })
+    .from(schema.pipelineStage)
+    .where(
+      scoped(
+        schema.pipelineStage.organizationId,
+        input.organizationId,
+        eq(schema.pipelineStage.id, input.stageId)
+      )
+    )
+    .limit(1);
+
+  const s = stage[0];
+  if (!s) return;
+
+  await db.insert(schema.leadStageEvent).values({
+    id: newId("leadStageEvent"),
+    organizationId: input.organizationId,
+    leadId: input.leadId,
+    contactId: input.contactId,
+    fromStageId: null,
+    fromStageName: null,
+    toStageId: s.id,
+    toStageName: s.name,
+    toStageKind: s.kind,
+    occurredAt: input.occurredAt ?? new Date(),
+    actorUserId: input.actorUserId ?? null,
+    source: input.source ?? "sistema",
+    approximate: false,
+    // Un lead no puede nacer perdido: el CHECK de la base lo permitiría solo
+    // con motivo, y aquí nunca hay uno que capturar.
+    lossReason: null,
+    lossNote: null,
+  });
+}
+
+/**
+ * Reubicación masiva al eliminar una etapa. Un evento por lead: el embudo debe
+ * poder explicar por qué 30 tarjetas cambiaron de columna el mismo minuto.
+ */
+export async function relocateLeadsFromStage(input: {
+  organizationId: string;
+  fromStageId: string;
+  toStageId: string;
+  actorUserId?: string | null;
+}): Promise<number> {
+  const db = getDb();
+  const leads = await db
+    .select({ id: schema.lead.id })
+    .from(schema.lead)
+    .where(
+      scoped(
+        schema.lead.organizationId,
+        input.organizationId,
+        eq(schema.lead.stageId, input.fromStageId)
+      )
+    )
+    .orderBy(asc(schema.lead.position));
+
+  const stageRows = await db
+    .select({ name: schema.pipelineStage.name })
+    .from(schema.pipelineStage)
+    .where(
+      scoped(
+        schema.pipelineStage.organizationId,
+        input.organizationId,
+        eq(schema.pipelineStage.id, input.fromStageId)
+      )
+    )
+    .limit(1);
+  const fromName = stageRows[0]?.name ?? "una etapa eliminada";
+
+  let moved = 0;
+  for (const l of leads) {
+    const res = await moveLeadToStage({
+      organizationId: input.organizationId,
+      leadId: l.id,
+      toStageId: input.toStageId,
+      actorUserId: input.actorUserId ?? null,
+      source: "sistema",
+      // Si el destino resulta ser la etapa perdida, el motivo no se puede
+      // inventar pero tampoco puede faltar: se registra lo que de verdad pasó.
+      lossReason: "otro",
+      lossNote: `Reubicado al eliminar la etapa "${fromName}"`,
+    });
+    if (res.ok) moved += 1;
+  }
+  return moved;
+}
+
+/** El último motivo de pérdida registrado de un lead, si lo hay. */
+export async function lastLossReason(
+  organizationId: string,
+  leadId: string
+): Promise<{ reason: LossReason; note: string | null; at: Date } | null> {
+  const db = getDb();
+  const rows = await db
+    .select({
+      lossReason: schema.leadStageEvent.lossReason,
+      lossNote: schema.leadStageEvent.lossNote,
+      occurredAt: schema.leadStageEvent.occurredAt,
+    })
+    .from(schema.leadStageEvent)
+    .where(
+      scoped(
+        schema.leadStageEvent.organizationId,
+        organizationId,
+        and(
+          eq(schema.leadStageEvent.leadId, leadId),
+          eq(schema.leadStageEvent.toStageKind, "lost")
+        )
+      )
+    )
+    .orderBy(asc(schema.leadStageEvent.occurredAt))
+    .limit(50);
+
+  const last = rows.filter((r) => r.lossReason).at(-1);
+  if (!last?.lossReason) return null;
+  return {
+    reason: last.lossReason,
+    note: last.lossNote,
+    at: last.occurredAt,
+  };
+}

--- a/tests/e2e/us2-pipeline.md
+++ b/tests/e2e/us2-pipeline.md
@@ -27,7 +27,29 @@
    las anclas ganado/perdido no se pueden eliminar.
 7. Eliminar "Cotizado" (vacía) → desaparece.
 
+## Bitácora de etapas
+
+Automatizado en `scripts/e2e-bitacora-etapas.mjs`. El tablero dice dónde está
+cada lead HOY; la bitácora es lo que permite preguntar qué pasó antes.
+
+8. **Nace con su evento**: provocar un entrante de un número nuevo.
+   ✅ El lead aparece en la primera etapa y su primer movimiento queda
+   registrado (sin etapa de origen).
+9. **Mover deja renglón**: arrastrar la tarjeta a otra columna.
+   ✅ Queda un movimiento con de-dónde, a-dónde, cuándo y quién lo movió.
+   ✅ Reordenar dentro de la MISMA columna no inventa un movimiento.
+10. **Perder exige motivo**: arrastrar a la etapa perdida.
+    ✅ Se abre el diálogo. Si se cancela, la tarjeta ni se movió.
+    ✅ Por API sin motivo → **422** `loss_reason_required`, y el lead se queda
+    donde estaba.
+    ✅ Con motivo → el motivo y la nota quedan en la bitácora.
+    ✅ Un INSERT directo en la base de un movimiento a "perdido" sin motivo lo
+    rechaza el CHECK `lse_loss_reason_ck`: la regla no depende de la ruta.
+11. **Todos los caminos pasan por la puerta**: `POST /api/bot/reset` deja su
+    movimiento como `sistema`, y eliminar una etapa con reubicación deja un
+    evento por cada lead reubicado.
+
 ## Contactos (FR-013)
 
-8. Buscar por "Frio" → filtra; editar notas → persiste; archivar → desaparece
-   de la lista (visible con "Ver archivados"); desarchivar → vuelve.
+12. Buscar por "Frio" → filtra; editar notas → persiste; archivar → desaparece
+    de la lista (visible con "Ver archivados"); desarchivar → vuelve.

--- a/tests/unit/stage-history-guard.test.ts
+++ b/tests/unit/stage-history-guard.test.ts
@@ -1,0 +1,77 @@
+﻿import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Guardarraíl de la bitácora de etapas.
+ *
+ * Mover un lead y registrar el movimiento son la misma operación. Si un camino
+ * nuevo escribe `lead.stage_id` por su cuenta, nada truena: simplemente el
+ * historial nace con un hueco y las gráficas mienten meses después, cuando ya
+ * no hay forma de reconstruirlo.
+ *
+ * Este test escanea el código fuente y falla si aparece esa escritura fuera de
+ * la única puerta. Si estás leyendo esto porque el test se puso rojo: no lo
+ * relajes — enruta tu cambio por `moveLeadToStage()`.
+ */
+
+const SRC = path.resolve(import.meta.dirname, "..", "..", "src");
+const PUERTA = path.join("server", "leads", "stage-history.ts");
+
+function archivosTs(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...archivosTs(full));
+    } else if (/\.(ts|tsx)$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Trozo que sigue a cada `.update(schema.lead)`, donde vive el `.set({…})`. */
+function bloquesDeUpdate(code: string): string[] {
+  const bloques: string[] = [];
+  const re = /\.update\(\s*schema\.lead\s*\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(code)) !== null) {
+    bloques.push(code.slice(match.index, match.index + 400));
+  }
+  return bloques;
+}
+
+describe("guardarraíl: una sola puerta escribe la etapa del lead", () => {
+  it("ningún archivo fuera de stage-history.ts actualiza lead.stageId", () => {
+    const infractores: string[] = [];
+
+    for (const file of archivosTs(SRC)) {
+      if (file.endsWith(PUERTA)) continue;
+      const code = readFileSync(file, "utf8");
+      if (!code.includes("update(schema.lead)")) continue;
+
+      for (const bloque of bloquesDeUpdate(code)) {
+        if (/\bstageId\s*:/.test(bloque)) {
+          infractores.push(path.relative(SRC, file));
+          break;
+        }
+      }
+    }
+
+    expect(
+      infractores,
+      `Estos archivos cambian la etapa sin registrar el movimiento. ` +
+        `Usa moveLeadToStage() de server/leads/stage-history.ts:\n` +
+        infractores.map((f) => `  · ${f}`).join("\n")
+    ).toEqual([]);
+  });
+
+  it("la puerta sí escribe la etapa (el test detectaría el patrón)", () => {
+    // Si este test falla, la detección de arriba dejó de servir: alguien
+    // reescribió la puerta con otra forma y el guardarraíl quedó ciego.
+    const code = readFileSync(path.join(SRC, PUERTA), "utf8");
+    const bloques = bloquesDeUpdate(code);
+    expect(bloques.some((b) => /\bstageId\s*:/.test(b))).toBe(true);
+  });
+});


### PR DESCRIPTION
El tablero guarda un **estado, no una historia**: `lead.stage_id` dice dónde
está cada lead hoy, y al arrastrarlo el valor anterior se pierde. Por eso el CRM
no puede contestar preguntas que cualquier dueño se hace:

- ¿cuánto cerré en julio? (hoy solo sabe cuántos están en "Cliente" *hoy*)
- ¿cuánto tarda un lead en llegar a Cliente?
- ¿en qué etapa se me caen?
- ¿por qué se perdieron los que perdí?

Se agrega `lead_stage_event`, **append-only**: cada movimiento deja de dónde, a
dónde, cuándo, quién y por qué camino. Nada se actualiza ni se borra; corregir
un dato es agregar otro movimiento. Guarda los **nombres** de etapa además de
los ids, para que renombrar o borrar una columna hoy no reescriba el embudo del
pasado.

## Una sola puerta

Había **cinco** caminos que escribían la etapa por su cuenta: el PATCH del
tablero, el agente in-process, el reset del bot, la reubicación al borrar una
etapa y la creación del lead al entrar un mensaje. Ahora todos pasan por
`server/leads/stage-history.ts`.

No es formalismo. Si cada camino copiara el "anota el evento", el sexto que
alguien agregue lo olvidaría — y olvidarlo **no truena**: solo hace que las
gráficas mientan meses después, cuando ya no hay forma de reconstruirlo. Por eso
va con un unit test que escanea `src/` y falla si aparece otra escritura:

```
✗ Estos archivos cambian la etapa sin registrar el movimiento.
  Usa moveLeadToStage() de server/leads/stage-history.ts
```

## Perder un trato exige motivo

Y la regla vive en la **base** (un CHECK), no en la disciplina de cada ruta:

- el tablero pregunta **antes** de mover — si el dueño cancela, la tarjeta ni
  parpadea fuera de su columna;
- la API responde `422 loss_reason_required`;
- un INSERT directo sin motivo lo rechaza Postgres.

La lista de motivos es corta a propósito: una taxonomía larga se contesta "otro"
y deja de informar.

## ⚠️ Cambio de contrato

`PATCH /api/pipeline/leads/[id]` puede responder **422 `loss_reason_required`**
al mover a una etapa perdida. Cualquier integración que arrastre tarjetas por
API tiene que mandar el motivo. Lo pongo al frente porque es lo único de este PR
que puede romperle algo a alguien.

## El pasado de quien ya tiene datos

La migración siembra dos eventos por lead existente —nació en la primera etapa,
llegó hasta la actual— marcados `approximate = true`: cuentan para los totales
pero **jamás** para promedios de tiempo, porque `updated_at` no es la fecha en
que el lead cambió de etapa. Es idempotente por md5 del lead, así que
re-ejecutar la migración no duplica.

## Verificación

```
pnpm typecheck   ✓
pnpm lint        ✓
pnpm test        ✓  174 pruebas, 26 archivos (incluye el guardarraíl)
pnpm build       ✓
pnpm test:e2e    ✓  87/87, sin regresión
```

Guion nuevo contra la app viva (`scripts/e2e-bitacora-etapas.mjs`), **19/19 en
dos corridas**. Verifica la tabla directo en la base, porque todavía no hay
endpoint que la exponga y lo que este PR promete es justamente que ningún camino
se salte el registro:

```
✓ quedó su evento de nacimiento
✓ la bitácora tiene DOS eventos y el segundo trae de dónde venía
✓ y guarda quién lo movió y por qué camino
✓ siguen siendo dos eventos            (reordenar en la misma etapa no inventa)
✓ sin motivo → 422 loss_reason_required
✓ y la tarjeta NO se movió: el rechazo no deja el tablero a medias
✓ un INSERT directo de 'perdido' sin motivo lo rechaza el CHECK
✓ el regreso al inicio quedó registrado como 'sistema'   (bot/reset)
✓ la reubicación dejó su propio evento                   (borrar etapa)
```

El backfill se probó aparte, simulando una instalación previa: con el lead
movido fuera de la primera etapa siembra los dos eventos en orden
(`— → Nuevo`, `Nuevo → Interesado`), ambos aproximados, y correrlo dos veces
deja el mismo número de filas.

## Lo que abre

Es el primero del tramo de esquema (migración `0004`) y de él cuelgan el embudo
por cohorte, la conversión por etapa y los días por etapa. Sin esta tabla, esa
analítica no tiene de dónde salir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
