### PR TITLE
ci: correr typecheck, lint, test y build en cada PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,14 @@ jobs:
     name: typecheck · lint · test · build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Antes que setup-node, porque su caché necesita pnpm ya instalado.
       # La versión sale de `packageManager` en package.json y no se repite
       # aquí: duplicarla es tenerla desactualizada en uno de los dos lados.
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+# Los cuatro gates del proyecto, corridos por una máquina en cada PR.
+#
+# Existe sobre todo por los PRs de fuera: quien manda uno no tiene la base de
+# datos ni el `.env` de nadie, así que hoy la única forma de saber si su cambio
+# sirve es que un humano lo clone y lo corra a mano. Con esto, el resultado
+# llega pegado al PR y el colaborador lo ve antes que el mantenedor.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Tres pushes seguidos a un PR no necesitan tres corridas: manda la última.
+# En `main` no se cancela nada — ahí el historial de qué pasó importa.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Solo lectura: ninguno de estos pasos escribe en el repo, y un PR desde un
+# fork ajeno no debe recibir un token que pueda hacerlo.
+permissions:
+  contents: read
+
+jobs:
+  gates:
+    name: typecheck · lint · test · build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Antes que setup-node, porque su caché necesita pnpm ya instalado.
+      # La versión sale de `packageManager` en package.json y no se repite
+      # aquí: duplicarla es tenerla desactualizada en uno de los dos lados.
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      # `--frozen-lockfile` falla si el lockfile no cuadra con package.json,
+      # en vez de resolver otras versiones en silencio y probar algo que nadie
+      # va a instalar.
+      - name: install
+        run: pnpm install --frozen-lockfile
+
+      # Los cuatro corren AUNQUE uno falle. Es a propósito: si se detuviera en
+      # el primero, arreglar tres cosas costaría tres vueltas de ida y vuelta a
+      # alguien que no puede reproducirlas en su máquina. Una corrida, la lista
+      # completa.
+      - name: typecheck
+        run: pnpm typecheck
+
+      - name: lint
+        if: ${{ !cancelled() }}
+        run: pnpm lint
+
+      - name: test
+        if: ${{ !cancelled() }}
+        run: pnpm test
+
+      # Va al final porque es el más lento, y porque ya atrapó cosas que los
+      # otros tres no ven: Next rechaza exports que no son handlers en un
+      # `route.ts`, y eso solo aparece al construir.
+      - name: build
+        if: ${{ !cancelled() }}
+        run: pnpm build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Vocero CRM
 
+[![CI](https://github.com/kevinrivm/vocero-crm/actions/workflows/ci.yml/badge.svg)](https://github.com/kevinrivm/vocero-crm/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 **El CRM de WhatsApp open source con un agente de IA que se pone a prueba solo.**
 
 Vocero es un CRM self-hosted y gratuito para negocios que venden por WhatsApp:


### PR DESCRIPTION
El repo tiene cuatro gates que funcionan —`typecheck`, `lint`, `test`, `build`—
y nadie los corre solo.

Hoy, saber si un PR de fuera sirve exige que un humano lo clone, instale y los
corra a mano. Y el problema de fondo es que **quien manda el PR no puede
hacerlo**: no tiene la base de datos ni el `.env` de nadie. En #9 la
verificación fue "corrido localmente antes de abrir el PR" — había que creerle.
Con esto no hace falta.

## Qué corre

En cada `pull_request` y en cada push a `main`:

```
pnpm install --frozen-lockfile
pnpm typecheck
pnpm lint
pnpm test
pnpm build
```

**Sin secretos.** Verifiqué los cuatro sobre un árbol limpio con el `.env`
apartado: pasan sin una sola variable de entorno. El workflow corre con
`permissions: contents: read` y no necesita acceso a nada.

## Dos decisiones que no son obvias

**Los cuatro corren aunque uno falle** (`if: ${{ !cancelled() }}`). Detenerse en
el primero le costaría tres vueltas de ida y vuelta a alguien que no puede
reproducir ninguna en su máquina. Una corrida, la lista completa.

**`build` va al último** porque es el más lento y porque atrapa cosas que los
otros tres no ven: Next rechaza los exports que no son handlers dentro de un
`route.ts`, y eso solo aparece al construir — ya pasó en esta base de código,
con typecheck, lint y las pruebas en verde.

La versión de pnpm no se repite en el workflow: sale de `packageManager` en
`package.json`. Duplicarla es tenerla desactualizada en uno de los dos lados.

## Verificación

Los cuatro gates, sobre árbol limpio y sin `.env`:

| | |
|---|---|
| `pnpm install --frozen-lockfile` | ✓ |
| `pnpm typecheck` | ✓ |
| `pnpm lint` | ✓ |
| `pnpm test` | ✓ 174 pruebas, 26 archivos |
| `pnpm build` | ✓ |

Y este PR se verifica a sí mismo: el workflow que agrega es el que lo revisa.
Corrida verde en 1m33s.

### Prueba en rojo

Un CI que siempre pasa es peor que no tenerlo, así que le metí un error de
tipos a propósito y empujé para ver qué hacía:

```
✓ install
X typecheck        Type 'string' is not assignable to type 'number'.
✓ lint             <- corrió igual
✓ test             <- corrió igual
X build
```

Falla, señala el archivo y la línea exactos en la anotación, y confirma que la
decisión de arriba funciona: `lint` y `test` se ejecutan aunque `typecheck` ya
haya fallado. El commit de prueba se revirtió; el historial de la rama queda
con los dos commits reales.

## Sobre las versiones de las acciones

Las `v4` de `checkout`/`setup-node` y la `v4` de `pnpm/action-setup` apuntan a
Node 20, que GitHub deprecó: la corrida pasa igual, pero deja una anotación
amarilla en **cada** PR. En un repo público eso lo ve todo el que contribuye.
Van en `v7`, `v7` y `v6`, verificadas en verde.

## Lo que NO incluye

El E2E (`pnpm test:e2e`) necesita Postgres levantado y la app corriendo. Se
puede hacer con un contenedor de servicio, pero es otro PR: estos cuatro son
los que corren gratis y atrapan la mayoría.

## Superficie

Un archivo nuevo (`.github/workflows/ci.yml`) y dos insignias en el README. Sin
dependencias, sin cambios en la app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
