### PR TITLE
feat(pipeline): monto de la negociacion y total por columna

### DIFF
--- a/drizzle/0006_keen_thor_girl.sql
+++ b/drizzle/0006_keen_thor_girl.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "lead" ADD COLUMN "amount_cents" integer;--> statement-breakpoint
+ALTER TABLE "lead" ADD COLUMN "currency" text;

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,2413 @@
+{
+  "id": "dbfe098f-ab7b-46c0-ac8e-03f75dbbdcdd",
+  "prevId": "af962991-6992-4eec-8de3-45b8e2ebb6f0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_profile": {
+      "name": "agent_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asistente'"
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalation_rules": {
+          "name": "escalation_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_profile_org_uq": {
+          "name": "agent_profile_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_profile_organization_id_organization_id_fk": {
+          "name": "agent_profile_organization_id_organization_id_fk",
+          "tableFrom": "agent_profile",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_case": {
+      "name": "agent_test_case",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "veredicto": {
+          "name": "veredicto",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hallazgos": {
+          "name": "hallazgos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_case_run_idx": {
+          "name": "test_case_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_case_organization_id_organization_id_fk": {
+          "name": "agent_test_case_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_run_id_agent_test_run_id_fk": {
+          "name": "agent_test_case_run_id_agent_test_run_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "agent_test_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_conversation_id_conversation_id_fk": {
+          "name": "agent_test_case_conversation_id_conversation_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_run": {
+      "name": "agent_test_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "test_run_org_running_uq": {
+          "name": "test_run_org_running_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_test_run\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_run_org_idx": {
+          "name": "test_run_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_run_organization_id_organization_id_fk": {
+          "name": "agent_test_run_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact": {
+      "name": "contact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_identity": {
+          "name": "wa_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_user_id": {
+          "name": "wa_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ficha": {
+          "name": "ficha",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_org_wa_identity_uq": {
+          "name": "contact_org_wa_identity_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_wa_user_id_idx": {
+          "name": "contact_org_wa_user_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_name_idx": {
+          "name": "contact_org_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_organization_id_organization_id_fk": {
+          "name": "contact_organization_id_organization_id_fk",
+          "tableFrom": "contact",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_test": {
+          "name": "is_test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ai_enabled": {
+          "name": "ai_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handoff_at": {
+          "name": "handoff_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_reason": {
+          "name": "handoff_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_inbound_at": {
+          "name": "last_inbound_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_org_contact_real_uq": {
+          "name": "conversation_org_contact_real_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation\".\"is_test\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_org_last_idx": {
+          "name": "conversation_org_last_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_organization_id_organization_id_fk": {
+          "name": "conversation_organization_id_organization_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_contact_id_contact_id_fk": {
+          "name": "conversation_contact_id_contact_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_entry": {
+      "name": "kb_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kb_org_idx": {
+          "name": "kb_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_entry_organization_id_organization_id_fk": {
+          "name": "kb_entry_organization_id_organization_id_fk",
+          "tableFrom": "kb_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead": {
+      "name": "lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lead_contact_uq": {
+          "name": "lead_contact_uq",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lead_org_stage_idx": {
+          "name": "lead_org_stage_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_organization_id_organization_id_fk": {
+          "name": "lead_organization_id_organization_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_contact_id_contact_id_fk": {
+          "name": "lead_contact_id_contact_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead_stage_event": {
+      "name": "lead_stage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_stage_id": {
+          "name": "from_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_stage_name": {
+          "name": "from_stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage_id": {
+          "name": "to_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage_name": {
+          "name": "to_stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_stage_kind": {
+          "name": "to_stage_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dueno'"
+        },
+        "approximate": {
+          "name": "approximate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "loss_reason": {
+          "name": "loss_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loss_note": {
+          "name": "loss_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lse_org_occurred_idx": {
+          "name": "lse_org_occurred_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lse_lead_occurred_idx": {
+          "name": "lse_lead_occurred_idx",
+          "columns": [
+            {
+              "expression": "lead_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lse_org_kind_occurred_idx": {
+          "name": "lse_org_kind_occurred_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_stage_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_stage_event_organization_id_organization_id_fk": {
+          "name": "lead_stage_event_organization_id_organization_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_lead_id_lead_id_fk": {
+          "name": "lead_stage_event_lead_id_lead_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "lead",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_contact_id_contact_id_fk": {
+          "name": "lead_stage_event_contact_id_contact_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_from_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_event_from_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "from_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_to_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_event_to_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "to_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_actor_user_id_user_id_fk": {
+          "name": "lead_stage_event_actor_user_id_user_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lse_loss_reason_ck": {
+          "name": "lse_loss_reason_ck",
+          "value": "\"lead_stage_event\".\"to_stage_kind\" <> 'lost' OR \"lead_stage_event\".\"approximate\" = true OR \"lead_stage_event\".\"loss_reason\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_asset": {
+      "name": "media_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_media_id": {
+          "name": "wa_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_status": {
+          "name": "fetch_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_asset_org_idx": {
+          "name": "media_asset_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_asset_wa_media_idx": {
+          "name": "media_asset_wa_media_idx",
+          "columns": [
+            {
+              "expression": "wa_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_asset_organization_id_organization_id_fk": {
+          "name": "media_asset_organization_id_organization_id_fk",
+          "tableFrom": "media_asset",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_message_id": {
+          "name": "wa_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated": {
+          "name": "ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'operator'"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_timestamp": {
+          "name": "wa_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_org_conv_idx": {
+          "name": "message_org_conv_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_organization_id_organization_id_fk": {
+          "name": "message_organization_id_organization_id_fk",
+          "tableFrom": "message",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_media_asset_id_media_asset_id_fk": {
+          "name": "message_media_asset_id_media_asset_id_fk",
+          "tableFrom": "message",
+          "tableTo": "media_asset",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_wa_message_id_unique": {
+          "name": "message_wa_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wa_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_credentials": {
+      "name": "meta_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waba_id": {
+          "name": "waba_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number_id": {
+          "name": "phone_number_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_phone_number": {
+          "name": "display_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_name": {
+          "name": "verified_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_cipher": {
+          "name": "token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meta_credentials_org_uq": {
+          "name": "meta_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meta_credentials_phone_uq": {
+          "name": "meta_credentials_phone_uq",
+          "columns": [
+            {
+              "expression": "phone_number_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meta_credentials_organization_id_organization_id_fk": {
+          "name": "meta_credentials_organization_id_organization_id_fk",
+          "tableFrom": "meta_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_stage": {
+      "name": "pipeline_stage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stage_org_pos_idx": {
+          "name": "stage_org_pos_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_stage_organization_id_organization_id_fk": {
+          "name": "pipeline_stage_organization_id_organization_id_fk",
+          "tableFrom": "pipeline_stage",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_template_id": {
+          "name": "wa_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_org_name_lang_uq": {
+          "name": "template_org_name_lang_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_organization_id_organization_id_fk": {
+          "name": "template_organization_id_organization_id_fk",
+          "tableFrom": "template",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1786850050625,
       "tag": "0005_glossy_excalibur",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1786855153169,
+      "tag": "0006_keen_thor_girl",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/e2e-monto-pipeline.mjs
+++ b/scripts/e2e-monto-pipeline.mjs
@@ -1,0 +1,193 @@
+/**
+ * Self-test E2E de comportamiento — monto de la negociación
+ * (guion tests/e2e/us2-pipeline.md, sección "monto").
+ *
+ * El total por columna lo suma el CLIENTE, así que aquí se verifica lo que lo
+ * alimenta: que el monto se guarde sin mover la tarjeta, que viaje con su
+ * moneda, y que la moneda del negocio llegue al tablero. La aritmética tiene
+ * sus propias pruebas en tests/unit/money.test.ts.
+ *
+ * Uso: node --env-file=.env scripts/e2e-monto-pipeline.mjs
+ */
+const BASE = process.env.APP_BASE_URL ?? "http://localhost:3000";
+const PN = "PN-MONTO-1";
+const S = Math.random().toString(36).slice(2, 6).toUpperCase();
+
+let cookie = "";
+let failures = 0;
+let checks = 0;
+const ok = (name, cond, extra = "") => {
+  checks++;
+  if (cond) console.log(`  ✓ ${name}`);
+  else {
+    failures++;
+    console.log(`  ✗ ${name}${extra ? ` — ${extra}` : ""}`);
+  }
+};
+
+async function api(path, opts = {}) {
+  const res = await fetch(`${BASE}${path}`, {
+    ...opts,
+    headers: {
+      "content-type": "application/json",
+      origin: BASE,
+      ...(cookie ? { cookie } : {}),
+      ...(opts.headers ?? {}),
+    },
+  });
+  const set = res.headers.getSetCookie?.() ?? [];
+  if (set.length) cookie = set.map((c) => c.split(";")[0]).join("; ");
+  let json = null;
+  try {
+    json = await res.clone().json();
+  } catch {}
+  return { res, json };
+}
+
+console.log("== Setup ==");
+const email = "e2e@vocero.test";
+const password = "password-e2e-123";
+let su = await api("/api/auth/sign-up/email", {
+  method: "POST",
+  body: JSON.stringify({ email, password, name: "Operador E2E" }),
+});
+if (!su.res.ok) {
+  su = await api("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+}
+ok("registro o login del operador", su.res.ok);
+await api("/api/settings/whatsapp", {
+  method: "PUT",
+  body: JSON.stringify({ wabaId: "WABA-MON", phoneNumberId: PN, token: "tok-mon" }),
+});
+
+const stages = (await api("/api/pipeline/stages")).json?.stages ?? [];
+const abiertas = stages.filter((s) => s.kind === "open");
+const alta = await api("/api/contacts", {
+  method: "POST",
+  body: JSON.stringify({
+    name: `Trato${S}`,
+    phone: `52155900${Math.floor(1000 + Math.random() * 8999)}`,
+    source: "referido",
+  }),
+});
+const leadId = alta.json?.lead?.id;
+ok("prospecto de prueba creado", Boolean(leadId));
+
+console.log("\n== Capturar el monto NO mueve la tarjeta ==");
+const antes = (await api("/api/pipeline/board")).json;
+const etapaAntes = antes.leads.find((l) => l.id === leadId)?.stageId;
+
+const guardado = await api(`/api/pipeline/leads/${leadId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ amountCents: 1_250_050 }),
+});
+ok(
+  "PATCH solo con monto → 200 (sin stageId)",
+  guardado.res.ok,
+  JSON.stringify(guardado.json)
+);
+
+const board = (await api("/api/pipeline/board")).json;
+const tarjeta = board.leads.find((l) => l.id === leadId);
+ok("el monto quedó guardado en centavos", tarjeta?.amountCents === 1_250_050);
+ok(
+  "la tarjeta NO se movió de etapa",
+  tarjeta?.stageId === etapaAntes,
+  `antes ${etapaAntes}, ahora ${tarjeta?.stageId}`
+);
+ok(
+  "el monto viaja con su moneda, tomada del negocio",
+  tarjeta?.currency === board.currency,
+  JSON.stringify({ lead: tarjeta?.currency, negocio: board.currency })
+);
+ok(
+  "el tablero informa la moneda del negocio",
+  typeof board.currency === "string" && board.currency.length === 3,
+  JSON.stringify(board.currency)
+);
+
+console.log("\n== Mover la tarjeta conserva el monto ==");
+const otra = abiertas.find((s) => s.id !== etapaAntes) ?? abiertas[0];
+await api(`/api/pipeline/leads/${leadId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ stageId: otra.id, position: 0 }),
+});
+const trasMover = (await api("/api/pipeline/board")).json.leads.find(
+  (l) => l.id === leadId
+);
+ok(
+  "sigue valiendo lo mismo tras cambiar de columna",
+  trasMover?.amountCents === 1_250_050,
+  JSON.stringify(trasMover?.amountCents)
+);
+
+console.log("\n== Cambiar la moneda del negocio ==");
+const marca = (await api("/api/settings/branding")).json?.branding;
+const nuevaMoneda = marca.currency === "USD" ? "MXN" : "USD";
+const put = await api("/api/settings/branding", {
+  method: "PUT",
+  body: JSON.stringify({
+    name: marca.name,
+    accent: marca.accent,
+    currency: nuevaMoneda,
+  }),
+});
+ok("la moneda se guarda en Ajustes → Marca", put.res.ok, JSON.stringify(put.json));
+const board2 = (await api("/api/pipeline/board")).json;
+ok(
+  "y el tablero la refleja",
+  board2.currency === nuevaMoneda,
+  JSON.stringify(board2.currency)
+);
+ok(
+  "el monto ya capturado conserva SU moneda (no se reinterpreta)",
+  board2.leads.find((l) => l.id === leadId)?.currency === marca.currency,
+  "un importe capturado en pesos no se vuelve dólares porque cambie el ajuste"
+);
+// Volver a dejarlo como estaba para no ensuciar corridas siguientes.
+await api("/api/settings/branding", {
+  method: "PUT",
+  body: JSON.stringify({ name: marca.name, accent: marca.accent, currency: marca.currency }),
+});
+
+console.log("\n== Caminos infelices ==");
+const borrado = await api(`/api/pipeline/leads/${leadId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ amountCents: null }),
+});
+const trasBorrar = (await api("/api/pipeline/board")).json.leads.find(
+  (l) => l.id === leadId
+);
+ok(
+  "amountCents null borra el monto y su moneda",
+  borrado.res.ok &&
+    trasBorrar?.amountCents === null &&
+    trasBorrar?.currency === null,
+  JSON.stringify({ cents: trasBorrar?.amountCents, cur: trasBorrar?.currency })
+);
+
+const vacio = await api(`/api/pipeline/leads/${leadId}`, {
+  method: "PATCH",
+  body: JSON.stringify({}),
+});
+ok(
+  "un PATCH sin nada que cambiar → 422, no un 200 mentiroso",
+  vacio.res.status === 422,
+  JSON.stringify(vacio.json)
+);
+
+const negativo = await api(`/api/pipeline/leads/${leadId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ amountCents: -500 }),
+});
+ok("monto negativo → 422", negativo.res.status === 422);
+
+console.log(
+  failures === 0
+    ? `\nTODO VERDE — ${checks}/${checks} checks`
+    : `\n${checks - failures}/${checks} checks — ${failures} FALLARON`
+);
+process.exit(failures === 0 ? 0 : 1);

--- a/src/app/api/pipeline/board/route.ts
+++ b/src/app/api/pipeline/board/route.ts
@@ -2,6 +2,7 @@ import { and, asc, eq } from "drizzle-orm";
 import { withAuth } from "@/lib/api";
 import { getDb, schema } from "@/lib/db";
 import { scoped } from "@/lib/db/tenant";
+import { getBranding } from "@/server/branding";
 
 export const dynamic = "force-dynamic";
 
@@ -33,7 +34,12 @@ export const GET = withAuth(async (session) => {
     .where(scoped(schema.lead.organizationId, session.organizationId))
     .orderBy(asc(schema.lead.position));
 
+  // La moneda del negocio viaja con el tablero: el cliente suma sus columnas y
+  // necesita saber cuál es la única sumable, sin adivinarla ni pedirla aparte.
+  const { currency } = await getBranding(session.organizationId);
+
   return Response.json({
+    currency,
     stages: stages.map((s) => ({
       id: s.id,
       name: s.name,
@@ -45,6 +51,8 @@ export const GET = withAuth(async (session) => {
       stageId: r.lead.stageId,
       position: r.lead.position,
       lastActivityAt: r.lead.lastActivityAt?.toISOString() ?? null,
+      amountCents: r.lead.amountCents,
+      currency: r.lead.currency,
       contact: {
         id: r.contact.id,
         name: r.contact.name,

--- a/src/app/api/pipeline/leads/[id]/route.ts
+++ b/src/app/api/pipeline/leads/[id]/route.ts
@@ -2,16 +2,24 @@ import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { apiError, parseBody, withAuth } from "@/lib/api";
 import { getDb, schema } from "@/lib/db";
+import { scoped } from "@/lib/db/tenant";
 import { publish } from "@/server/events/bus";
 import { moveLeadToStage } from "@/server/leads/stage-history";
+import { getBranding } from "@/server/branding";
 
 export const dynamic = "force-dynamic";
 
 type Params = { params: Promise<{ id: string }> };
 
 const patchSchema = z.object({
-  stageId: z.string().min(1),
-  position: z.number().int().min(0),
+  /**
+   * Opcionales desde que el lead tiene monto: capturar dinero es un gesto
+   * distinto de mover la tarjeta, y exigir la etapa para guardar un importe
+   * obligaría al cliente a reenviar dónde estaba —con el riesgo de moverlo sin
+   * querer si el tablero venía desfasado—. Sin `stageId` no se mueve nada.
+   */
+  stageId: z.string().min(1).optional(),
+  position: z.number().int().min(0).optional(),
   /**
    * Obligatorio al ENTRAR a una etapa perdida. No se valida aquí sino en la
    * puerta: la regla es del dominio, no de esta ruta, y hay más caminos que
@@ -28,12 +36,56 @@ const patchSchema = z.object({
     ])
     .optional(),
   lossNote: z.string().max(500).optional(),
+  /**
+   * Monto en centavos enteros. `null` explícito lo borra; ausente lo deja como
+   * estaba — capturar el monto y mover la tarjeta son dos gestos distintos y
+   * uno no debe pisar al otro.
+   */
+  amountCents: z.number().int().min(0).max(1_000_000_000_00).nullable().optional(),
+  currency: z.string().length(3).nullable().optional(),
 });
 
 export const PATCH = withAuth(async (session, req: Request, ctx: Params) => {
   const { id } = await ctx.params;
   const body = await parseBody(req, patchSchema);
   if (!body.ok) return body.response;
+
+  // El monto viaja en el MISMO update que el movimiento: capturarlo mientras
+  // se arrastra la tarjeta no debe costar dos viajes ni dejar un estado a
+  // medias si el segundo falla.
+  const extra: Record<string, unknown> = {};
+  if (body.data.amountCents !== undefined) {
+    extra.amountCents = body.data.amountCents;
+    // Sin monto no hay moneda que guardar: dejarla apuntando a un importe
+    // borrado haría que el tablero contara un lead que ya no tiene número.
+    extra.currency =
+      body.data.amountCents === null
+        ? null
+        : (body.data.currency ?? (await getBranding(session.organizationId)).currency);
+  }
+
+  // Sin etapa: solo se actualizan los campos del lead. No pasa por la puerta
+  // de la bitácora porque no hay movimiento que registrar — y el guardarraíl
+  // sigue contento: aquí jamás se escribe `stageId`.
+  if (!body.data.stageId) {
+    if (Object.keys(extra).length === 0) {
+      return apiError(422, "nothing_to_update", "No hay nada que actualizar");
+    }
+    const db = getDb();
+    const updated = await db
+      .update(schema.lead)
+      .set({ ...extra, updatedAt: new Date() })
+      .where(
+        scoped(
+          schema.lead.organizationId,
+          session.organizationId,
+          eq(schema.lead.id, id)
+        )
+      )
+      .returning();
+    if (!updated[0]) return apiError(404, "not_found", "Lead no encontrado");
+    return Response.json({ lead: updated[0] });
+  }
 
   const res = await moveLeadToStage({
     organizationId: session.organizationId,
@@ -44,6 +96,7 @@ export const PATCH = withAuth(async (session, req: Request, ctx: Params) => {
     source: "dueno",
     lossReason: body.data.lossReason ?? null,
     lossNote: body.data.lossNote ?? null,
+    extra,
   });
 
   if (!res.ok) {

--- a/src/app/api/settings/branding/route.ts
+++ b/src/app/api/settings/branding/route.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { apiError, parseBody, withAuth } from "@/lib/api";
 import { getSessionOrNull } from "@/lib/auth/session";
 import { isValidHex, resolveAccentSet } from "@/lib/branding";
+import { CURRENCIES } from "@/lib/money";
 import { getBranding, saveBranding } from "@/server/branding";
 
 export const dynamic = "force-dynamic";
@@ -16,6 +17,8 @@ export async function GET() {
 const putSchema = z.object({
   name: z.string().trim().min(1).max(30),
   accent: z.string().refine(isValidHex, "Color hex inválido (#rrggbb)"),
+  /** La moneda del negocio: la única que el tablero suma. */
+  currency: z.enum(CURRENCIES),
 });
 
 export const PUT = withAuth(async (session, req: Request) => {

--- a/src/components/pipeline/amount-dialog.tsx
+++ b/src/components/pipeline/amount-dialog.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import { formatMoneyCents, parseMoneyToCents } from "@/lib/money";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+/**
+ * Captura del monto de la negociación.
+ *
+ * Acepta lo que el dueño escriba —"12,500", "$12 500.50"— porque nadie teclea
+ * centavos, y guarda centavos enteros. Vacío BORRA el monto: un trato sin
+ * número no vale cero, simplemente no se sabe, y esa diferencia se nota en el
+ * total de la columna.
+ */
+export function AmountDialog({
+  leadName,
+  currency,
+  amountCents,
+  onCancel,
+  onSave,
+}: {
+  leadName: string;
+  currency: string;
+  amountCents: number | null;
+  onCancel: () => void;
+  onSave: (cents: number | null) => void;
+}) {
+  const [texto, setTexto] = useState(
+    amountCents === null ? "" : (amountCents / 100).toFixed(2)
+  );
+  const parsed = texto.trim() ? parseMoneyToCents(texto) : null;
+  const invalido = texto.trim().length > 0 && parsed === null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Monto de la negociación"
+    >
+      <div className="w-full max-w-sm rounded-lg border bg-card p-4 shadow-pop">
+        <h3 className="font-semibold">Monto de la negociación</h3>
+        <p className="mt-0.5 text-xs text-text-3">{leadName}</p>
+
+        <label className="mt-3 block text-xs font-medium" htmlFor="monto">
+          Cuánto vale este trato ({currency})
+        </label>
+        <Input
+          id="monto"
+          value={texto}
+          inputMode="decimal"
+          autoFocus
+          onChange={(e) => setTexto(e.target.value)}
+          placeholder="12,500.00"
+          className="mt-1"
+        />
+        {invalido ? (
+          <p className="mt-1 text-xs text-danger-text">
+            No reconozco ese número. Escríbelo como 12500 o 12,500.00
+          </p>
+        ) : (
+          <p className="mt-1 text-xs text-text-3">
+            {parsed === null
+              ? "Déjalo vacío para quitar el monto."
+              : `Se guardará como ${formatMoneyCents(parsed, currency)}`}
+          </p>
+        )}
+
+        <div className="mt-4 flex justify-end gap-2">
+          <Button variant="ghost" onClick={onCancel}>
+            Cancelar
+          </Button>
+          <Button disabled={invalido} onClick={() => onSave(parsed)}>
+            Guardar
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pipeline/pipeline-client.tsx
+++ b/src/components/pipeline/pipeline-client.tsx
@@ -15,12 +15,14 @@ import {
 } from "@dnd-kit/core";
 import { MessageSquareText, Settings2, Trophy, XCircle } from "lucide-react";
 import type { LossReason, StageDto } from "@/lib/types";
+import { formatMoneyCents, sumable } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import { ContactAvatar } from "@/components/avatar";
 import { Button } from "@/components/ui/button";
 import { formatTime } from "@/components/inbox/helpers";
 import { StageManager } from "./stage-manager";
 import { LossReasonDialog } from "./loss-reason-dialog";
+import { AmountDialog } from "./amount-dialog";
 
 export type BoardLead = {
   id: string;
@@ -29,10 +31,13 @@ export type BoardLead = {
   lastActivityAt: string | null;
   contact: { id: string; name: string; phone: string | null };
   conversationId: string | null;
+  amountCents: number | null;
+  currency: string | null;
 };
 
 export function PipelineClient() {
   const [stages, setStages] = useState<StageDto[]>([]);
+  const [currency, setCurrency] = useState("MXN");
   const [leads, setLeads] = useState<BoardLead[]>([]);
   const [activeLead, setActiveLead] = useState<BoardLead | null>(null);
   const [managing, setManaging] = useState(false);
@@ -42,6 +47,8 @@ export function PipelineClient() {
     stageId: string;
     name: string;
   } | null>(null);
+  /** Tarjeta cuyo monto se está capturando. */
+  const [editandoMonto, setEditandoMonto] = useState<BoardLead | null>(null);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } })
@@ -50,7 +57,12 @@ export function PipelineClient() {
   const refetch = useCallback(async () => {
     const res = await fetch("/api/pipeline/board").catch(() => null);
     if (!res?.ok) return;
-    const data = (await res.json()) as { stages: StageDto[]; leads: BoardLead[] };
+    const data = (await res.json()) as {
+      stages: StageDto[];
+      leads: BoardLead[];
+      currency?: string;
+    };
+    if (data.currency) setCurrency(data.currency);
     setStages(data.stages);
     setLeads(data.leads);
   }, []);
@@ -84,6 +96,19 @@ export function PipelineClient() {
           ? { lossReason: loss.reason, ...(loss.note ? { lossNote: loss.note } : {}) }
           : {}),
       }),
+    }).catch(() => null);
+    void refetch();
+  }
+
+  async function guardarMonto(leadId: string, cents: number | null) {
+    setLeads((prev) =>
+      prev.map((l) => (l.id === leadId ? { ...l, amountCents: cents } : l))
+    );
+    await fetch(`/api/pipeline/leads/${leadId}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      // Sin `stageId`: esto NO mueve la tarjeta, solo escribe el importe.
+      body: JSON.stringify({ amountCents: cents }),
     }).catch(() => null);
     void refetch();
   }
@@ -129,6 +154,8 @@ export function PipelineClient() {
               <StageColumn
                 key={stage.id}
                 stage={stage}
+                currency={currency}
+                onEditAmount={setEditandoMonto}
                 leads={leads
                   .filter((l) => l.stageId === stage.id)
                   .sort((a, b) => a.position - b.position)}
@@ -136,7 +163,9 @@ export function PipelineClient() {
             ))}
           </div>
           <DragOverlay>
-            {activeLead ? <LeadCard lead={activeLead} overlay /> : null}
+            {activeLead ? (
+              <LeadCard lead={activeLead} currency={currency} overlay />
+            ) : null}
           </DragOverlay>
         </DndContext>
       </div>
@@ -146,6 +175,20 @@ export function PipelineClient() {
           stages={stages}
           onClose={() => setManaging(false)}
           onChanged={() => void refetch()}
+        />
+      )}
+
+      {editandoMonto && (
+        <AmountDialog
+          leadName={editandoMonto.contact.name}
+          currency={editandoMonto.currency ?? currency}
+          amountCents={editandoMonto.amountCents}
+          onCancel={() => setEditandoMonto(null)}
+          onSave={(cents) => {
+            const leadId = editandoMonto.id;
+            setEditandoMonto(null);
+            void guardarMonto(leadId, cents);
+          }}
         />
       )}
 
@@ -164,7 +207,41 @@ export function PipelineClient() {
   );
 }
 
-function StageColumn({ stage, leads }: { stage: StageDto; leads: BoardLead[] }) {
+/**
+ * Totales de una columna. Se calculan al pintar: un total guardado se
+ * desincroniza en cuanto alguien mueve una tarjeta, y sumar unas decenas es
+ * gratis. Todo en CENTAVOS enteros — el dinero jamás pasa por coma flotante.
+ */
+function totalesDeEtapa(leads: BoardLead[], businessCurrency: string) {
+  let totalCents = 0;
+  let sinMonto = 0;
+  let otraMoneda = 0;
+
+  for (const l of leads) {
+    if (l.amountCents === null) {
+      sinMonto++;
+      continue;
+    }
+    if (!sumable({ amountCents: l.amountCents, currency: l.currency }, businessCurrency)) {
+      otraMoneda++;
+      continue;
+    }
+    totalCents += l.amountCents;
+  }
+  return { totalCents, sinMonto, otraMoneda };
+}
+
+function StageColumn({
+  stage,
+  leads,
+  currency,
+  onEditAmount,
+}: {
+  stage: StageDto;
+  leads: BoardLead[];
+  currency: string;
+  onEditAmount: (lead: BoardLead) => void;
+}) {
   const { setNodeRef, isOver } = useDroppable({ id: stage.id });
   return (
     <div
@@ -188,14 +265,59 @@ function StageColumn({ stage, leads }: { stage: StageDto; leads: BoardLead[] }) 
       </div>
       <div className="flex-1 space-y-2 overflow-y-auto p-2">
         {leads.map((lead) => (
-          <DraggableLead key={lead.id} lead={lead} />
+          <DraggableLead
+            key={lead.id}
+            lead={lead}
+            currency={currency}
+            onEditAmount={onEditAmount}
+          />
         ))}
       </div>
+      <StageFooter leads={leads} currency={currency} />
     </div>
   );
 }
 
-function DraggableLead({ lead }: { lead: BoardLead }) {
+/** Cuánto dinero hay en esta etapa, y qué quedó fuera de la cuenta. */
+function StageFooter({ leads, currency }: { leads: BoardLead[]; currency: string }) {
+  const { totalCents, sinMonto, otraMoneda } = totalesDeEtapa(leads, currency);
+  const conMonto = leads.length - sinMonto - otraMoneda;
+
+  return (
+    <div className="border-t px-3 py-2 text-[11px]">
+      {conMonto === 0 ? (
+        // Un "$0.00" aquí se lee como un error del sistema, no como un dato.
+        <p className="text-muted-foreground">Sin montos capturados</p>
+      ) : (
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="text-muted-foreground">
+            Total{sinMonto > 0 ? ` · ${sinMonto} sin monto` : ""}
+          </span>
+          <span className="font-semibold tabular-nums">
+            {formatMoneyCents(totalCents, currency)}
+          </span>
+        </div>
+      )}
+      {otraMoneda > 0 && (
+        // Descartarlos en silencio haría que el total mintiera sin que nadie
+        // pudiera notarlo.
+        <p className="mt-0.5 text-warning-text">
+          {otraMoneda} en otra moneda, fuera del total
+        </p>
+      )}
+    </div>
+  );
+}
+
+function DraggableLead({
+  lead,
+  currency,
+  onEditAmount,
+}: {
+  lead: BoardLead;
+  currency: string;
+  onEditAmount: (lead: BoardLead) => void;
+}) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: lead.id,
   });
@@ -206,12 +328,22 @@ function DraggableLead({ lead }: { lead: BoardLead }) {
       {...attributes}
       className={cn(isDragging && "opacity-40")}
     >
-      <LeadCard lead={lead} />
+      <LeadCard lead={lead} currency={currency} onEditAmount={onEditAmount} />
     </div>
   );
 }
 
-function LeadCard({ lead, overlay = false }: { lead: BoardLead; overlay?: boolean }) {
+function LeadCard({
+  lead,
+  currency,
+  overlay = false,
+  onEditAmount,
+}: {
+  lead: BoardLead;
+  currency: string;
+  overlay?: boolean;
+  onEditAmount?: (lead: BoardLead) => void;
+}) {
   return (
     <div
       className={cn(
@@ -240,6 +372,29 @@ function LeadCard({ lead, overlay = false }: { lead: BoardLead; overlay?: boolea
           </Link>
         )}
       </div>
+      {!overlay && onEditAmount && (
+        <button
+          // `stopPropagation` en pointerdown: sin esto, tocar el monto empieza
+          // un arrastre y el diálogo nunca abre.
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={() => onEditAmount(lead)}
+          className={cn(
+            "mt-1.5 w-full rounded px-1 py-0.5 text-right text-xs tabular-nums hover:bg-accent",
+            lead.amountCents === null
+              ? "text-text-3"
+              : "font-semibold text-foreground"
+          )}
+        >
+          {lead.amountCents === null
+            ? "+ monto"
+            : formatMoneyCents(lead.amountCents, lead.currency ?? currency)}
+        </button>
+      )}
+      {overlay && lead.amountCents !== null && (
+        <p className="mt-1.5 text-right text-xs font-semibold tabular-nums">
+          {formatMoneyCents(lead.amountCents, lead.currency ?? currency)}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/settings/branding-client.tsx
+++ b/src/components/settings/branding-client.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ACCENT_PRESETS, isValidHex, resolveAccentSet, type Branding } from "@/lib/branding";
+import { CURRENCIES, DEFAULT_CURRENCY, type Currency } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import { useResolvedTheme } from "@/components/use-theme";
 import { Button } from "@/components/ui/button";
@@ -15,6 +16,7 @@ export function BrandingClient() {
   const mode = useResolvedTheme();
   const [name, setName] = useState("");
   const [accent, setAccent] = useState("#3f5972");
+  const [currency, setCurrency] = useState<Currency>(DEFAULT_CURRENCY);
   const [loaded, setLoaded] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -27,6 +29,7 @@ export function BrandingClient() {
         if (d) {
           setName(d.branding.name);
           setAccent(d.branding.accent);
+          if (d.branding.currency) setCurrency(d.branding.currency);
         }
         setLoaded(true);
       })
@@ -45,7 +48,7 @@ export function BrandingClient() {
     const res = await fetch("/api/settings/branding", {
       method: "PUT",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ name: name.trim(), accent }),
+      body: JSON.stringify({ name: name.trim(), accent, currency }),
     }).catch(() => null);
     setSaving(false);
     if (!res?.ok) {
@@ -83,6 +86,26 @@ export function BrandingClient() {
               placeholder="Vocero"
               className="max-w-xs"
             />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="brand-currency">Moneda del negocio</Label>
+            <select
+              id="brand-currency"
+              value={currency}
+              onChange={(e) => setCurrency(e.target.value as Currency)}
+              className="h-9 max-w-xs rounded-md border border-input bg-card px-2 text-sm"
+            >
+              {CURRENCIES.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-text-3">
+              Es la única que el Pipeline suma. Los montos capturados en otra
+              moneda se muestran, pero quedan fuera del total de su columna.
+            </p>
           </div>
 
           <div className="space-y-2">

--- a/src/lib/branding.ts
+++ b/src/lib/branding.ts
@@ -1,5 +1,7 @@
+import { DEFAULT_CURRENCY, isCurrency, type Currency } from "@/lib/money";
+
 /**
- * White-label: nombre del CRM + acento por organización.
+ * White-label: nombre del CRM, acento y moneda por organización.
  * Presets sobrios del sistema Atlas; para un color personalizado se derivan
  * hover/soft/tint/text y se garantiza contraste con texto blanco.
  */
@@ -20,9 +22,15 @@ export type ThemeMode = "light" | "dark";
 export type Branding = {
   name: string;
   accent: string; // hex del acento base elegido
+  /** Moneda del negocio: la única que el tablero suma. */
+  currency: Currency;
 };
 
-export const DEFAULT_BRANDING: Branding = { name: "Vocero", accent: "#3f5972" };
+export const DEFAULT_BRANDING: Branding = {
+  name: "Vocero",
+  accent: "#3f5972",
+  currency: DEFAULT_CURRENCY,
+};
 
 /** Presets del handoff (valores exactos). */
 export const ACCENT_PRESETS: Record<string, { label: string; set: AccentSet }> = {
@@ -178,5 +186,8 @@ export function normalizeBranding(input: Partial<Branding> | null): Branding {
     input?.accent && isValidHex(input.accent)
       ? input.accent.toLowerCase()
       : DEFAULT_BRANDING.accent;
-  return { name, accent };
+  const currency = isCurrency(input?.currency)
+    ? input.currency
+    : DEFAULT_BRANDING.currency;
+  return { name, accent, currency };
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -183,6 +183,14 @@ export const lead = pgTable(
       .notNull()
       .references(() => pipelineStage.id),
     position: integer("position").notNull().default(0),
+    /**
+     * Monto de la negociación en CENTAVOS ENTEROS. NULL = nadie lo capturó, que
+     * no es lo mismo que cero: un trato sin monto no vale $0, simplemente no se
+     * sabe, y el tablero lo dice con palabras en vez de sumar un cero.
+     */
+    amountCents: integer("amount_cents"),
+    /** Moneda del monto; la del negocio al capturarlo (Ajustes → Marca). */
+    currency: text("currency"),
     lastActivityAt: timestamp("last_activity_at"),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -1,0 +1,94 @@
+/**
+ * Dinero. Vive en `lib/` (no en `server/`) porque el tablero suma sus columnas
+ * en el cliente y no puede arrastrar la BD al bundle.
+ *
+ * Todo en CENTAVOS ENTEROS, también en el cálculo: sumar pesos en coma flotante
+ * da totales que el dueño no puede cuadrar contra sus propias tarjetas.
+ *
+ * La moneda NO está cableada. Cada instancia elige la suya en Ajustes → Marca,
+ * y todas las funciones la reciben explícitamente: un default global escondido
+ * haría que una instalación fuera de su país sumara mal sin avisar.
+ */
+
+/** Monedas ISO-4217 razonables para un CRM de WhatsApp hispanohablante. */
+export const CURRENCIES = [
+  "MXN",
+  "USD",
+  "EUR",
+  "COP",
+  "ARS",
+  "CLP",
+  "PEN",
+  "GTQ",
+  "DOP",
+  "BRL",
+] as const;
+
+export type Currency = (typeof CURRENCIES)[number];
+
+export const DEFAULT_CURRENCY: Currency = "MXN";
+
+export function isCurrency(v: unknown): v is Currency {
+  return typeof v === "string" && (CURRENCIES as readonly string[]).includes(v);
+}
+
+/**
+ * ¿Este monto entra en el total de su columna? Solo suma lo que está en la
+ * moneda del negocio: convertir exigiría un tipo de cambio, y un CRM que
+ * inventa tipos de cambio miente. Lo que queda fuera se CUENTA aparte para
+ * poder decirlo en pantalla, en vez de desaparecerlo.
+ */
+export function sumable(
+  amount: { amountCents: number | null; currency: string | null },
+  businessCurrency: string
+): boolean {
+  if (amount.amountCents === null) return false;
+  return (amount.currency ?? businessCurrency) === businessCurrency;
+}
+
+/** Dinero para mostrar. Recibe centavos porque es como viaja y como se guarda. */
+export function formatMoneyCents(
+  cents: number | null | undefined,
+  currency: string,
+  locale = "es-MX"
+): string | null {
+  if (cents === null || cents === undefined) return null;
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: "currency",
+      currency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(cents / 100);
+  } catch {
+    // Moneda o locale que el runtime no conoce: mejor un número correcto sin
+    // símbolo que una pantalla rota.
+    return `${(cents / 100).toFixed(2)} ${currency}`;
+  }
+}
+
+/**
+ * Texto libre del dueño → centavos. Acepta "12,500.50", "12500", "$12 500".
+ * Devuelve `null` si no hay un número reconocible, para no guardar un 0 que
+ * después se lea como "no vale nada".
+ */
+export function parseMoneyToCents(input: string): number | null {
+  const limpio = input.replace(/[^\d.,-]/g, "").trim();
+  if (!limpio) return null;
+  // El último separador manda como decimal; el resto son de millares.
+  const ultimoPunto = limpio.lastIndexOf(".");
+  const ultimaComa = limpio.lastIndexOf(",");
+  const corte = Math.max(ultimoPunto, ultimaComa);
+  let entero = limpio;
+  let decimales = "";
+  if (corte !== -1 && limpio.length - corte <= 3) {
+    entero = limpio.slice(0, corte);
+    decimales = limpio.slice(corte + 1);
+  }
+  const soloDigitos = entero.replace(/[^\d-]/g, "");
+  if (!soloDigitos || soloDigitos === "-") return null;
+  const cents =
+    Number(soloDigitos) * 100 + Number((decimales + "00").slice(0, 2)) *
+      (soloDigitos.startsWith("-") ? -1 : 1);
+  return Number.isFinite(cents) ? Math.trunc(cents) : null;
+}

--- a/tests/e2e/us2-pipeline.md
+++ b/tests/e2e/us2-pipeline.md
@@ -71,7 +71,27 @@ la gente llegue por WhatsApp.
     ✅ Solo plantillas aprobadas: iniciar con texto libre lo prohíbe Meta.
     ✅ Con la ventana de 24 h abierta se avisa en vez de gastar una plantilla.
 
+## Monto de la negociación
+
+Automatizado en `scripts/e2e-monto-pipeline.mjs`. El tablero cuenta personas;
+esto le agrega cuánto dinero hay en cada columna.
+
+16. **Capturar el monto** desde la tarjeta ("+ monto").
+    ✅ Acepta lo que uno teclea: `12500`, `12,500.50`, `$12 500`.
+    ✅ Guardarlo **no mueve** la tarjeta, y mover la tarjeta no borra el monto.
+    ✅ Vacío borra el monto: un trato sin número no vale cero, no se sabe.
+17. **Total por columna** al pie de cada etapa.
+    ✅ Suma solo la moneda del negocio, en centavos enteros.
+    ✅ Sin montos capturados dice "Sin montos capturados" — un `$0.00` se lee
+    como un error del sistema, no como un dato.
+    ✅ Si hay importes en otra moneda, lo **dice** en vez de descartarlos en
+    silencio.
+18. **La moneda se elige** en Ajustes → Marca.
+    ✅ El tablero la refleja.
+    ✅ Un importe ya capturado conserva la suya: cambiar el ajuste no
+    reinterpreta pesos como dólares.
+
 ## Contactos (FR-013)
 
-16. Buscar por "Frio" → filtra; editar notas → persiste; archivar → desaparece
+19. Buscar por "Frio" → filtra; editar notas → persiste; archivar → desaparece
     de la lista (visible con "Ver archivados"); desarchivar → vuelve.

--- a/tests/unit/money.test.ts
+++ b/tests/unit/money.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatMoneyCents,
+  isCurrency,
+  parseMoneyToCents,
+  sumable,
+} from "@/lib/money";
+
+describe("parseMoneyToCents", () => {
+  it("acepta lo que la gente teclea de verdad", () => {
+    expect(parseMoneyToCents("12500")).toBe(1_250_000);
+    expect(parseMoneyToCents("12,500")).toBe(1_250_000);
+    expect(parseMoneyToCents("12,500.50")).toBe(1_250_050);
+    expect(parseMoneyToCents("$12 500.50")).toBe(1_250_050);
+    expect(parseMoneyToCents("  900  ")).toBe(90_000);
+  });
+
+  it("un decimal solo no se confunde con millares", () => {
+    // "12.5" son doce cincuenta, no doce mil quinientos.
+    expect(parseMoneyToCents("12.5")).toBe(1_250);
+    expect(parseMoneyToCents("12,5")).toBe(1_250);
+  });
+
+  it("trata el punto de millares como millares, no como decimales", () => {
+    // "12.500" con tres dígitos detrás es doce mil quinientos.
+    expect(parseMoneyToCents("12.500")).toBe(1_250_000);
+  });
+
+  it("sin número reconocible devuelve null, no cero", () => {
+    // Un 0 se leería como "este trato no vale nada", que es un dato distinto
+    // de "nadie capturó el monto".
+    expect(parseMoneyToCents("")).toBeNull();
+    expect(parseMoneyToCents("   ")).toBeNull();
+    expect(parseMoneyToCents("$")).toBeNull();
+    expect(parseMoneyToCents("no sé")).toBeNull();
+  });
+
+  it("el cero explícito sí es un cero", () => {
+    expect(parseMoneyToCents("0")).toBe(0);
+  });
+});
+
+describe("sumable", () => {
+  it("solo suma lo que está en la moneda del negocio", () => {
+    expect(sumable({ amountCents: 1000, currency: "MXN" }, "MXN")).toBe(true);
+    expect(sumable({ amountCents: 1000, currency: "USD" }, "MXN")).toBe(false);
+  });
+
+  it("un monto sin moneda se asume en la del negocio", () => {
+    // Es el caso de los leads capturados antes de que existiera la columna.
+    expect(sumable({ amountCents: 1000, currency: null }, "MXN")).toBe(true);
+  });
+
+  it("sin monto no suma, aunque la moneda coincida", () => {
+    expect(sumable({ amountCents: null, currency: "MXN" }, "MXN")).toBe(false);
+  });
+
+  it("cambiar la moneda del negocio cambia lo sumable", () => {
+    const monto = { amountCents: 1000, currency: "USD" };
+    expect(sumable(monto, "MXN")).toBe(false);
+    expect(sumable(monto, "USD")).toBe(true);
+  });
+});
+
+describe("formatMoneyCents", () => {
+  it("formatea en la moneda pedida", () => {
+    const out = formatMoneyCents(1_250_050, "MXN");
+    expect(out).toContain("12,500.50");
+  });
+
+  it("null entra, null sale: no inventa un $0.00", () => {
+    expect(formatMoneyCents(null, "MXN")).toBeNull();
+    expect(formatMoneyCents(undefined, "MXN")).toBeNull();
+  });
+
+  it("una moneda que el runtime no conoce degrada sin romper la pantalla", () => {
+    const out = formatMoneyCents(1_000, "XXX_INVALIDA");
+    expect(out).toBe("10.00 XXX_INVALIDA");
+  });
+});
+
+describe("catálogo de monedas", () => {
+  it("valida entradas basura", () => {
+    expect(isCurrency("MXN")).toBe(true);
+    expect(isCurrency("mxn")).toBe(false);
+    expect(isCurrency("pesos")).toBe(false);
+    expect(isCurrency(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
> Apilado sobre #22 (alta manual), que a su vez sale de #21. Al mergear: de
> abajo hacia arriba.

El tablero contaba **personas, no dinero**: no había forma de saber cuánto vale
lo que hay en cada etapa. Ahora cada tarjeta puede llevar su importe y cada
columna muestra su total.

## La moneda no está cableada

Se elige en **Ajustes → Marca** y viaja con el tablero; todas las funciones la
reciben explícitamente. Un default global escondido haría que cada instalación
fuera de su país sumara mal **sin avisar** — la clase de error que nadie reporta
porque parece que funciona.

Y lo que no se puede sumar **no se descarta en silencio**: al total solo entra
lo que está en la moneda del negocio —convertir exigiría un tipo de cambio, y un
CRM que inventa tipos de cambio miente— pero la columna dice cuántos importes
quedaron fuera. Un importe ya capturado conserva su moneda: cambiar el ajuste no
reinterpreta pesos como dólares.

## Tres decisiones sobre el dinero

**Centavos enteros, también al sumar.** Sumar pesos en coma flotante da totales
que el dueño no puede cuadrar contra sus propias tarjetas.

**El total se calcula al pintar, no se guarda.** Un total almacenado se
desincroniza en cuanto alguien arrastra una tarjeta, y sumar unas decenas es
gratis.

**NULL no es cero.** Sin monto capturado la columna dice *"Sin montos
capturados"* en palabras: un `$0.00` ahí se lee como un error del sistema, no
como un dato. Y un trato sin número no vale nada — simplemente no se sabe.

## ⚠️ Cambio de contrato

En `PATCH /api/pipeline/leads/[id]`, **`stageId` y `position` pasan a ser
opcionales**. Capturar dinero es un gesto distinto de mover la tarjeta, y exigir
la etapa para guardar un importe obligaría al cliente a reenviar dónde estaba —
moviendo el lead sin querer si su tablero venía desfasado. Sin `stageId` no se
mueve nada y no pasa por la bitácora, porque no hay movimiento que registrar.

El guardarraíl del #21 sigue contento: esa rama nunca escribe `stageId`.

## Verificación

```
pnpm typecheck   ✓
pnpm lint        ✓
pnpm test        ✓  193 pruebas, 28 archivos (13 nuevas de dinero)
pnpm build       ✓
```

Las pruebas de dinero incluyen los casos que rompen a los parsers ingenuos:
**"12.5" son doce cincuenta y "12.500" son doce mil quinientos**, y un texto sin
número devuelve `null` en vez de un `0` que después se leería como "no vale
nada".

Contra la app viva:

| Guion | Resultado |
|---|---|
| `e2e-monto-pipeline.mjs` (nuevo) | **14/14** |
| `e2e-alta-manual.mjs` (#22) | 14/14 |
| `e2e-bitacora-etapas.mjs` (#21) | 19/19 |
| `e2e-selftest.mjs` (general) | 87/87 |

```
✓ PATCH solo con monto → 200 (sin stageId)
✓ la tarjeta NO se movió de etapa
✓ sigue valiendo lo mismo tras cambiar de columna
✓ el monto ya capturado conserva SU moneda (no se reinterpreta)
✓ amountCents null borra el monto y su moneda
✓ un PATCH sin nada que cambiar → 422, no un 200 mentiroso
```

El total por columna lo suma el cliente, así que el guion verifica lo que lo
alimenta y la aritmética queda cubierta por los unit tests de `sumable`.

## Superficie

Migración `0006`: dos columnas nullable, sin backfill. Sin dependencias nuevas.

Se descartó la **probabilidad de cierre** que venía en el mismo commit del fork:
su heurística está calibrada a un ciclo de venta concreto (califica el bot →
agenda sesión → manda cotización) y de sus siete señales solo dos existen aquí.
Un negocio que vende por catálogo vería todas las tarjetas casi iguales — justo
el problema que dice resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
