### PR TITLE
feat(bandeja): la ficha del lead, donde se trabaja la conversación

### DIFF
--- a/drizzle/0005_glossy_excalibur.sql
+++ b/drizzle/0005_glossy_excalibur.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "contact" ADD COLUMN "source" text;

--- a/drizzle/0006_keen_thor_girl.sql
+++ b/drizzle/0006_keen_thor_girl.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "lead" ADD COLUMN "amount_cents" integer;--> statement-breakpoint
+ALTER TABLE "lead" ADD COLUMN "currency" text;

--- a/drizzle/0007_confused_zaran.sql
+++ b/drizzle/0007_confused_zaran.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "lead" ADD COLUMN "priority" text;--> statement-breakpoint
+ALTER TABLE "lead" ADD COLUMN "priority_updated_at" timestamp;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,2401 @@
+{
+  "id": "af962991-6992-4eec-8de3-45b8e2ebb6f0",
+  "prevId": "02ee9517-0e47-4ab4-899e-37258269025f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_profile": {
+      "name": "agent_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asistente'"
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalation_rules": {
+          "name": "escalation_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_profile_org_uq": {
+          "name": "agent_profile_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_profile_organization_id_organization_id_fk": {
+          "name": "agent_profile_organization_id_organization_id_fk",
+          "tableFrom": "agent_profile",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_case": {
+      "name": "agent_test_case",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "veredicto": {
+          "name": "veredicto",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hallazgos": {
+          "name": "hallazgos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_case_run_idx": {
+          "name": "test_case_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_case_organization_id_organization_id_fk": {
+          "name": "agent_test_case_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_run_id_agent_test_run_id_fk": {
+          "name": "agent_test_case_run_id_agent_test_run_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "agent_test_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_conversation_id_conversation_id_fk": {
+          "name": "agent_test_case_conversation_id_conversation_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_run": {
+      "name": "agent_test_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "test_run_org_running_uq": {
+          "name": "test_run_org_running_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_test_run\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_run_org_idx": {
+          "name": "test_run_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_run_organization_id_organization_id_fk": {
+          "name": "agent_test_run_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact": {
+      "name": "contact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_identity": {
+          "name": "wa_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_user_id": {
+          "name": "wa_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ficha": {
+          "name": "ficha",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_org_wa_identity_uq": {
+          "name": "contact_org_wa_identity_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_wa_user_id_idx": {
+          "name": "contact_org_wa_user_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_name_idx": {
+          "name": "contact_org_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_organization_id_organization_id_fk": {
+          "name": "contact_organization_id_organization_id_fk",
+          "tableFrom": "contact",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_test": {
+          "name": "is_test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ai_enabled": {
+          "name": "ai_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handoff_at": {
+          "name": "handoff_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_reason": {
+          "name": "handoff_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_inbound_at": {
+          "name": "last_inbound_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_org_contact_real_uq": {
+          "name": "conversation_org_contact_real_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation\".\"is_test\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_org_last_idx": {
+          "name": "conversation_org_last_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_organization_id_organization_id_fk": {
+          "name": "conversation_organization_id_organization_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_contact_id_contact_id_fk": {
+          "name": "conversation_contact_id_contact_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_entry": {
+      "name": "kb_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kb_org_idx": {
+          "name": "kb_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_entry_organization_id_organization_id_fk": {
+          "name": "kb_entry_organization_id_organization_id_fk",
+          "tableFrom": "kb_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead": {
+      "name": "lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lead_contact_uq": {
+          "name": "lead_contact_uq",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lead_org_stage_idx": {
+          "name": "lead_org_stage_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_organization_id_organization_id_fk": {
+          "name": "lead_organization_id_organization_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_contact_id_contact_id_fk": {
+          "name": "lead_contact_id_contact_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead_stage_event": {
+      "name": "lead_stage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_stage_id": {
+          "name": "from_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_stage_name": {
+          "name": "from_stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage_id": {
+          "name": "to_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage_name": {
+          "name": "to_stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_stage_kind": {
+          "name": "to_stage_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dueno'"
+        },
+        "approximate": {
+          "name": "approximate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "loss_reason": {
+          "name": "loss_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loss_note": {
+          "name": "loss_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lse_org_occurred_idx": {
+          "name": "lse_org_occurred_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lse_lead_occurred_idx": {
+          "name": "lse_lead_occurred_idx",
+          "columns": [
+            {
+              "expression": "lead_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lse_org_kind_occurred_idx": {
+          "name": "lse_org_kind_occurred_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_stage_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_stage_event_organization_id_organization_id_fk": {
+          "name": "lead_stage_event_organization_id_organization_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_lead_id_lead_id_fk": {
+          "name": "lead_stage_event_lead_id_lead_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "lead",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_contact_id_contact_id_fk": {
+          "name": "lead_stage_event_contact_id_contact_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_from_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_event_from_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "from_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_to_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_event_to_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "to_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_actor_user_id_user_id_fk": {
+          "name": "lead_stage_event_actor_user_id_user_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lse_loss_reason_ck": {
+          "name": "lse_loss_reason_ck",
+          "value": "\"lead_stage_event\".\"to_stage_kind\" <> 'lost' OR \"lead_stage_event\".\"approximate\" = true OR \"lead_stage_event\".\"loss_reason\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_asset": {
+      "name": "media_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_media_id": {
+          "name": "wa_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_status": {
+          "name": "fetch_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_asset_org_idx": {
+          "name": "media_asset_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_asset_wa_media_idx": {
+          "name": "media_asset_wa_media_idx",
+          "columns": [
+            {
+              "expression": "wa_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_asset_organization_id_organization_id_fk": {
+          "name": "media_asset_organization_id_organization_id_fk",
+          "tableFrom": "media_asset",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_message_id": {
+          "name": "wa_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated": {
+          "name": "ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'operator'"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_timestamp": {
+          "name": "wa_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_org_conv_idx": {
+          "name": "message_org_conv_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_organization_id_organization_id_fk": {
+          "name": "message_organization_id_organization_id_fk",
+          "tableFrom": "message",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_media_asset_id_media_asset_id_fk": {
+          "name": "message_media_asset_id_media_asset_id_fk",
+          "tableFrom": "message",
+          "tableTo": "media_asset",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_wa_message_id_unique": {
+          "name": "message_wa_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wa_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_credentials": {
+      "name": "meta_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waba_id": {
+          "name": "waba_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number_id": {
+          "name": "phone_number_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_phone_number": {
+          "name": "display_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_name": {
+          "name": "verified_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_cipher": {
+          "name": "token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meta_credentials_org_uq": {
+          "name": "meta_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meta_credentials_phone_uq": {
+          "name": "meta_credentials_phone_uq",
+          "columns": [
+            {
+              "expression": "phone_number_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meta_credentials_organization_id_organization_id_fk": {
+          "name": "meta_credentials_organization_id_organization_id_fk",
+          "tableFrom": "meta_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_stage": {
+      "name": "pipeline_stage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stage_org_pos_idx": {
+          "name": "stage_org_pos_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_stage_organization_id_organization_id_fk": {
+          "name": "pipeline_stage_organization_id_organization_id_fk",
+          "tableFrom": "pipeline_stage",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_template_id": {
+          "name": "wa_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_org_name_lang_uq": {
+          "name": "template_org_name_lang_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_organization_id_organization_id_fk": {
+          "name": "template_organization_id_organization_id_fk",
+          "tableFrom": "template",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,2413 @@
+{
+  "id": "dbfe098f-ab7b-46c0-ac8e-03f75dbbdcdd",
+  "prevId": "af962991-6992-4eec-8de3-45b8e2ebb6f0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_profile": {
+      "name": "agent_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asistente'"
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalation_rules": {
+          "name": "escalation_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_profile_org_uq": {
+          "name": "agent_profile_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_profile_organization_id_organization_id_fk": {
+          "name": "agent_profile_organization_id_organization_id_fk",
+          "tableFrom": "agent_profile",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_case": {
+      "name": "agent_test_case",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "veredicto": {
+          "name": "veredicto",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hallazgos": {
+          "name": "hallazgos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_case_run_idx": {
+          "name": "test_case_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_case_organization_id_organization_id_fk": {
+          "name": "agent_test_case_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_run_id_agent_test_run_id_fk": {
+          "name": "agent_test_case_run_id_agent_test_run_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "agent_test_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_conversation_id_conversation_id_fk": {
+          "name": "agent_test_case_conversation_id_conversation_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_run": {
+      "name": "agent_test_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "test_run_org_running_uq": {
+          "name": "test_run_org_running_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_test_run\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_run_org_idx": {
+          "name": "test_run_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_run_organization_id_organization_id_fk": {
+          "name": "agent_test_run_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact": {
+      "name": "contact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_identity": {
+          "name": "wa_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_user_id": {
+          "name": "wa_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ficha": {
+          "name": "ficha",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_org_wa_identity_uq": {
+          "name": "contact_org_wa_identity_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_wa_user_id_idx": {
+          "name": "contact_org_wa_user_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_name_idx": {
+          "name": "contact_org_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_organization_id_organization_id_fk": {
+          "name": "contact_organization_id_organization_id_fk",
+          "tableFrom": "contact",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_test": {
+          "name": "is_test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ai_enabled": {
+          "name": "ai_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handoff_at": {
+          "name": "handoff_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_reason": {
+          "name": "handoff_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_inbound_at": {
+          "name": "last_inbound_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_org_contact_real_uq": {
+          "name": "conversation_org_contact_real_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation\".\"is_test\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_org_last_idx": {
+          "name": "conversation_org_last_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_organization_id_organization_id_fk": {
+          "name": "conversation_organization_id_organization_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_contact_id_contact_id_fk": {
+          "name": "conversation_contact_id_contact_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_entry": {
+      "name": "kb_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kb_org_idx": {
+          "name": "kb_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_entry_organization_id_organization_id_fk": {
+          "name": "kb_entry_organization_id_organization_id_fk",
+          "tableFrom": "kb_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead": {
+      "name": "lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lead_contact_uq": {
+          "name": "lead_contact_uq",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lead_org_stage_idx": {
+          "name": "lead_org_stage_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_organization_id_organization_id_fk": {
+          "name": "lead_organization_id_organization_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_contact_id_contact_id_fk": {
+          "name": "lead_contact_id_contact_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead_stage_event": {
+      "name": "lead_stage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_stage_id": {
+          "name": "from_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_stage_name": {
+          "name": "from_stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage_id": {
+          "name": "to_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage_name": {
+          "name": "to_stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_stage_kind": {
+          "name": "to_stage_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dueno'"
+        },
+        "approximate": {
+          "name": "approximate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "loss_reason": {
+          "name": "loss_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loss_note": {
+          "name": "loss_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lse_org_occurred_idx": {
+          "name": "lse_org_occurred_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lse_lead_occurred_idx": {
+          "name": "lse_lead_occurred_idx",
+          "columns": [
+            {
+              "expression": "lead_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lse_org_kind_occurred_idx": {
+          "name": "lse_org_kind_occurred_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_stage_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_stage_event_organization_id_organization_id_fk": {
+          "name": "lead_stage_event_organization_id_organization_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_lead_id_lead_id_fk": {
+          "name": "lead_stage_event_lead_id_lead_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "lead",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_contact_id_contact_id_fk": {
+          "name": "lead_stage_event_contact_id_contact_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_from_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_event_from_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "from_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_to_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_event_to_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "to_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_actor_user_id_user_id_fk": {
+          "name": "lead_stage_event_actor_user_id_user_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lse_loss_reason_ck": {
+          "name": "lse_loss_reason_ck",
+          "value": "\"lead_stage_event\".\"to_stage_kind\" <> 'lost' OR \"lead_stage_event\".\"approximate\" = true OR \"lead_stage_event\".\"loss_reason\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_asset": {
+      "name": "media_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_media_id": {
+          "name": "wa_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_status": {
+          "name": "fetch_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_asset_org_idx": {
+          "name": "media_asset_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_asset_wa_media_idx": {
+          "name": "media_asset_wa_media_idx",
+          "columns": [
+            {
+              "expression": "wa_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_asset_organization_id_organization_id_fk": {
+          "name": "media_asset_organization_id_organization_id_fk",
+          "tableFrom": "media_asset",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_message_id": {
+          "name": "wa_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated": {
+          "name": "ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'operator'"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_timestamp": {
+          "name": "wa_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_org_conv_idx": {
+          "name": "message_org_conv_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_organization_id_organization_id_fk": {
+          "name": "message_organization_id_organization_id_fk",
+          "tableFrom": "message",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_media_asset_id_media_asset_id_fk": {
+          "name": "message_media_asset_id_media_asset_id_fk",
+          "tableFrom": "message",
+          "tableTo": "media_asset",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_wa_message_id_unique": {
+          "name": "message_wa_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wa_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_credentials": {
+      "name": "meta_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waba_id": {
+          "name": "waba_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number_id": {
+          "name": "phone_number_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_phone_number": {
+          "name": "display_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_name": {
+          "name": "verified_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_cipher": {
+          "name": "token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meta_credentials_org_uq": {
+          "name": "meta_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meta_credentials_phone_uq": {
+          "name": "meta_credentials_phone_uq",
+          "columns": [
+            {
+              "expression": "phone_number_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meta_credentials_organization_id_organization_id_fk": {
+          "name": "meta_credentials_organization_id_organization_id_fk",
+          "tableFrom": "meta_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_stage": {
+      "name": "pipeline_stage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stage_org_pos_idx": {
+          "name": "stage_org_pos_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_stage_organization_id_organization_id_fk": {
+          "name": "pipeline_stage_organization_id_organization_id_fk",
+          "tableFrom": "pipeline_stage",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_template_id": {
+          "name": "wa_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_org_name_lang_uq": {
+          "name": "template_org_name_lang_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_organization_id_organization_id_fk": {
+          "name": "template_organization_id_organization_id_fk",
+          "tableFrom": "template",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,2425 @@
+{
+  "id": "e3ece8e8-09fd-474a-a25c-254150b3e735",
+  "prevId": "dbfe098f-ab7b-46c0-ac8e-03f75dbbdcdd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_profile": {
+      "name": "agent_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asistente'"
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalation_rules": {
+          "name": "escalation_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_profile_org_uq": {
+          "name": "agent_profile_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_profile_organization_id_organization_id_fk": {
+          "name": "agent_profile_organization_id_organization_id_fk",
+          "tableFrom": "agent_profile",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_case": {
+      "name": "agent_test_case",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "veredicto": {
+          "name": "veredicto",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hallazgos": {
+          "name": "hallazgos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_case_run_idx": {
+          "name": "test_case_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_case_organization_id_organization_id_fk": {
+          "name": "agent_test_case_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_run_id_agent_test_run_id_fk": {
+          "name": "agent_test_case_run_id_agent_test_run_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "agent_test_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_conversation_id_conversation_id_fk": {
+          "name": "agent_test_case_conversation_id_conversation_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_run": {
+      "name": "agent_test_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "test_run_org_running_uq": {
+          "name": "test_run_org_running_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_test_run\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_run_org_idx": {
+          "name": "test_run_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_run_organization_id_organization_id_fk": {
+          "name": "agent_test_run_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact": {
+      "name": "contact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_identity": {
+          "name": "wa_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_user_id": {
+          "name": "wa_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ficha": {
+          "name": "ficha",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_org_wa_identity_uq": {
+          "name": "contact_org_wa_identity_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_wa_user_id_idx": {
+          "name": "contact_org_wa_user_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_name_idx": {
+          "name": "contact_org_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_organization_id_organization_id_fk": {
+          "name": "contact_organization_id_organization_id_fk",
+          "tableFrom": "contact",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_test": {
+          "name": "is_test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ai_enabled": {
+          "name": "ai_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handoff_at": {
+          "name": "handoff_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_reason": {
+          "name": "handoff_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_inbound_at": {
+          "name": "last_inbound_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_org_contact_real_uq": {
+          "name": "conversation_org_contact_real_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation\".\"is_test\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_org_last_idx": {
+          "name": "conversation_org_last_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_organization_id_organization_id_fk": {
+          "name": "conversation_organization_id_organization_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_contact_id_contact_id_fk": {
+          "name": "conversation_contact_id_contact_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_entry": {
+      "name": "kb_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kb_org_idx": {
+          "name": "kb_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_entry_organization_id_organization_id_fk": {
+          "name": "kb_entry_organization_id_organization_id_fk",
+          "tableFrom": "kb_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead": {
+      "name": "lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_updated_at": {
+          "name": "priority_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lead_contact_uq": {
+          "name": "lead_contact_uq",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lead_org_stage_idx": {
+          "name": "lead_org_stage_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_organization_id_organization_id_fk": {
+          "name": "lead_organization_id_organization_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_contact_id_contact_id_fk": {
+          "name": "lead_contact_id_contact_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead_stage_event": {
+      "name": "lead_stage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_stage_id": {
+          "name": "from_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_stage_name": {
+          "name": "from_stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage_id": {
+          "name": "to_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage_name": {
+          "name": "to_stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_stage_kind": {
+          "name": "to_stage_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dueno'"
+        },
+        "approximate": {
+          "name": "approximate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "loss_reason": {
+          "name": "loss_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loss_note": {
+          "name": "loss_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lse_org_occurred_idx": {
+          "name": "lse_org_occurred_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lse_lead_occurred_idx": {
+          "name": "lse_lead_occurred_idx",
+          "columns": [
+            {
+              "expression": "lead_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lse_org_kind_occurred_idx": {
+          "name": "lse_org_kind_occurred_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_stage_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_stage_event_organization_id_organization_id_fk": {
+          "name": "lead_stage_event_organization_id_organization_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_lead_id_lead_id_fk": {
+          "name": "lead_stage_event_lead_id_lead_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "lead",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_contact_id_contact_id_fk": {
+          "name": "lead_stage_event_contact_id_contact_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_from_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_event_from_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "from_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_to_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_event_to_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "to_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_actor_user_id_user_id_fk": {
+          "name": "lead_stage_event_actor_user_id_user_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lse_loss_reason_ck": {
+          "name": "lse_loss_reason_ck",
+          "value": "\"lead_stage_event\".\"to_stage_kind\" <> 'lost' OR \"lead_stage_event\".\"approximate\" = true OR \"lead_stage_event\".\"loss_reason\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_asset": {
+      "name": "media_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_media_id": {
+          "name": "wa_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_status": {
+          "name": "fetch_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_asset_org_idx": {
+          "name": "media_asset_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_asset_wa_media_idx": {
+          "name": "media_asset_wa_media_idx",
+          "columns": [
+            {
+              "expression": "wa_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_asset_organization_id_organization_id_fk": {
+          "name": "media_asset_organization_id_organization_id_fk",
+          "tableFrom": "media_asset",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_message_id": {
+          "name": "wa_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated": {
+          "name": "ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'operator'"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_timestamp": {
+          "name": "wa_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_org_conv_idx": {
+          "name": "message_org_conv_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_organization_id_organization_id_fk": {
+          "name": "message_organization_id_organization_id_fk",
+          "tableFrom": "message",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_media_asset_id_media_asset_id_fk": {
+          "name": "message_media_asset_id_media_asset_id_fk",
+          "tableFrom": "message",
+          "tableTo": "media_asset",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_wa_message_id_unique": {
+          "name": "message_wa_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wa_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_credentials": {
+      "name": "meta_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waba_id": {
+          "name": "waba_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number_id": {
+          "name": "phone_number_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_phone_number": {
+          "name": "display_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_name": {
+          "name": "verified_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_cipher": {
+          "name": "token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meta_credentials_org_uq": {
+          "name": "meta_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meta_credentials_phone_uq": {
+          "name": "meta_credentials_phone_uq",
+          "columns": [
+            {
+              "expression": "phone_number_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meta_credentials_organization_id_organization_id_fk": {
+          "name": "meta_credentials_organization_id_organization_id_fk",
+          "tableFrom": "meta_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_stage": {
+      "name": "pipeline_stage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stage_org_pos_idx": {
+          "name": "stage_org_pos_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_stage_organization_id_organization_id_fk": {
+          "name": "pipeline_stage_organization_id_organization_id_fk",
+          "tableFrom": "pipeline_stage",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_template_id": {
+          "name": "wa_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_org_name_lang_uq": {
+          "name": "template_org_name_lang_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_organization_id_organization_id_fk": {
+          "name": "template_organization_id_organization_id_fk",
+          "tableFrom": "template",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1786850050625,
       "tag": "0005_glossy_excalibur",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1786855153169,
+      "tag": "0006_keen_thor_girl",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1786849014992,
       "tag": "0004_reflective_the_enforcers",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1786850050625,
+      "tag": "0005_glossy_excalibur",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1786855153169,
       "tag": "0006_keen_thor_girl",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1786856261073,
+      "tag": "0007_confused_zaran",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/e2e-alta-manual.mjs
+++ b/scripts/e2e-alta-manual.mjs
@@ -1,0 +1,192 @@
+/**
+ * Self-test E2E de comportamiento — captura manual de prospectos
+ * (guion tests/e2e/us2-pipeline.md, sección "alta manual").
+ *
+ * Antes: `POST /api/contacts` existía pero ninguna pantalla lo llamaba, y
+ * cuando se llamaba por API creaba el contacto SIN lead — invisible en el
+ * Pipeline, que es donde se trabaja el embudo.
+ *
+ * Uso: node --env-file=.env scripts/e2e-alta-manual.mjs
+ * Requiere: app corriendo (pnpm dev) con WA_MOCK_ENABLED=true y BD migrada.
+ */
+import postgres from "postgres";
+
+const BASE = process.env.APP_BASE_URL ?? "http://localhost:3000";
+const PN = "PN-ALTA-1";
+const S = Math.random().toString(36).slice(2, 6).toUpperCase();
+const TEL = `52155700${Math.floor(1000 + Math.random() * 8999)}`;
+
+let cookie = "";
+let failures = 0;
+let checks = 0;
+const ok = (name, cond, extra = "") => {
+  checks++;
+  if (cond) console.log(`  ✓ ${name}`);
+  else {
+    failures++;
+    console.log(`  ✗ ${name}${extra ? ` — ${extra}` : ""}`);
+  }
+};
+
+async function api(path, opts = {}) {
+  const res = await fetch(`${BASE}${path}`, {
+    ...opts,
+    headers: {
+      "content-type": "application/json",
+      origin: BASE,
+      ...(cookie ? { cookie } : {}),
+      ...(opts.headers ?? {}),
+    },
+  });
+  const set = res.headers.getSetCookie?.() ?? [];
+  if (set.length) cookie = set.map((c) => c.split(";")[0]).join("; ");
+  let json = null;
+  try {
+    json = await res.clone().json();
+  } catch {}
+  return { res, json };
+}
+
+const sql = postgres(process.env.DATABASE_URL, { max: 1, onnotice: () => {} });
+
+console.log("== Setup ==");
+const email = "e2e@vocero.test";
+const password = "password-e2e-123";
+let su = await api("/api/auth/sign-up/email", {
+  method: "POST",
+  body: JSON.stringify({ email, password, name: "Operador E2E" }),
+});
+if (!su.res.ok) {
+  su = await api("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+}
+ok("registro o login del operador", su.res.ok);
+await api("/api/settings/whatsapp", {
+  method: "PUT",
+  body: JSON.stringify({ wabaId: "WABA-ALTA", phoneNumberId: PN, token: "tok-alta" }),
+});
+
+console.log("\n== Alta manual: entra al embudo, no solo a la libreta ==");
+const stages = (await api("/api/pipeline/stages")).json?.stages ?? [];
+const abiertas = stages.filter((s) => s.kind === "open");
+const segunda = abiertas[1] ?? abiertas[0];
+
+const alta = await api("/api/contacts", {
+  method: "POST",
+  body: JSON.stringify({
+    name: `Prospecto${S}`,
+    phone: TEL,
+    source: "referido",
+    stageId: segunda.id,
+    notes: "Me lo pasó un cliente",
+  }),
+});
+ok("POST /api/contacts → 201", alta.res.status === 201, JSON.stringify(alta.json));
+ok("devuelve el lead recién creado", Boolean(alta.json?.lead?.id));
+
+const board = (await api("/api/pipeline/board")).json;
+const enTablero = (board?.leads ?? []).find(
+  (l) => l.contact.name === `Prospecto${S}`
+);
+ok(
+  "el prospecto APARECE en el Pipeline (antes quedaba invisible)",
+  Boolean(enTablero)
+);
+ok(
+  "y en la etapa que eligió el dueño, no en la primera",
+  enTablero?.stageId === segunda.id,
+  `esperaba ${segunda.name}`
+);
+
+console.log("\n== Su nacimiento queda en la bitácora ==");
+const eventos = await sql`
+  select * from lead_stage_event where lead_id = ${alta.json.lead.id}`;
+ok("tiene exactamente un evento", eventos.length === 1, `hay ${eventos.length}`);
+ok(
+  "marcado como capturado por el dueño, no por el sistema",
+  eventos[0]?.source === "dueno" && eventos[0]?.actor_user_id !== null,
+  JSON.stringify({ source: eventos[0]?.source })
+);
+ok(
+  "y apunta a la etapa elegida",
+  eventos[0]?.to_stage_id === segunda.id
+);
+
+console.log("\n== La fuente capturada manda; lo no capturado no se inventa ==");
+const lista = (await api(`/api/contacts?q=Prospecto${S}`)).json?.contacts ?? [];
+ok(
+  "la fuente viaja como capturada",
+  lista[0]?.source?.value === "referido" &&
+    lista[0]?.source?.source === "capturada",
+  JSON.stringify(lista[0]?.source)
+);
+
+await api("/api/dev/wa-mock/inbound", {
+  method: "POST",
+  body: JSON.stringify({
+    phoneNumberId: PN,
+    from: `52155800${Math.floor(1000 + Math.random() * 8999)}`,
+    name: `Entrante${S}`,
+    text: "hola",
+  }),
+});
+await new Promise((r) => setTimeout(r, 1200));
+const lista2 = (await api(`/api/contacts?q=Entrante${S}`)).json?.contacts ?? [];
+ok(
+  "quien llegó por WhatsApp queda 'sin identificar', y se dice que es deducida",
+  lista2[0]?.source?.value === "desconocida" &&
+    lista2[0]?.source?.source === "deducida",
+  JSON.stringify(lista2[0]?.source)
+);
+
+console.log("\n== Caminos infelices ==");
+const dup = await api("/api/contacts", {
+  method: "POST",
+  body: JSON.stringify({ name: "Otro nombre", phone: TEL, source: "otro" }),
+});
+ok(
+  "mismo teléfono → 409 duplicate (no crea una segunda ficha)",
+  dup.res.status === 409 && dup.json?.error?.code === "duplicate",
+  JSON.stringify(dup.json)
+);
+
+const sinLada = await api("/api/contacts", {
+  method: "POST",
+  body: JSON.stringify({ name: "Sin lada", phone: "5512345678" }),
+});
+ok(
+  "teléfono de 10 dígitos pasa, pero uno con letras no",
+  sinLada.res.status === 201 || sinLada.res.status === 409,
+  `status ${sinLada.res.status}`
+);
+const basura = await api("/api/contacts", {
+  method: "POST",
+  body: JSON.stringify({ name: "Basura", phone: "55-1234-5678" }),
+});
+ok(
+  "teléfono con guiones → 422 con la explicación del código de país",
+  basura.res.status === 422,
+  JSON.stringify(basura.json)
+);
+
+console.log("\n== Escribir primero exige plantilla (regla de Meta) ==");
+const contactoNuevo = alta.json.contact.id;
+const sinPlantilla = await api(
+  `/api/contacts/${contactoNuevo}/start-conversation`,
+  { method: "POST", body: JSON.stringify({ templateId: "tpl_inexistente" }) }
+);
+ok(
+  "plantilla inexistente → error tipado, no 500",
+  sinPlantilla.res.status >= 400 && sinPlantilla.res.status < 500,
+  `status ${sinPlantilla.res.status}`
+);
+
+console.log(
+  failures === 0
+    ? `\nTODO VERDE — ${checks}/${checks} checks`
+    : `\n${checks - failures}/${checks} checks — ${failures} FALLARON`
+);
+await sql.end();
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/e2e-ficha-lead.mjs
+++ b/scripts/e2e-ficha-lead.mjs
@@ -1,0 +1,196 @@
+/**
+ * Self-test E2E de comportamiento — ficha del lead
+ * (guion tests/e2e/us1-inbox.md, sección "ficha").
+ *
+ * Lo que se prueba de verdad es la CONVIVENCIA: el agente va llenando la ficha
+ * mientras el dueño la corrige. Con reemplazo en vez de merge, el último en
+ * guardar le borra el trabajo al otro y nadie se entera hasta que falta un
+ * dato en una llamada.
+ *
+ * Uso: node --env-file=.env scripts/e2e-ficha-lead.mjs
+ */
+const BASE = process.env.APP_BASE_URL ?? "http://localhost:3000";
+const BOT_KEY = process.env.BOT_API_KEY;
+const PN = "PN-FICHA-1";
+const S = Math.random().toString(36).slice(2, 6).toUpperCase();
+
+let cookie = "";
+let failures = 0;
+let checks = 0;
+const ok = (name, cond, extra = "") => {
+  checks++;
+  if (cond) console.log(`  ✓ ${name}`);
+  else {
+    failures++;
+    console.log(`  ✗ ${name}${extra ? ` — ${extra}` : ""}`);
+  }
+};
+
+async function api(path, opts = {}) {
+  const res = await fetch(`${BASE}${path}`, {
+    ...opts,
+    headers: {
+      "content-type": "application/json",
+      origin: BASE,
+      ...(cookie ? { cookie } : {}),
+      ...(opts.headers ?? {}),
+    },
+  });
+  const set = res.headers.getSetCookie?.() ?? [];
+  if (set.length) cookie = set.map((c) => c.split(";")[0]).join("; ");
+  let json = null;
+  try {
+    json = await res.clone().json();
+  } catch {}
+  return { res, json };
+}
+
+/** Llamada del cerebro externo: va con la API key, sin sesión. */
+const bot = (path, body) =>
+  fetch(`${BASE}${path}`, {
+    method: "PUT",
+    headers: { "content-type": "application/json", "x-api-key": BOT_KEY },
+    body: JSON.stringify(body),
+  }).then(async (r) => ({ res: r, json: await r.json().catch(() => null) }));
+
+const fichaDe = async (contactId) =>
+  (await api(`/api/contacts/${contactId}`)).json?.contact?.ficha;
+
+console.log("== Setup ==");
+if (!BOT_KEY) {
+  console.log("  ✗ falta BOT_API_KEY en el entorno");
+  process.exit(1);
+}
+const email = "e2e@vocero.test";
+const password = "password-e2e-123";
+let su = await api("/api/auth/sign-up/email", {
+  method: "POST",
+  body: JSON.stringify({ email, password, name: "Operador E2E" }),
+});
+if (!su.res.ok) {
+  su = await api("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+}
+ok("registro o login del operador", su.res.ok);
+await api("/api/settings/whatsapp", {
+  method: "PUT",
+  body: JSON.stringify({ wabaId: "WABA-FI", phoneNumberId: PN, token: "tok-fi" }),
+});
+
+// Un entrante crea contacto + conversación, que es lo que el bot necesita.
+const phone = `52155000${Math.floor(1000 + Math.random() * 8999)}`;
+await api("/api/dev/wa-mock/inbound", {
+  method: "POST",
+  body: JSON.stringify({ phoneNumberId: PN, from: phone, name: `Ficha${S}`, text: "hola" }),
+});
+await new Promise((r) => setTimeout(r, 1200));
+const convs = (await api("/api/conversations")).json?.conversations ?? [];
+const conv = convs.find((c) => c.contact?.name === `Ficha${S}`);
+ok("conversación de prueba creada", Boolean(conv), JSON.stringify(convs.length));
+const contactId = conv?.contact?.id;
+
+console.log("\n== Nace vacía, no ausente ==");
+const inicial = await fichaDe(contactId);
+ok(
+  "un contacto nuevo trae ficha vacía, no undefined",
+  inicial && typeof inicial === "object" && Object.keys(inicial).length === 0,
+  JSON.stringify(inicial)
+);
+
+console.log("\n== El agente la llena y el dueño la ve ==");
+const escrita = await bot("/api/bot/ficha", {
+  conversationId: conv.id,
+  ficha: { presupuesto: 50000, zona: "Roma", calificado: true },
+});
+ok("PUT /api/bot/ficha → 200", escrita.res.ok, JSON.stringify(escrita.json));
+const vista = await fichaDe(contactId);
+ok(
+  "lo que guardó el agente llega a la pantalla del dueño",
+  vista?.presupuesto === 50000 && vista?.zona === "Roma" && vista?.calificado === true,
+  JSON.stringify(vista)
+);
+
+console.log("\n== El dueño corrige sin cambiar el tipo ==");
+await api(`/api/contacts/${contactId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ ficha: { presupuesto: 60000 } }),
+});
+const corregida = await fichaDe(contactId);
+ok(
+  "el valor corregido queda, y sigue siendo número",
+  corregida?.presupuesto === 60000,
+  JSON.stringify(corregida?.presupuesto)
+);
+ok(
+  "corregir una clave NO borra las demás",
+  corregida?.zona === "Roma" && corregida?.calificado === true
+);
+
+console.log("\n== Nadie le pisa el trabajo al otro ==");
+// El agente sigue conversando y descubre algo nuevo mientras el dueño edita.
+await bot("/api/bot/ficha", {
+  conversationId: conv.id,
+  ficha: { urgencia: "esta semana" },
+});
+const convive = await fichaDe(contactId);
+ok(
+  "lo nuevo del agente entra sin borrar la corrección del dueño",
+  convive?.urgencia === "esta semana" && convive?.presupuesto === 60000,
+  JSON.stringify(convive)
+);
+
+console.log("\n== Se puede quitar un dato equivocado ==");
+await api(`/api/contacts/${contactId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ ficha: { zona: null } }),
+});
+const sinZona = await fichaDe(contactId);
+ok("null quita la clave", !("zona" in (sinZona ?? {})), JSON.stringify(sinZona));
+ok("y no se lleva a las vecinas", sinZona?.presupuesto === 60000);
+
+console.log("\n== La cadena vacía NO borra ==");
+await api(`/api/contacts/${contactId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ ficha: { urgencia: "" } }),
+});
+const tras = await fichaDe(contactId);
+ok(
+  "vaciar sin querer no se lleva un dato que costó una conversación",
+  tras?.urgencia === "esta semana",
+  JSON.stringify(tras?.urgencia)
+);
+
+console.log("\n== Camino infeliz ==");
+await api(`/api/contacts/${contactId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ ficha: { anidado: { no: "se guarda" }, lista: [1, 2] } }),
+});
+const limpia = await fichaDe(contactId);
+ok(
+  "objetos y arreglos se ignoran en silencio, sin tirar la ficha",
+  !("anidado" in limpia) && !("lista" in limpia) && limpia?.presupuesto === 60000,
+  JSON.stringify(limpia)
+);
+
+const ajeno = await api("/api/contacts/ct_inexistente_999", {
+  method: "PATCH",
+  body: JSON.stringify({ ficha: { x: "y" } }),
+});
+// Ojo con lo que este check NO prueba: un id inexistente da 404 aunque la
+// query no filtre por organización. El aislamiento entre inquilinos lo cuida
+// `tests/unit/ficha-guard.test.ts`, que sí se pone rojo si alguien quita el
+// `scoped` de la puerta.
+ok(
+  "un contacto que no existe → 404, no una escritura a ciegas",
+  ajeno.res.status === 404,
+  String(ajeno.res.status)
+);
+
+console.log(
+  failures === 0
+    ? `\nTODO VERDE — ${checks}/${checks} checks`
+    : `\n${checks - failures}/${checks} checks — ${failures} FALLARON`
+);
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/e2e-monto-pipeline.mjs
+++ b/scripts/e2e-monto-pipeline.mjs
@@ -1,0 +1,193 @@
+/**
+ * Self-test E2E de comportamiento — monto de la negociación
+ * (guion tests/e2e/us2-pipeline.md, sección "monto").
+ *
+ * El total por columna lo suma el CLIENTE, así que aquí se verifica lo que lo
+ * alimenta: que el monto se guarde sin mover la tarjeta, que viaje con su
+ * moneda, y que la moneda del negocio llegue al tablero. La aritmética tiene
+ * sus propias pruebas en tests/unit/money.test.ts.
+ *
+ * Uso: node --env-file=.env scripts/e2e-monto-pipeline.mjs
+ */
+const BASE = process.env.APP_BASE_URL ?? "http://localhost:3000";
+const PN = "PN-MONTO-1";
+const S = Math.random().toString(36).slice(2, 6).toUpperCase();
+
+let cookie = "";
+let failures = 0;
+let checks = 0;
+const ok = (name, cond, extra = "") => {
+  checks++;
+  if (cond) console.log(`  ✓ ${name}`);
+  else {
+    failures++;
+    console.log(`  ✗ ${name}${extra ? ` — ${extra}` : ""}`);
+  }
+};
+
+async function api(path, opts = {}) {
+  const res = await fetch(`${BASE}${path}`, {
+    ...opts,
+    headers: {
+      "content-type": "application/json",
+      origin: BASE,
+      ...(cookie ? { cookie } : {}),
+      ...(opts.headers ?? {}),
+    },
+  });
+  const set = res.headers.getSetCookie?.() ?? [];
+  if (set.length) cookie = set.map((c) => c.split(";")[0]).join("; ");
+  let json = null;
+  try {
+    json = await res.clone().json();
+  } catch {}
+  return { res, json };
+}
+
+console.log("== Setup ==");
+const email = "e2e@vocero.test";
+const password = "password-e2e-123";
+let su = await api("/api/auth/sign-up/email", {
+  method: "POST",
+  body: JSON.stringify({ email, password, name: "Operador E2E" }),
+});
+if (!su.res.ok) {
+  su = await api("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+}
+ok("registro o login del operador", su.res.ok);
+await api("/api/settings/whatsapp", {
+  method: "PUT",
+  body: JSON.stringify({ wabaId: "WABA-MON", phoneNumberId: PN, token: "tok-mon" }),
+});
+
+const stages = (await api("/api/pipeline/stages")).json?.stages ?? [];
+const abiertas = stages.filter((s) => s.kind === "open");
+const alta = await api("/api/contacts", {
+  method: "POST",
+  body: JSON.stringify({
+    name: `Trato${S}`,
+    phone: `52155900${Math.floor(1000 + Math.random() * 8999)}`,
+    source: "referido",
+  }),
+});
+const leadId = alta.json?.lead?.id;
+ok("prospecto de prueba creado", Boolean(leadId));
+
+console.log("\n== Capturar el monto NO mueve la tarjeta ==");
+const antes = (await api("/api/pipeline/board")).json;
+const etapaAntes = antes.leads.find((l) => l.id === leadId)?.stageId;
+
+const guardado = await api(`/api/pipeline/leads/${leadId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ amountCents: 1_250_050 }),
+});
+ok(
+  "PATCH solo con monto → 200 (sin stageId)",
+  guardado.res.ok,
+  JSON.stringify(guardado.json)
+);
+
+const board = (await api("/api/pipeline/board")).json;
+const tarjeta = board.leads.find((l) => l.id === leadId);
+ok("el monto quedó guardado en centavos", tarjeta?.amountCents === 1_250_050);
+ok(
+  "la tarjeta NO se movió de etapa",
+  tarjeta?.stageId === etapaAntes,
+  `antes ${etapaAntes}, ahora ${tarjeta?.stageId}`
+);
+ok(
+  "el monto viaja con su moneda, tomada del negocio",
+  tarjeta?.currency === board.currency,
+  JSON.stringify({ lead: tarjeta?.currency, negocio: board.currency })
+);
+ok(
+  "el tablero informa la moneda del negocio",
+  typeof board.currency === "string" && board.currency.length === 3,
+  JSON.stringify(board.currency)
+);
+
+console.log("\n== Mover la tarjeta conserva el monto ==");
+const otra = abiertas.find((s) => s.id !== etapaAntes) ?? abiertas[0];
+await api(`/api/pipeline/leads/${leadId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ stageId: otra.id, position: 0 }),
+});
+const trasMover = (await api("/api/pipeline/board")).json.leads.find(
+  (l) => l.id === leadId
+);
+ok(
+  "sigue valiendo lo mismo tras cambiar de columna",
+  trasMover?.amountCents === 1_250_050,
+  JSON.stringify(trasMover?.amountCents)
+);
+
+console.log("\n== Cambiar la moneda del negocio ==");
+const marca = (await api("/api/settings/branding")).json?.branding;
+const nuevaMoneda = marca.currency === "USD" ? "MXN" : "USD";
+const put = await api("/api/settings/branding", {
+  method: "PUT",
+  body: JSON.stringify({
+    name: marca.name,
+    accent: marca.accent,
+    currency: nuevaMoneda,
+  }),
+});
+ok("la moneda se guarda en Ajustes → Marca", put.res.ok, JSON.stringify(put.json));
+const board2 = (await api("/api/pipeline/board")).json;
+ok(
+  "y el tablero la refleja",
+  board2.currency === nuevaMoneda,
+  JSON.stringify(board2.currency)
+);
+ok(
+  "el monto ya capturado conserva SU moneda (no se reinterpreta)",
+  board2.leads.find((l) => l.id === leadId)?.currency === marca.currency,
+  "un importe capturado en pesos no se vuelve dólares porque cambie el ajuste"
+);
+// Volver a dejarlo como estaba para no ensuciar corridas siguientes.
+await api("/api/settings/branding", {
+  method: "PUT",
+  body: JSON.stringify({ name: marca.name, accent: marca.accent, currency: marca.currency }),
+});
+
+console.log("\n== Caminos infelices ==");
+const borrado = await api(`/api/pipeline/leads/${leadId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ amountCents: null }),
+});
+const trasBorrar = (await api("/api/pipeline/board")).json.leads.find(
+  (l) => l.id === leadId
+);
+ok(
+  "amountCents null borra el monto y su moneda",
+  borrado.res.ok &&
+    trasBorrar?.amountCents === null &&
+    trasBorrar?.currency === null,
+  JSON.stringify({ cents: trasBorrar?.amountCents, cur: trasBorrar?.currency })
+);
+
+const vacio = await api(`/api/pipeline/leads/${leadId}`, {
+  method: "PATCH",
+  body: JSON.stringify({}),
+});
+ok(
+  "un PATCH sin nada que cambiar → 422, no un 200 mentiroso",
+  vacio.res.status === 422,
+  JSON.stringify(vacio.json)
+);
+
+const negativo = await api(`/api/pipeline/leads/${leadId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ amountCents: -500 }),
+});
+ok("monto negativo → 422", negativo.res.status === 422);
+
+console.log(
+  failures === 0
+    ? `\nTODO VERDE — ${checks}/${checks} checks`
+    : `\n${checks - failures}/${checks} checks — ${failures} FALLARON`
+);
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/e2e-prioridad.mjs
+++ b/scripts/e2e-prioridad.mjs
@@ -1,0 +1,177 @@
+/**
+ * Self-test E2E de comportamiento — prioridad del lead
+ * (guion tests/e2e/us2-pipeline.md, sección "prioridad").
+ *
+ * Lo que se verifica sobre todo es lo que NO pasa: que nada escriba la
+ * prioridad por su cuenta. Un CRM que la adivina y pisa lo que el dueño puso
+ * es un CRM en el que se deja de mirar esa columna.
+ *
+ * Uso: node --env-file=.env scripts/e2e-prioridad.mjs
+ */
+const BASE = process.env.APP_BASE_URL ?? "http://localhost:3000";
+const PN = "PN-PRIO-1";
+const S = Math.random().toString(36).slice(2, 6).toUpperCase();
+
+let cookie = "";
+let failures = 0;
+let checks = 0;
+const ok = (name, cond, extra = "") => {
+  checks++;
+  if (cond) console.log(`  ✓ ${name}`);
+  else {
+    failures++;
+    console.log(`  ✗ ${name}${extra ? ` — ${extra}` : ""}`);
+  }
+};
+
+async function api(path, opts = {}) {
+  const res = await fetch(`${BASE}${path}`, {
+    ...opts,
+    headers: {
+      "content-type": "application/json",
+      origin: BASE,
+      ...(cookie ? { cookie } : {}),
+      ...(opts.headers ?? {}),
+    },
+  });
+  const set = res.headers.getSetCookie?.() ?? [];
+  if (set.length) cookie = set.map((c) => c.split(";")[0]).join("; ");
+  let json = null;
+  try {
+    json = await res.clone().json();
+  } catch {}
+  return { res, json };
+}
+const board = async () => (await api("/api/pipeline/board")).json;
+const tarjeta = async (id) => (await board()).leads.find((l) => l.id === id);
+
+console.log("== Setup ==");
+const email = "e2e@vocero.test";
+const password = "password-e2e-123";
+let su = await api("/api/auth/sign-up/email", {
+  method: "POST",
+  body: JSON.stringify({ email, password, name: "Operador E2E" }),
+});
+if (!su.res.ok) {
+  su = await api("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+}
+ok("registro o login del operador", su.res.ok);
+await api("/api/settings/whatsapp", {
+  method: "PUT",
+  body: JSON.stringify({ wabaId: "WABA-PRI", phoneNumberId: PN, token: "tok-pri" }),
+});
+
+const alta = await api("/api/contacts", {
+  method: "POST",
+  body: JSON.stringify({
+    name: `Prio${S}`,
+    phone: `52156000${Math.floor(1000 + Math.random() * 8999)}`,
+  }),
+});
+const leadId = alta.json?.lead?.id;
+ok("prospecto de prueba creado", Boolean(leadId));
+
+console.log("\n== Nace SIN prioridad, no con una inventada ==");
+ok(
+  "un lead nuevo no trae prioridad",
+  (await tarjeta(leadId))?.priority === null,
+  JSON.stringify((await tarjeta(leadId))?.priority)
+);
+
+console.log("\n== La fija el dueño y se queda ==");
+const puesta = await api(`/api/pipeline/leads/${leadId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ priority: "alta" }),
+});
+ok("PATCH con prioridad → 200", puesta.res.ok, JSON.stringify(puesta.json));
+ok("queda guardada", (await tarjeta(leadId))?.priority === "alta");
+
+console.log("\n== Nada la pisa ==");
+const stages = (await api("/api/pipeline/stages")).json.stages;
+const actual = await tarjeta(leadId);
+const otra = stages.find((s) => s.kind === "open" && s.id !== actual.stageId);
+await api(`/api/pipeline/leads/${leadId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ stageId: otra.id, position: 0 }),
+});
+ok(
+  "mover la tarjeta de etapa NO cambia la prioridad",
+  (await tarjeta(leadId))?.priority === "alta"
+);
+await api(`/api/pipeline/leads/${leadId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ amountCents: 500000 }),
+});
+ok(
+  "capturar el monto tampoco la toca",
+  (await tarjeta(leadId))?.priority === "alta"
+);
+
+// Un mensaje entrante mueve la actividad del lead: tampoco debe opinar.
+await api("/api/dev/wa-mock/inbound", {
+  method: "POST",
+  body: JSON.stringify({
+    phoneNumberId: PN,
+    from: alta.json.contact.phone,
+    name: `Prio${S}`,
+    text: "sigo interesado",
+  }),
+});
+await new Promise((r) => setTimeout(r, 1200));
+ok(
+  "un mensaje entrante tampoco la reescribe",
+  (await tarjeta(leadId))?.priority === "alta"
+);
+
+console.log("\n== Se puede QUITAR, no solo cambiar ==");
+const bajada = await api(`/api/pipeline/leads/${leadId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ priority: "baja" }),
+});
+ok("cambiar de alta a baja", bajada.res.ok && (await tarjeta(leadId))?.priority === "baja");
+
+const quitada = await api(`/api/pipeline/leads/${leadId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ priority: null }),
+});
+ok(
+  "null la quita: un clic por error no queda para siempre",
+  quitada.res.ok && (await tarjeta(leadId))?.priority === null
+);
+
+console.log("\n== Llega a la lista de Contactos ==");
+await api(`/api/pipeline/leads/${leadId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ priority: "alta" }),
+});
+const lista = (await api(`/api/contacts?q=Prio${S}`)).json?.contacts ?? [];
+ok(
+  "el contacto trae la prioridad de su lead",
+  lista[0]?.priority === "alta",
+  JSON.stringify(lista[0]?.priority)
+);
+
+console.log("\n== Camino infeliz ==");
+const basura = await api(`/api/pipeline/leads/${leadId}`, {
+  method: "PATCH",
+  body: JSON.stringify({ priority: "urgentísima" }),
+});
+ok(
+  "una prioridad fuera del catálogo → 422",
+  basura.res.status === 422,
+  JSON.stringify(basura.json)
+);
+ok(
+  "y la que había sigue intacta",
+  (await tarjeta(leadId))?.priority === "alta"
+);
+
+console.log(
+  failures === 0
+    ? `\nTODO VERDE — ${checks}/${checks} checks`
+    : `\n${checks - failures}/${checks} checks — ${failures} FALLARON`
+);
+process.exit(failures === 0 ? 0 : 1);

--- a/src/app/api/bot/ficha/route.ts
+++ b/src/app/api/bot/ficha/route.ts
@@ -46,8 +46,10 @@ export async function PUT(req: Request) {
   if (!rows[0]) return apiError(404, "not_found", "Conversación no encontrada");
 
   const result = await upsertFicha({
+    organizationId,
     contactId: rows[0].contactId,
     ficha: body.data.ficha,
   });
+  if (!result) return apiError(404, "not_found", "Contacto no encontrado");
   return Response.json(result);
 }

--- a/src/app/api/contacts/[id]/route.ts
+++ b/src/app/api/contacts/[id]/route.ts
@@ -8,6 +8,7 @@ import {
   getContactStage,
   serializeContact,
 } from "@/server/contacts";
+import { upsertFicha } from "@/server/bot/ficha";
 
 export const dynamic = "force-dynamic";
 
@@ -36,12 +37,31 @@ const patchSchema = z.object({
   name: z.string().trim().min(1).max(120).optional(),
   notes: z.string().max(4000).nullable().optional(),
   archived: z.boolean().optional(),
+  /**
+   * Parche de la ficha: solo las claves que cambian. `null` borra una clave.
+   * No es un reemplazo — el agente sigue escribiendo mientras el dueño
+   * corrige, y mandar la ficha entera haría que el último en guardar le
+   * borrara lo recién descubierto al otro.
+   */
+  ficha: z.record(z.unknown()).optional(),
 });
 
 export const PATCH = withAuth(async (session, req: Request, ctx: Params) => {
   const { id } = await ctx.params;
   const body = await parseBody(req, patchSchema);
   if (!body.ok) return body.response;
+
+  // La ficha va por su propia puerta —la MISMA que usa el cerebro externo en
+  // `PUT /api/bot/ficha`— para heredar el merge y las cotas. Escribirla aquí
+  // con un `set` plano sería un segundo camino con otras reglas.
+  if (body.data.ficha !== undefined) {
+    const res = await upsertFicha({
+      organizationId: session.organizationId,
+      contactId: id,
+      ficha: body.data.ficha,
+    });
+    if (!res) return apiError(404, "not_found", "Contacto no encontrado");
+  }
 
   const set: Record<string, unknown> = { updatedAt: new Date() };
   if (body.data.name !== undefined) set.name = body.data.name;

--- a/src/app/api/contacts/[id]/start-conversation/route.ts
+++ b/src/app/api/contacts/[id]/start-conversation/route.ts
@@ -1,0 +1,91 @@
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { apiError, parseBody, withAuth } from "@/lib/api";
+import { getDb, schema } from "@/lib/db";
+import { scoped } from "@/lib/db/tenant";
+import { getContactById } from "@/server/contacts";
+import { getOrCreateConversation } from "@/server/inbox/ingest";
+import { SendError } from "@/server/inbox/send";
+import { isWindowOpen } from "@/server/inbox/window";
+import {
+  sendTemplate,
+  TemplateError,
+  templateErrorStatus,
+} from "@/server/whatsapp/templates";
+
+export const dynamic = "force-dynamic";
+
+type Params = { params: Promise<{ id: string }> };
+
+const bodySchema = z.object({
+  templateId: z.string().min(1),
+  variables: z.array(z.string().trim().max(500)).max(10).optional(),
+});
+
+/**
+ * Abre la conversación con un contacto que NUNCA ha escrito (capturado
+ * a mano). WhatsApp solo permite iniciar con plantilla aprobada; esa es una
+ * regla de Meta, no del CRM.
+ *
+ * La conversación se crea AQUÍ y no al capturar el contacto: un hilo vacío
+ * ensuciaría la Bandeja y rompería su orden por último mensaje.
+ */
+export const POST = withAuth(async (session, req: Request, ctx: Params) => {
+  const { id } = await ctx.params;
+  const contact = await getContactById(session.organizationId, id);
+  if (!contact) return apiError(404, "not_found", "Contacto no encontrado");
+  if (!contact.phone && !contact.waIdentity) {
+    return apiError(422, "no_identity", "Este contacto no tiene a dónde escribir");
+  }
+
+  const body = await parseBody(req, bodySchema);
+  if (!body.ok) return body.response;
+
+  const db = getDb();
+  const existing = await db
+    .select({ id: schema.conversation.id, lastInboundAt: schema.conversation.lastInboundAt })
+    .from(schema.conversation)
+    .where(
+      scoped(
+        schema.conversation.organizationId,
+        session.organizationId,
+        eq(schema.conversation.contactId, id),
+        eq(schema.conversation.isTest, false)
+      )
+    )
+    .limit(1);
+
+  // Gastar una plantilla teniendo la ventana abierta es tirar dinero y
+  // reputación de plantilla: se avisa en vez de enviarla.
+  if (existing[0] && isWindowOpen(existing[0].lastInboundAt)) {
+    return apiError(
+      409,
+      "window_open",
+      "Esta persona te escribió hace menos de 24 h: puedes responderle directo desde la Bandeja, sin plantilla"
+    );
+  }
+
+  const conversation =
+    existing[0] ?? (await getOrCreateConversation(session.organizationId, id));
+
+  try {
+    const result = await sendTemplate({
+      organizationId: session.organizationId,
+      conversationId: conversation.id,
+      templateId: body.data.templateId,
+      variables: body.data.variables,
+    });
+    return Response.json({
+      messageId: result.messageId,
+      conversationId: conversation.id,
+    });
+  } catch (err) {
+    if (err instanceof TemplateError) {
+      return apiError(templateErrorStatus(err), err.code, err.message);
+    }
+    if (err instanceof SendError) {
+      return apiError(409, err.code, err.message);
+    }
+    throw err;
+  }
+});

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -7,6 +7,7 @@ import { scoped } from "@/lib/db/tenant";
 import { normalizeMx } from "@/lib/meta/client";
 import { digitsOnly, normalizeText } from "@/lib/search";
 import { serializeContact } from "@/server/contacts";
+import { createLeadForContact } from "@/server/inbox/lead-activity";
 
 export const dynamic = "force-dynamic";
 
@@ -91,11 +92,21 @@ export const GET = withAuth(async (session, req: Request) => {
 
 const createSchema = z.object({
   name: z.string().trim().min(1).max(120),
+  /**
+   * EXIGE código de país. Un número local crearía un contacto que jamás casaría
+   * con los mensajes entrantes —Meta siempre manda la identidad completa— y el
+   * dueño acabaría con dos fichas de la misma persona. No se asume un país:
+   * diez dígitos son válidos en varios, y asumir mal produce un número
+   * silenciosamente equivocado.
+   */
   phone: z
     .string()
     .trim()
     .regex(/^\d{7,15}$/, "Teléfono en dígitos, con código de país (ej. 5215512345678)"),
   notes: z.string().max(4000).optional(),
+  source: z.enum(["anuncio", "organico", "referido", "conocido", "otro"]).optional(),
+  /** Etapa inicial del lead; si no viene, la primera abierta del tablero. */
+  stageId: z.string().min(1).optional(),
 });
 
 export const POST = withAuth(async (session, req: Request) => {
@@ -114,6 +125,7 @@ export const POST = withAuth(async (session, req: Request) => {
       phone,
       waIdentity: phone,
       notes: body.data.notes ?? null,
+      source: body.data.source ?? null,
     })
     .onConflictDoNothing({
       target: [schema.contact.organizationId, schema.contact.waIdentity],
@@ -122,8 +134,27 @@ export const POST = withAuth(async (session, req: Request) => {
   if (!inserted[0]) {
     return apiError(409, "duplicate", "Ya existe un contacto con ese teléfono");
   }
+
+  // Y su lead: un contacto sin lead es invisible en el Pipeline, que es la
+  // pantalla donde se trabaja el embudo. Dar de alta a alguien y no verlo ahí
+  // es la mitad de la función.
+  const lead = await createLeadForContact({
+    organizationId: session.organizationId,
+    contactId: inserted[0].id,
+    stageId: body.data.stageId,
+    source: "dueno",
+    actorUserId: session.userId,
+  });
+  if (!lead) {
+    return apiError(
+      422,
+      "no_stage",
+      "El tablero no tiene etapas abiertas donde colocar al prospecto"
+    );
+  }
+
   return Response.json(
-    { contact: serializeContact(inserted[0]) },
+    { contact: serializeContact(inserted[0]), lead: { id: lead.id } },
     { status: 201 }
   );
 });

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -35,6 +35,7 @@ export const GET = withAuth(async (session, req: Request) => {
     .select({
       contactId: schema.lead.contactId,
       stageName: schema.pipelineStage.name,
+      priority: schema.lead.priority,
     })
     .from(schema.lead)
     .innerJoin(
@@ -44,6 +45,9 @@ export const GET = withAuth(async (session, req: Request) => {
     .where(scoped(schema.lead.organizationId, session.organizationId));
   const stageByContact = new Map(
     leadStages.map((r) => [r.contactId, r.stageName])
+  );
+  const priorityByContact = new Map(
+    leadStages.map((r) => [r.contactId, r.priority])
   );
 
   const qDigits = q ? digitsOnly(q) : "";
@@ -86,7 +90,13 @@ export const GET = withAuth(async (session, req: Request) => {
 
   const contacts = rows
     .filter((c) => includeArchived || !c.archivedAt)
-    .map((c) => serializeContact(c, stageByContact.get(c.id) ?? null));
+    .map((c) =>
+      serializeContact(
+        c,
+        stageByContact.get(c.id) ?? null,
+        priorityByContact.get(c.id) ?? null
+      )
+    );
   return Response.json({ contacts });
 });
 

--- a/src/app/api/pipeline/board/route.ts
+++ b/src/app/api/pipeline/board/route.ts
@@ -2,6 +2,7 @@ import { and, asc, eq } from "drizzle-orm";
 import { withAuth } from "@/lib/api";
 import { getDb, schema } from "@/lib/db";
 import { scoped } from "@/lib/db/tenant";
+import { getBranding } from "@/server/branding";
 
 export const dynamic = "force-dynamic";
 
@@ -33,7 +34,12 @@ export const GET = withAuth(async (session) => {
     .where(scoped(schema.lead.organizationId, session.organizationId))
     .orderBy(asc(schema.lead.position));
 
+  // La moneda del negocio viaja con el tablero: el cliente suma sus columnas y
+  // necesita saber cuál es la única sumable, sin adivinarla ni pedirla aparte.
+  const { currency } = await getBranding(session.organizationId);
+
   return Response.json({
+    currency,
     stages: stages.map((s) => ({
       id: s.id,
       name: s.name,
@@ -45,6 +51,8 @@ export const GET = withAuth(async (session) => {
       stageId: r.lead.stageId,
       position: r.lead.position,
       lastActivityAt: r.lead.lastActivityAt?.toISOString() ?? null,
+      amountCents: r.lead.amountCents,
+      currency: r.lead.currency,
       contact: {
         id: r.contact.id,
         name: r.contact.name,

--- a/src/app/api/pipeline/board/route.ts
+++ b/src/app/api/pipeline/board/route.ts
@@ -53,6 +53,7 @@ export const GET = withAuth(async (session) => {
       lastActivityAt: r.lead.lastActivityAt?.toISOString() ?? null,
       amountCents: r.lead.amountCents,
       currency: r.lead.currency,
+      priority: r.lead.priority,
       contact: {
         id: r.contact.id,
         name: r.contact.name,

--- a/src/app/api/pipeline/leads/[id]/route.ts
+++ b/src/app/api/pipeline/leads/[id]/route.ts
@@ -2,16 +2,24 @@ import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { apiError, parseBody, withAuth } from "@/lib/api";
 import { getDb, schema } from "@/lib/db";
+import { scoped } from "@/lib/db/tenant";
 import { publish } from "@/server/events/bus";
 import { moveLeadToStage } from "@/server/leads/stage-history";
+import { getBranding } from "@/server/branding";
 
 export const dynamic = "force-dynamic";
 
 type Params = { params: Promise<{ id: string }> };
 
 const patchSchema = z.object({
-  stageId: z.string().min(1),
-  position: z.number().int().min(0),
+  /**
+   * Opcionales desde que el lead tiene monto: capturar dinero es un gesto
+   * distinto de mover la tarjeta, y exigir la etapa para guardar un importe
+   * obligaría al cliente a reenviar dónde estaba —con el riesgo de moverlo sin
+   * querer si el tablero venía desfasado—. Sin `stageId` no se mueve nada.
+   */
+  stageId: z.string().min(1).optional(),
+  position: z.number().int().min(0).optional(),
   /**
    * Obligatorio al ENTRAR a una etapa perdida. No se valida aquí sino en la
    * puerta: la regla es del dominio, no de esta ruta, y hay más caminos que
@@ -28,12 +36,56 @@ const patchSchema = z.object({
     ])
     .optional(),
   lossNote: z.string().max(500).optional(),
+  /**
+   * Monto en centavos enteros. `null` explícito lo borra; ausente lo deja como
+   * estaba — capturar el monto y mover la tarjeta son dos gestos distintos y
+   * uno no debe pisar al otro.
+   */
+  amountCents: z.number().int().min(0).max(1_000_000_000_00).nullable().optional(),
+  currency: z.string().length(3).nullable().optional(),
 });
 
 export const PATCH = withAuth(async (session, req: Request, ctx: Params) => {
   const { id } = await ctx.params;
   const body = await parseBody(req, patchSchema);
   if (!body.ok) return body.response;
+
+  // El monto viaja en el MISMO update que el movimiento: capturarlo mientras
+  // se arrastra la tarjeta no debe costar dos viajes ni dejar un estado a
+  // medias si el segundo falla.
+  const extra: Record<string, unknown> = {};
+  if (body.data.amountCents !== undefined) {
+    extra.amountCents = body.data.amountCents;
+    // Sin monto no hay moneda que guardar: dejarla apuntando a un importe
+    // borrado haría que el tablero contara un lead que ya no tiene número.
+    extra.currency =
+      body.data.amountCents === null
+        ? null
+        : (body.data.currency ?? (await getBranding(session.organizationId)).currency);
+  }
+
+  // Sin etapa: solo se actualizan los campos del lead. No pasa por la puerta
+  // de la bitácora porque no hay movimiento que registrar — y el guardarraíl
+  // sigue contento: aquí jamás se escribe `stageId`.
+  if (!body.data.stageId) {
+    if (Object.keys(extra).length === 0) {
+      return apiError(422, "nothing_to_update", "No hay nada que actualizar");
+    }
+    const db = getDb();
+    const updated = await db
+      .update(schema.lead)
+      .set({ ...extra, updatedAt: new Date() })
+      .where(
+        scoped(
+          schema.lead.organizationId,
+          session.organizationId,
+          eq(schema.lead.id, id)
+        )
+      )
+      .returning();
+    if (!updated[0]) return apiError(404, "not_found", "Lead no encontrado");
+    return Response.json({ lead: updated[0] });
+  }
 
   const res = await moveLeadToStage({
     organizationId: session.organizationId,
@@ -44,6 +96,7 @@ export const PATCH = withAuth(async (session, req: Request, ctx: Params) => {
     source: "dueno",
     lossReason: body.data.lossReason ?? null,
     lossNote: body.data.lossNote ?? null,
+    extra,
   });
 
   if (!res.ok) {

--- a/src/app/api/pipeline/leads/[id]/route.ts
+++ b/src/app/api/pipeline/leads/[id]/route.ts
@@ -43,6 +43,8 @@ const patchSchema = z.object({
    */
   amountCents: z.number().int().min(0).max(1_000_000_000_00).nullable().optional(),
   currency: z.string().length(3).nullable().optional(),
+  /** `null` explícito la quita; ausente la deja como estaba. */
+  priority: z.enum(["alta", "media", "baja"]).nullable().optional(),
 });
 
 export const PATCH = withAuth(async (session, req: Request, ctx: Params) => {
@@ -62,6 +64,13 @@ export const PATCH = withAuth(async (session, req: Request, ctx: Params) => {
       body.data.amountCents === null
         ? null
         : (body.data.currency ?? (await getBranding(session.organizationId)).currency);
+  }
+
+  if (body.data.priority !== undefined) {
+    extra.priority = body.data.priority;
+    // La fecha acompaña al valor: sirve para saber si la decisión es de hoy o
+    // de hace tres semanas, que es lo que vuelve útil mirarla.
+    extra.priorityUpdatedAt = body.data.priority === null ? null : new Date();
   }
 
   // Sin etapa: solo se actualizan los campos del lead. No pasa por la puerta

--- a/src/app/api/settings/branding/route.ts
+++ b/src/app/api/settings/branding/route.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { apiError, parseBody, withAuth } from "@/lib/api";
 import { getSessionOrNull } from "@/lib/auth/session";
 import { isValidHex, resolveAccentSet } from "@/lib/branding";
+import { CURRENCIES } from "@/lib/money";
 import { getBranding, saveBranding } from "@/server/branding";
 
 export const dynamic = "force-dynamic";
@@ -16,6 +17,8 @@ export async function GET() {
 const putSchema = z.object({
   name: z.string().trim().min(1).max(30),
   accent: z.string().refine(isValidHex, "Color hex inválido (#rrggbb)"),
+  /** La moneda del negocio: la única que el tablero suma. */
+  currency: z.enum(CURRENCIES),
 });
 
 export const PUT = withAuth(async (session, req: Request) => {

--- a/src/components/contacts/contacts-client.tsx
+++ b/src/components/contacts/contacts-client.tsx
@@ -2,7 +2,15 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { Archive, ArchiveRestore, MessageSquareText, Search } from "lucide-react";
+import { useRouter } from "next/navigation";
+import {
+  Archive,
+  ArchiveRestore,
+  MessageSquareText,
+  Search,
+  Send,
+  UserPlus,
+} from "lucide-react";
 import type { ContactDto } from "@/lib/types";
 import { formatPhone } from "@/lib/utils";
 import { ContactAvatar } from "@/components/avatar";
@@ -10,14 +18,20 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { SOURCE_LABELS } from "@/server/contact-source";
+import { NewContactDialog } from "./new-contact-dialog";
+import { StartConversation } from "./start-conversation";
 
 export function ContactsClient() {
+  const router = useRouter();
   const [contacts, setContacts] = useState<ContactDto[]>([]);
   const [query, setQuery] = useState("");
   const [stage, setStage] = useState("all");
   const [stages, setStages] = useState<string[]>([]);
   const [showArchived, setShowArchived] = useState(false);
   const [editing, setEditing] = useState<ContactDto | null>(null);
+  const [creando, setCreando] = useState(false);
+  const [escribiendo, setEscribiendo] = useState<ContactDto | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Mismo rescate que en la Bandeja: lo tecleado antes de que hidrate el JS
@@ -64,7 +78,13 @@ export function ContactsClient() {
   return (
     <div className="flex h-full flex-col">
       <header className="flex flex-wrap items-center justify-between gap-3 border-b px-4 py-3 sm:gap-4 sm:px-6 sm:py-4">
-        <h2 className="font-semibold">Contactos</h2>
+        <div className="flex flex-wrap items-center gap-2">
+          <h2 className="font-semibold">Contactos</h2>
+          <Button size="sm" onClick={() => setCreando(true)}>
+            <UserPlus className="mr-1.5 h-4 w-4" strokeWidth={1.8} />
+            Nuevo contacto
+          </Button>
+        </div>
         <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:gap-3">
           <label className="flex items-center gap-2 text-xs text-muted-foreground">
             <input
@@ -148,6 +168,14 @@ export function ContactsClient() {
                     {c.archivedAt && (
                       <Badge variant="secondary">Archivado</Badge>
                     )}
+                    {/* Solo la fuente que alguien capturó: presentar una
+                        deducción como dato la volvería un número inventado en
+                        cuanto se cuente por fuente. */}
+                    {c.source?.source === "capturada" && (
+                      <Badge variant="secondary">
+                        {SOURCE_LABELS[c.source.value]}
+                      </Badge>
+                    )}
                   </div>
                   <p className="text-xs text-muted-foreground">
                     {formatPhone(c.phone)}
@@ -161,6 +189,17 @@ export function ContactsClient() {
                     onClick={() => setEditing(c)}
                   >
                     Editar
+                  </Button>
+                  {/* A quien nunca escribió hay que abrirle la conversación con
+                      una plantilla: es regla de Meta, no del CRM. */}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Escribir primero"
+                    title="Escribir primero (con plantilla)"
+                    onClick={() => setEscribiendo(c)}
+                  >
+                    <Send className="h-4 w-4" />
                   </Button>
                   <Link href={`/inbox?contact=${c.id}`}>
                     <Button variant="ghost" size="icon" aria-label="Abrir conversación">
@@ -193,6 +232,50 @@ export function ContactsClient() {
           onSave={async (patchBody) => {
             await patch(editing.id, patchBody);
             setEditing(null);
+          }}
+        />
+      )}
+
+      {escribiendo && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Escribir primero"
+        >
+          <div className="w-full max-w-md rounded-lg border bg-card p-4 shadow-pop">
+            <div className="mb-3 flex items-baseline justify-between gap-2">
+              <h3 className="font-semibold">
+                Escribir a {escribiendo.name}
+              </h3>
+              <Button variant="ghost" size="sm" onClick={() => setEscribiendo(null)}>
+                Cerrar
+              </Button>
+            </div>
+            <StartConversation
+              contactId={escribiendo.id}
+              onStarted={() => {
+                const contactId = escribiendo.id;
+                setEscribiendo(null);
+                // La Bandeja resuelve por CONTACTO (`?contact=`), no por
+                // conversación: con `?conversation=` no seleccionaría nada.
+                router.push(`/inbox?contact=${contactId}`);
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {creando && (
+        <NewContactDialog
+          onClose={() => setCreando(false)}
+          onCreated={() => {
+            setCreando(false);
+            void refetch();
+          }}
+          onOpenExisting={(contactId) => {
+            setCreando(false);
+            router.push(`/inbox?contact=${contactId}`);
           }}
         />
       )}

--- a/src/components/contacts/contacts-client.tsx
+++ b/src/components/contacts/contacts-client.tsx
@@ -19,6 +19,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { SOURCE_LABELS } from "@/server/contact-source";
+import { priorityRank } from "@/server/leads/priority";
+import { PriorityBadge } from "@/components/pipeline/priority-picker";
 import { NewContactDialog } from "./new-contact-dialog";
 import { StartConversation } from "./start-conversation";
 
@@ -58,7 +60,14 @@ export function ContactsClient() {
     const res = await fetch(`/api/contacts?${params}`).catch(() => null);
     if (!res?.ok) return;
     const data = (await res.json()) as { contacts: ContactDto[] };
-    setContacts(data.contacts);
+    // A quién llamar primero: alta arriba, sin prioridad al final. El orden lo
+    // decide esta lista, no el servidor, porque es una preferencia de trabajo y
+    // no un dato del contacto.
+    setContacts(
+      [...data.contacts].sort(
+        (a, b) => priorityRank(a.priority ?? null) - priorityRank(b.priority ?? null)
+      )
+    );
   }, [query, stage, showArchived]);
 
   useEffect(() => {
@@ -162,6 +171,7 @@ export function ContactsClient() {
                     <span className="truncate text-sm font-medium">
                       {c.name}
                     </span>
+                    {c.priority && <PriorityBadge value={c.priority} />}
                     {c.stageName && (
                       <Badge variant="outline">{c.stageName}</Badge>
                     )}

--- a/src/components/contacts/new-contact-dialog.tsx
+++ b/src/components/contacts/new-contact-dialog.tsx
@@ -1,0 +1,233 @@
+﻿"use client";
+
+import { useEffect, useState } from "react";
+import type { SourceValue, StageDto } from "@/lib/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+const SOURCES: { value: SourceValue; label: string }[] = [
+  { value: "referido", label: "Referido" },
+  { value: "organico", label: "Contenido orgánico" },
+  { value: "conocido", label: "Conocido" },
+  { value: "anuncio", label: "Anuncio" },
+  { value: "otro", label: "Otro" },
+];
+
+/**
+ * Alta manual de un prospecto que no llegó por WhatsApp.
+ * El teléfono es obligatorio porque ES la identidad en WhatsApp: sin él, el
+ * contacto no podría recibir ni mandar nada, y sería una ficha muerta.
+ */
+export function NewContactDialog({
+  onClose,
+  onCreated,
+  onOpenExisting,
+}: {
+  onClose: () => void;
+  onCreated: () => void;
+  /** Duplicado: en vez de un error seco, se ofrece ir a quien ya existe. */
+  onOpenExisting: (contactId: string) => void;
+}) {
+  const [name, setName] = useState("");
+  const [phone, setPhone] = useState("");
+  const [source, setSource] = useState<SourceValue>("referido");
+  const [notes, setNotes] = useState("");
+  const [stages, setStages] = useState<StageDto[]>([]);
+  const [stageId, setStageId] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [duplicado, setDuplicado] = useState<{ id: string; name: string } | null>(
+    null
+  );
+
+  useEffect(() => {
+    void (async () => {
+      const res = await fetch("/api/pipeline/stages").catch(() => null);
+      if (!res?.ok) return;
+      const data = (await res.json()) as { stages: StageDto[] };
+      const abiertas = data.stages.filter((s) => s.kind === "open");
+      setStages(abiertas);
+      setStageId(abiertas[0]?.id ?? "");
+    })();
+  }, []);
+
+  async function guardar() {
+    setSaving(true);
+    setError(null);
+    setDuplicado(null);
+    const res = await fetch("/api/contacts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: name.trim(),
+        phone: phone.trim(),
+        source,
+        notes: notes.trim() || undefined,
+        stageId: stageId || undefined,
+      }),
+    }).catch(() => null);
+    setSaving(false);
+
+    if (!res) {
+      setError("No se pudo guardar. Revisa tu conexión.");
+      return;
+    }
+    const data = (await res.json().catch(() => null)) as {
+      error?: { message?: string };
+      contact?: { id: string; name: string };
+    } | null;
+
+    if (res.status === 409 && data?.contact) {
+      setDuplicado({ id: data.contact.id, name: data.contact.name });
+      return;
+    }
+    if (!res.ok) {
+      setError(data?.error?.message ?? "No se pudo guardar el contacto");
+      return;
+    }
+    onCreated();
+  }
+
+  // 11 dígitos = código de país + número. Ver la nota del endpoint sobre por
+  // qué el código de país no puede faltar ni asumirse.
+  const listo = name.trim().length > 0 && phone.replace(/\D/g, "").length >= 11;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-label="Nuevo contacto"
+        className="w-full max-w-md rounded-lg border bg-card p-5 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="mb-1 font-semibold">Nuevo contacto</h3>
+        <p className="mb-4 text-xs text-text-3">
+          Para prospectos que no llegaron por WhatsApp: referidos, gente que te
+          escribió por otra red, conocidos.
+        </p>
+
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium" htmlFor="nc-name">
+              Nombre
+            </label>
+            <Input
+              id="nc-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Ferretería La Central"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium" htmlFor="nc-phone">
+              Teléfono con código de país
+            </label>
+            <Input
+              id="nc-phone"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              placeholder="52 462 134 9768"
+            />
+            <p className="text-[11px] text-text-3">
+              Escríbelo con espacios si quieres, pero{" "}
+              <strong>incluye el código de país</strong> (52 para México). Sin
+              él, WhatsApp no lo reconoce como la misma persona que te escriba
+              después.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium" htmlFor="nc-source">
+                ¿De dónde salió?
+              </label>
+              <select
+                id="nc-source"
+                value={source}
+                onChange={(e) => setSource(e.target.value as SourceValue)}
+                className="h-9 w-full rounded-md border border-input bg-card px-2 text-sm"
+              >
+                {SOURCES.map((s) => (
+                  <option key={s.value} value={s.value}>
+                    {s.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium" htmlFor="nc-stage">
+                Etapa inicial
+              </label>
+              <select
+                id="nc-stage"
+                value={stageId}
+                onChange={(e) => setStageId(e.target.value)}
+                className="h-9 w-full rounded-md border border-input bg-card px-2 text-sm"
+              >
+                {stages.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium" htmlFor="nc-notes">
+              Notas (opcional)
+            </label>
+            <Textarea
+              id="nc-notes"
+              rows={3}
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Me lo pasó Juan; tiene taller de motos…"
+            />
+          </div>
+        </div>
+
+        {duplicado && (
+          <div className="mt-3 rounded-md border border-warning-soft bg-warning-tint px-3 py-2.5">
+            <p className="text-[13px] text-warning-text">
+              Ese teléfono ya es de <strong>{duplicado.name}</strong>. No se creó
+              un duplicado.
+            </p>
+            <Button
+              size="sm"
+              variant="secondary"
+              className="mt-2"
+              onClick={() => onOpenExisting(duplicado.id)}
+            >
+              Abrir su conversación
+            </Button>
+          </div>
+        )}
+        {error && <p className="mt-3 text-xs text-danger-text">{error}</p>}
+        {stages.length === 0 && (
+          <p className="mt-3 text-xs text-warning-text">
+            Tu embudo no tiene etapas abiertas. Crea una en el Pipeline antes de
+            capturar contactos.
+          </p>
+        )}
+
+        <div className="mt-4 flex justify-end gap-2">
+          <Button variant="ghost" onClick={onClose}>
+            Cancelar
+          </Button>
+          <Button
+            disabled={!listo || saving || stages.length === 0}
+            onClick={() => void guardar()}
+          >
+            {saving ? "Guardando…" : "Crear contacto"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/contacts/start-conversation.tsx
+++ b/src/components/contacts/start-conversation.tsx
@@ -1,0 +1,149 @@
+﻿"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Send } from "lucide-react";
+import type { TemplateDto } from "@/lib/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+/** Cuenta {{1}}..{{n}} igual que el servidor, para pedir sus valores. */
+function countVariables(body: string): number {
+  const found = new Set(
+    Array.from(body.matchAll(/\{\{\s*(\d+)\s*\}\}/g)).map((m) => m[1])
+  );
+  return found.size;
+}
+
+/**
+ * Abrir conversación con quien nunca ha escrito.
+ *
+ * WhatsApp obliga a usar una plantilla aprobada para escribir primero; no es
+ * una decisión del CRM. Si la ventana de 24 h está abierta, este panel ni se
+ * muestra: gastar una plantilla ahí sería tirar dinero.
+ */
+export function StartConversation({
+  contactId,
+  onStarted,
+}: {
+  contactId: string;
+  onStarted: (conversationId: string) => void;
+}) {
+  const [templates, setTemplates] = useState<TemplateDto[] | null>(null);
+  const [templateId, setTemplateId] = useState("");
+  const [vars, setVars] = useState<string[]>([]);
+  const [enviando, setEnviando] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void (async () => {
+      const res = await fetch("/api/templates").catch(() => null);
+      if (!res?.ok) return setTemplates([]);
+      const data = (await res.json()) as { templates: TemplateDto[] };
+      const aprobadas = data.templates.filter((t) => t.status === "approved");
+      setTemplates(aprobadas);
+      setTemplateId(aprobadas[0]?.id ?? "");
+    })();
+  }, []);
+
+  const elegida = templates?.find((t) => t.id === templateId) ?? null;
+  const nVars = elegida ? countVariables(elegida.body) : 0;
+
+  async function enviar() {
+    setEnviando(true);
+    setError(null);
+    const res = await fetch(`/api/contacts/${contactId}/start-conversation`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        templateId,
+        variables: nVars > 0 ? vars.slice(0, nVars) : undefined,
+      }),
+    }).catch(() => null);
+    setEnviando(false);
+    const data = (await res?.json().catch(() => null)) as
+      | { error?: { message?: string }; conversationId?: string }
+      | null;
+    if (!res?.ok) {
+      // El fallo de Meta se explica aquí mismo (plantilla en pausa, número
+      // que no la recibe…) en vez de perderse.
+      setError(data?.error?.message ?? "No se pudo iniciar la conversación");
+      return;
+    }
+    onStarted(data?.conversationId ?? "");
+  }
+
+  if (templates === null) {
+    return <p className="text-xs text-text-3">Cargando plantillas…</p>;
+  }
+
+  if (templates.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed bg-secondary/30 px-3 py-2.5">
+        <p className="text-[13px]">
+          Esta persona nunca te ha escrito, así que WhatsApp solo permite
+          contactarla con una <strong>plantilla aprobada</strong>, y todavía no
+          tienes ninguna.
+        </p>
+        <Link href="/settings/templates">
+          <Button size="sm" variant="secondary" className="mt-2">
+            Ir a plantillas
+          </Button>
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-text-3">
+        Nunca te ha escrito: para iniciar hay que usar una plantilla aprobada.
+      </p>
+      <select
+        value={templateId}
+        onChange={(e) => {
+          setTemplateId(e.target.value);
+          setVars([]);
+        }}
+        aria-label="Plantilla para iniciar"
+        className="h-9 w-full rounded-md border border-input bg-card px-2 text-sm"
+      >
+        {templates.map((t) => (
+          <option key={t.id} value={t.id}>
+            {t.name} ({t.language})
+          </option>
+        ))}
+      </select>
+
+      {elegida && (
+        <p className="rounded-md border bg-secondary/40 px-3 py-2 text-[12px] text-text-2">
+          {elegida.body}
+        </p>
+      )}
+
+      {Array.from({ length: nVars }, (_, i) => (
+        <Input
+          key={i}
+          value={vars[i] ?? ""}
+          aria-label={`Valor de la variable ${i + 1}`}
+          placeholder={`Valor de {{${i + 1}}}`}
+          onChange={(e) => {
+            const next = [...vars];
+            next[i] = e.target.value;
+            setVars(next);
+          }}
+        />
+      ))}
+
+      <Button
+        size="sm"
+        disabled={enviando || !templateId || vars.slice(0, nVars).some((v) => !v?.trim())}
+        onClick={() => void enviar()}
+      >
+        <Send className="mr-1.5 h-3.5 w-3.5" strokeWidth={1.7} />
+        {enviando ? "Enviando…" : "Iniciar conversación"}
+      </Button>
+      {error && <p className="text-xs text-danger-text">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/inbox/contact-panel.tsx
+++ b/src/components/inbox/contact-panel.tsx
@@ -3,11 +3,17 @@
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { Check, ChevronRight, Sparkles, UserRound } from "lucide-react";
-import type { ConversationDto, StageDto } from "@/lib/types";
+import type {
+  ConversationDto,
+  FichaDto,
+  FichaValue,
+  StageDto,
+} from "@/lib/types";
 import { cn, formatPhone } from "@/lib/utils";
 import { ContactAvatar } from "@/components/avatar";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { FichaPanel } from "./ficha-panel";
 
 const HANDOFF_LABELS: Record<string, string> = {
   cliente: "El cliente pidió un humano",
@@ -33,6 +39,7 @@ export function ContactPanel({
   onClose: () => void;
 }) {
   const [notes, setNotes] = useState("");
+  const [ficha, setFicha] = useState<FichaDto>({});
   const [notesLoaded, setNotesLoaded] = useState(false);
   const [savingNotes, setSavingNotes] = useState(false);
   const [stages, setStages] = useState<StageDto[]>([]);
@@ -60,6 +67,7 @@ export function ContactPanel({
     ]).catch(() => [null, null, null]);
     if (detail) {
       setNotes(detail.contact?.notes ?? "");
+      setFicha(detail.contact?.ficha ?? {});
       setCurrentStageId(detail.stage?.id ?? null);
       setLeadId(detail.lead?.id ?? null);
     }
@@ -77,6 +85,10 @@ export function ContactPanel({
       fetch("/api/agent/profile").then((r) => (r.ok ? r.json() : null)),
     ]).catch(() => [null, null]);
     if (detail) {
+      // La ficha SÍ se refresca en vivo: el agente la va llenando mientras la
+      // conversación ocurre, y verla aparecer sola es justo para lo que sirve.
+      // No pisa una edición a medias — el borrador vive dentro del panel.
+      setFicha(detail.contact?.ficha ?? {});
       setCurrentStageId(detail.stage?.id ?? null);
       setLeadId(detail.lead?.id ?? null);
     }
@@ -103,6 +115,24 @@ export function ContactPanel({
       method: "PATCH",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ stageId, position: 0 }),
+    }).catch(() => null);
+    void refreshLive();
+  }
+
+  /** Manda SOLO lo que cambió: el servidor hace merge (ver `server/bot/ficha`). */
+  async function saveFicha(patch: Record<string, FichaValue | null>) {
+    setFicha((prev) => {
+      const next = { ...prev };
+      for (const [k, v] of Object.entries(patch)) {
+        if (v === null) delete next[k];
+        else next[k] = v;
+      }
+      return next; // optimista: el refetch de abajo confirma
+    });
+    await fetch(`/api/contacts/${contactId}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ficha: patch }),
     }).catch(() => null);
     void refreshLive();
   }
@@ -281,6 +311,10 @@ export function ContactPanel({
             </ol>
           </section>
         )}
+
+        {/* Ficha: lo que se SABE del lead. Va antes de Notas —lo que alguien
+            OPINA— porque es lo que se consulta a mitad de una conversación. */}
+        <FichaPanel ficha={ficha} onSave={saveFicha} />
 
         {/* Notas */}
         <section className="p-4">

--- a/src/components/inbox/ficha-panel.tsx
+++ b/src/components/inbox/ficha-panel.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Pencil, Plus, Trash2, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { fichaEntries, fichaLabel, fichaValueText, parseFichaValue } from "@/lib/ficha";
+import type { FichaDto, FichaValue } from "@/lib/types";
+
+/**
+ * Lo que se sabe del lead, donde se trabaja la conversación.
+ *
+ * Existe porque `PUT /api/bot/ficha` ya deja al agente guardar lo que
+ * averigua: sin esta pantalla, eso era un cajón que se llenaba y no se abría.
+ *
+ * Se puede corregir a mano. Un dato equivocado que el dueño ve pero no puede
+ * arreglar es peor que no tenerlo: enseña a desconfiar de toda la ficha.
+ */
+export function FichaPanel({
+  ficha,
+  onSave,
+}: {
+  ficha: FichaDto;
+  /** Parche: solo lo que cambia. `null` borra la clave. */
+  onSave: (patch: Record<string, FichaValue | null>) => Promise<void>;
+}) {
+  const [editando, setEditando] = useState<string | null>(null);
+  const [borrador, setBorrador] = useState("");
+  const [agregando, setAgregando] = useState(false);
+  const [claveNueva, setClaveNueva] = useState("");
+  const [valorNuevo, setValorNuevo] = useState("");
+  const [guardando, setGuardando] = useState(false);
+
+  const entradas = fichaEntries(ficha);
+
+  async function guardar(patch: Record<string, FichaValue | null>) {
+    setGuardando(true);
+    try {
+      await onSave(patch);
+    } finally {
+      setGuardando(false);
+    }
+  }
+
+  async function confirmarEdicion(clave: string) {
+    const valor = parseFichaValue(borrador, ficha[clave]);
+    setEditando(null);
+    // Vacío no borra: para eso está el bote de basura. Un campo que se vacía
+    // solo, porque alguien seleccionó y salió, se lleva un dato que costó una
+    // conversación.
+    if (valor === "" || valor === ficha[clave]) return;
+    await guardar({ [clave]: valor });
+  }
+
+  async function agregar() {
+    const clave = claveNueva.trim();
+    const valor = valorNuevo.trim();
+    if (!clave || !valor) return;
+    setAgregando(false);
+    setClaveNueva("");
+    setValorNuevo("");
+    await guardar({ [clave]: valor });
+  }
+
+  return (
+    <section className="border-b p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <p className="text-[11px] font-semibold uppercase tracking-wide text-text-3">
+          Ficha
+        </p>
+        {!agregando && (
+          <button
+            onClick={() => setAgregando(true)}
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-text-3 hover:bg-accent hover:text-foreground"
+          >
+            <Plus className="h-3 w-3" />
+            Agregar
+          </button>
+        )}
+      </div>
+
+      {entradas.length === 0 && !agregando && (
+        <p className="text-xs leading-relaxed text-text-3">
+          Todavía vacía. Aquí aparece lo que tu agente va averiguando del lead
+          mientras conversa — y puedes escribirlo tú.
+        </p>
+      )}
+
+      {entradas.length > 0 && (
+        <dl className="space-y-1.5">
+          {entradas.map(([clave, valor]) => (
+            <div key={clave} className="group flex items-start gap-2 text-xs">
+              <dt className="w-[38%] shrink-0 pt-1 text-text-3">
+                {fichaLabel(clave)}
+              </dt>
+              <dd className="flex min-w-0 flex-1 items-start gap-1">
+                {editando === clave ? (
+                  <>
+                    <Input
+                      autoFocus
+                      value={borrador}
+                      onChange={(e) => setBorrador(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") void confirmarEdicion(clave);
+                        if (e.key === "Escape") setEditando(null);
+                      }}
+                      className="h-7 py-0 text-xs"
+                      aria-label={`Valor de ${fichaLabel(clave)}`}
+                    />
+                    <button
+                      onClick={() => void confirmarEdicion(clave)}
+                      aria-label="Guardar"
+                      className="rounded p-1 text-text-3 hover:bg-accent hover:text-foreground"
+                    >
+                      <Check className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      onClick={() => setEditando(null)}
+                      aria-label="Cancelar"
+                      className="rounded p-1 text-text-3 hover:bg-accent hover:text-foreground"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <button
+                      onClick={() => {
+                        setEditando(clave);
+                        setBorrador(fichaValueText(valor));
+                      }}
+                      className="min-w-0 flex-1 break-words rounded px-1 py-1 text-left hover:bg-accent"
+                      aria-label={`Editar ${fichaLabel(clave)}`}
+                    >
+                      {fichaValueText(valor)}
+                    </button>
+                    <span className="flex opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+                      <button
+                        onClick={() => setEditando(clave)}
+                        aria-label={`Editar ${fichaLabel(clave)}`}
+                        className="rounded p-1 text-text-3 hover:bg-accent hover:text-foreground"
+                      >
+                        <Pencil className="h-3 w-3" />
+                      </button>
+                      <button
+                        disabled={guardando}
+                        onClick={() => void guardar({ [clave]: null })}
+                        aria-label={`Quitar ${fichaLabel(clave)}`}
+                        className="rounded p-1 text-text-3 hover:bg-accent hover:text-danger"
+                      >
+                        <Trash2 className="h-3 w-3" />
+                      </button>
+                    </span>
+                  </>
+                )}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+
+      {agregando && (
+        <div className="mt-2 space-y-1.5">
+          <Input
+            autoFocus
+            value={claveNueva}
+            onChange={(e) => setClaveNueva(e.target.value)}
+            placeholder="Qué dato (ej. presupuesto)"
+            className="h-7 py-0 text-xs"
+            aria-label="Nombre del dato"
+          />
+          <Input
+            value={valorNuevo}
+            onChange={(e) => setValorNuevo(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void agregar();
+              if (e.key === "Escape") setAgregando(false);
+            }}
+            placeholder="Valor"
+            className="h-7 py-0 text-xs"
+            aria-label="Valor del dato"
+          />
+          <div className="flex gap-1.5">
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={!claveNueva.trim() || !valorNuevo.trim() || guardando}
+              onClick={() => void agregar()}
+            >
+              Agregar
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                setAgregando(false);
+                setClaveNueva("");
+                setValorNuevo("");
+              }}
+            >
+              Cancelar
+            </Button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/pipeline/amount-dialog.tsx
+++ b/src/components/pipeline/amount-dialog.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import { formatMoneyCents, parseMoneyToCents } from "@/lib/money";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+/**
+ * Captura del monto de la negociación.
+ *
+ * Acepta lo que el dueño escriba —"12,500", "$12 500.50"— porque nadie teclea
+ * centavos, y guarda centavos enteros. Vacío BORRA el monto: un trato sin
+ * número no vale cero, simplemente no se sabe, y esa diferencia se nota en el
+ * total de la columna.
+ */
+export function AmountDialog({
+  leadName,
+  currency,
+  amountCents,
+  onCancel,
+  onSave,
+}: {
+  leadName: string;
+  currency: string;
+  amountCents: number | null;
+  onCancel: () => void;
+  onSave: (cents: number | null) => void;
+}) {
+  const [texto, setTexto] = useState(
+    amountCents === null ? "" : (amountCents / 100).toFixed(2)
+  );
+  const parsed = texto.trim() ? parseMoneyToCents(texto) : null;
+  const invalido = texto.trim().length > 0 && parsed === null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Monto de la negociación"
+    >
+      <div className="w-full max-w-sm rounded-lg border bg-card p-4 shadow-pop">
+        <h3 className="font-semibold">Monto de la negociación</h3>
+        <p className="mt-0.5 text-xs text-text-3">{leadName}</p>
+
+        <label className="mt-3 block text-xs font-medium" htmlFor="monto">
+          Cuánto vale este trato ({currency})
+        </label>
+        <Input
+          id="monto"
+          value={texto}
+          inputMode="decimal"
+          autoFocus
+          onChange={(e) => setTexto(e.target.value)}
+          placeholder="12,500.00"
+          className="mt-1"
+        />
+        {invalido ? (
+          <p className="mt-1 text-xs text-danger-text">
+            No reconozco ese número. Escríbelo como 12500 o 12,500.00
+          </p>
+        ) : (
+          <p className="mt-1 text-xs text-text-3">
+            {parsed === null
+              ? "Déjalo vacío para quitar el monto."
+              : `Se guardará como ${formatMoneyCents(parsed, currency)}`}
+          </p>
+        )}
+
+        <div className="mt-4 flex justify-end gap-2">
+          <Button variant="ghost" onClick={onCancel}>
+            Cancelar
+          </Button>
+          <Button disabled={invalido} onClick={() => onSave(parsed)}>
+            Guardar
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pipeline/amount-dialog.tsx
+++ b/src/components/pipeline/amount-dialog.tsx
@@ -4,9 +4,12 @@ import { useState } from "react";
 import { formatMoneyCents, parseMoneyToCents } from "@/lib/money";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { PriorityPicker } from "./priority-picker";
+import type { PriorityValue } from "@/lib/types";
 
 /**
- * Captura del monto de la negociación.
+ * Monto y prioridad de un trato: los dos datos que el dueño ajusta desde el
+ * tablero sin abrir nada más.
  *
  * Acepta lo que el dueño escriba —"12,500", "$12 500.50"— porque nadie teclea
  * centavos, y guarda centavos enteros. Vacío BORRA el monto: un trato sin
@@ -17,12 +20,17 @@ export function AmountDialog({
   leadName,
   currency,
   amountCents,
+  priority,
+  onPriorityChange,
   onCancel,
   onSave,
 }: {
   leadName: string;
   currency: string;
   amountCents: number | null;
+  priority: PriorityValue | null;
+  /** Se guarda al instante: es un clic, no un formulario. */
+  onPriorityChange: (value: PriorityValue | null) => void;
   onCancel: () => void;
   onSave: (cents: number | null) => void;
 }) {
@@ -37,10 +45,10 @@ export function AmountDialog({
       className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4"
       role="dialog"
       aria-modal="true"
-      aria-label="Monto de la negociación"
+      aria-label="Monto y prioridad"
     >
       <div className="w-full max-w-sm rounded-lg border bg-card p-4 shadow-pop">
-        <h3 className="font-semibold">Monto de la negociación</h3>
+        <h3 className="font-semibold">Monto y prioridad</h3>
         <p className="mt-0.5 text-xs text-text-3">{leadName}</p>
 
         <label className="mt-3 block text-xs font-medium" htmlFor="monto">
@@ -66,6 +74,13 @@ export function AmountDialog({
               : `Se guardará como ${formatMoneyCents(parsed, currency)}`}
           </p>
         )}
+
+        <div className="mt-4">
+          <p className="text-xs font-medium">Prioridad</p>
+          <div className="mt-1.5">
+            <PriorityPicker value={priority} onChange={onPriorityChange} />
+          </div>
+        </div>
 
         <div className="mt-4 flex justify-end gap-2">
           <Button variant="ghost" onClick={onCancel}>

--- a/src/components/pipeline/pipeline-client.tsx
+++ b/src/components/pipeline/pipeline-client.tsx
@@ -15,12 +15,14 @@ import {
 } from "@dnd-kit/core";
 import { MessageSquareText, Settings2, Trophy, XCircle } from "lucide-react";
 import type { LossReason, StageDto } from "@/lib/types";
+import { formatMoneyCents, sumable } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import { ContactAvatar } from "@/components/avatar";
 import { Button } from "@/components/ui/button";
 import { formatTime } from "@/components/inbox/helpers";
 import { StageManager } from "./stage-manager";
 import { LossReasonDialog } from "./loss-reason-dialog";
+import { AmountDialog } from "./amount-dialog";
 
 export type BoardLead = {
   id: string;
@@ -29,10 +31,13 @@ export type BoardLead = {
   lastActivityAt: string | null;
   contact: { id: string; name: string; phone: string | null };
   conversationId: string | null;
+  amountCents: number | null;
+  currency: string | null;
 };
 
 export function PipelineClient() {
   const [stages, setStages] = useState<StageDto[]>([]);
+  const [currency, setCurrency] = useState("MXN");
   const [leads, setLeads] = useState<BoardLead[]>([]);
   const [activeLead, setActiveLead] = useState<BoardLead | null>(null);
   const [managing, setManaging] = useState(false);
@@ -42,6 +47,8 @@ export function PipelineClient() {
     stageId: string;
     name: string;
   } | null>(null);
+  /** Tarjeta cuyo monto se está capturando. */
+  const [editandoMonto, setEditandoMonto] = useState<BoardLead | null>(null);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } })
@@ -50,7 +57,12 @@ export function PipelineClient() {
   const refetch = useCallback(async () => {
     const res = await fetch("/api/pipeline/board").catch(() => null);
     if (!res?.ok) return;
-    const data = (await res.json()) as { stages: StageDto[]; leads: BoardLead[] };
+    const data = (await res.json()) as {
+      stages: StageDto[];
+      leads: BoardLead[];
+      currency?: string;
+    };
+    if (data.currency) setCurrency(data.currency);
     setStages(data.stages);
     setLeads(data.leads);
   }, []);
@@ -84,6 +96,19 @@ export function PipelineClient() {
           ? { lossReason: loss.reason, ...(loss.note ? { lossNote: loss.note } : {}) }
           : {}),
       }),
+    }).catch(() => null);
+    void refetch();
+  }
+
+  async function guardarMonto(leadId: string, cents: number | null) {
+    setLeads((prev) =>
+      prev.map((l) => (l.id === leadId ? { ...l, amountCents: cents } : l))
+    );
+    await fetch(`/api/pipeline/leads/${leadId}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      // Sin `stageId`: esto NO mueve la tarjeta, solo escribe el importe.
+      body: JSON.stringify({ amountCents: cents }),
     }).catch(() => null);
     void refetch();
   }
@@ -129,6 +154,8 @@ export function PipelineClient() {
               <StageColumn
                 key={stage.id}
                 stage={stage}
+                currency={currency}
+                onEditAmount={setEditandoMonto}
                 leads={leads
                   .filter((l) => l.stageId === stage.id)
                   .sort((a, b) => a.position - b.position)}
@@ -136,7 +163,9 @@ export function PipelineClient() {
             ))}
           </div>
           <DragOverlay>
-            {activeLead ? <LeadCard lead={activeLead} overlay /> : null}
+            {activeLead ? (
+              <LeadCard lead={activeLead} currency={currency} overlay />
+            ) : null}
           </DragOverlay>
         </DndContext>
       </div>
@@ -146,6 +175,20 @@ export function PipelineClient() {
           stages={stages}
           onClose={() => setManaging(false)}
           onChanged={() => void refetch()}
+        />
+      )}
+
+      {editandoMonto && (
+        <AmountDialog
+          leadName={editandoMonto.contact.name}
+          currency={editandoMonto.currency ?? currency}
+          amountCents={editandoMonto.amountCents}
+          onCancel={() => setEditandoMonto(null)}
+          onSave={(cents) => {
+            const leadId = editandoMonto.id;
+            setEditandoMonto(null);
+            void guardarMonto(leadId, cents);
+          }}
         />
       )}
 
@@ -164,7 +207,41 @@ export function PipelineClient() {
   );
 }
 
-function StageColumn({ stage, leads }: { stage: StageDto; leads: BoardLead[] }) {
+/**
+ * Totales de una columna. Se calculan al pintar: un total guardado se
+ * desincroniza en cuanto alguien mueve una tarjeta, y sumar unas decenas es
+ * gratis. Todo en CENTAVOS enteros — el dinero jamás pasa por coma flotante.
+ */
+function totalesDeEtapa(leads: BoardLead[], businessCurrency: string) {
+  let totalCents = 0;
+  let sinMonto = 0;
+  let otraMoneda = 0;
+
+  for (const l of leads) {
+    if (l.amountCents === null) {
+      sinMonto++;
+      continue;
+    }
+    if (!sumable({ amountCents: l.amountCents, currency: l.currency }, businessCurrency)) {
+      otraMoneda++;
+      continue;
+    }
+    totalCents += l.amountCents;
+  }
+  return { totalCents, sinMonto, otraMoneda };
+}
+
+function StageColumn({
+  stage,
+  leads,
+  currency,
+  onEditAmount,
+}: {
+  stage: StageDto;
+  leads: BoardLead[];
+  currency: string;
+  onEditAmount: (lead: BoardLead) => void;
+}) {
   const { setNodeRef, isOver } = useDroppable({ id: stage.id });
   return (
     <div
@@ -188,14 +265,59 @@ function StageColumn({ stage, leads }: { stage: StageDto; leads: BoardLead[] }) 
       </div>
       <div className="flex-1 space-y-2 overflow-y-auto p-2">
         {leads.map((lead) => (
-          <DraggableLead key={lead.id} lead={lead} />
+          <DraggableLead
+            key={lead.id}
+            lead={lead}
+            currency={currency}
+            onEditAmount={onEditAmount}
+          />
         ))}
       </div>
+      <StageFooter leads={leads} currency={currency} />
     </div>
   );
 }
 
-function DraggableLead({ lead }: { lead: BoardLead }) {
+/** Cuánto dinero hay en esta etapa, y qué quedó fuera de la cuenta. */
+function StageFooter({ leads, currency }: { leads: BoardLead[]; currency: string }) {
+  const { totalCents, sinMonto, otraMoneda } = totalesDeEtapa(leads, currency);
+  const conMonto = leads.length - sinMonto - otraMoneda;
+
+  return (
+    <div className="border-t px-3 py-2 text-[11px]">
+      {conMonto === 0 ? (
+        // Un "$0.00" aquí se lee como un error del sistema, no como un dato.
+        <p className="text-muted-foreground">Sin montos capturados</p>
+      ) : (
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="text-muted-foreground">
+            Total{sinMonto > 0 ? ` · ${sinMonto} sin monto` : ""}
+          </span>
+          <span className="font-semibold tabular-nums">
+            {formatMoneyCents(totalCents, currency)}
+          </span>
+        </div>
+      )}
+      {otraMoneda > 0 && (
+        // Descartarlos en silencio haría que el total mintiera sin que nadie
+        // pudiera notarlo.
+        <p className="mt-0.5 text-warning-text">
+          {otraMoneda} en otra moneda, fuera del total
+        </p>
+      )}
+    </div>
+  );
+}
+
+function DraggableLead({
+  lead,
+  currency,
+  onEditAmount,
+}: {
+  lead: BoardLead;
+  currency: string;
+  onEditAmount: (lead: BoardLead) => void;
+}) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: lead.id,
   });
@@ -206,12 +328,22 @@ function DraggableLead({ lead }: { lead: BoardLead }) {
       {...attributes}
       className={cn(isDragging && "opacity-40")}
     >
-      <LeadCard lead={lead} />
+      <LeadCard lead={lead} currency={currency} onEditAmount={onEditAmount} />
     </div>
   );
 }
 
-function LeadCard({ lead, overlay = false }: { lead: BoardLead; overlay?: boolean }) {
+function LeadCard({
+  lead,
+  currency,
+  overlay = false,
+  onEditAmount,
+}: {
+  lead: BoardLead;
+  currency: string;
+  overlay?: boolean;
+  onEditAmount?: (lead: BoardLead) => void;
+}) {
   return (
     <div
       className={cn(
@@ -240,6 +372,29 @@ function LeadCard({ lead, overlay = false }: { lead: BoardLead; overlay?: boolea
           </Link>
         )}
       </div>
+      {!overlay && onEditAmount && (
+        <button
+          // `stopPropagation` en pointerdown: sin esto, tocar el monto empieza
+          // un arrastre y el diálogo nunca abre.
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={() => onEditAmount(lead)}
+          className={cn(
+            "mt-1.5 w-full rounded px-1 py-0.5 text-right text-xs tabular-nums hover:bg-accent",
+            lead.amountCents === null
+              ? "text-text-3"
+              : "font-semibold text-foreground"
+          )}
+        >
+          {lead.amountCents === null
+            ? "+ monto"
+            : formatMoneyCents(lead.amountCents, lead.currency ?? currency)}
+        </button>
+      )}
+      {overlay && lead.amountCents !== null && (
+        <p className="mt-1.5 text-right text-xs font-semibold tabular-nums">
+          {formatMoneyCents(lead.amountCents, lead.currency ?? currency)}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/pipeline/pipeline-client.tsx
+++ b/src/components/pipeline/pipeline-client.tsx
@@ -14,7 +14,7 @@ import {
   type DragStartEvent,
 } from "@dnd-kit/core";
 import { MessageSquareText, Settings2, Trophy, XCircle } from "lucide-react";
-import type { LossReason, StageDto } from "@/lib/types";
+import type { LossReason, PriorityValue, StageDto } from "@/lib/types";
 import { formatMoneyCents, sumable } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import { ContactAvatar } from "@/components/avatar";
@@ -23,6 +23,7 @@ import { formatTime } from "@/components/inbox/helpers";
 import { StageManager } from "./stage-manager";
 import { LossReasonDialog } from "./loss-reason-dialog";
 import { AmountDialog } from "./amount-dialog";
+import { PriorityBadge } from "./priority-picker";
 
 export type BoardLead = {
   id: string;
@@ -33,6 +34,7 @@ export type BoardLead = {
   conversationId: string | null;
   amountCents: number | null;
   currency: string | null;
+  priority: PriorityValue | null;
 };
 
 export function PipelineClient() {
@@ -113,6 +115,18 @@ export function PipelineClient() {
     void refetch();
   }
 
+  async function guardarPrioridad(leadId: string, priority: PriorityValue | null) {
+    setLeads((prev) =>
+      prev.map((l) => (l.id === leadId ? { ...l, priority } : l))
+    );
+    await fetch(`/api/pipeline/leads/${leadId}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ priority }),
+    }).catch(() => null);
+    void refetch();
+  }
+
   async function onDragEnd(event: DragEndEvent) {
     setActiveLead(null);
     const leadId = String(event.active.id);
@@ -183,6 +197,11 @@ export function PipelineClient() {
           leadName={editandoMonto.contact.name}
           currency={editandoMonto.currency ?? currency}
           amountCents={editandoMonto.amountCents}
+          priority={editandoMonto.priority}
+          onPriorityChange={(p) => {
+            setEditandoMonto({ ...editandoMonto, priority: p });
+            void guardarPrioridad(editandoMonto.id, p);
+          }}
           onCancel={() => setEditandoMonto(null)}
           onSave={(cents) => {
             const leadId = editandoMonto.id;
@@ -354,7 +373,10 @@ function LeadCard({
       <div className="flex items-center gap-2.5">
         <ContactAvatar name={lead.contact.name} seed={lead.contact.id} size="sm" />
         <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-medium">{lead.contact.name}</p>
+          <div className="flex items-center gap-1.5">
+            <p className="truncate text-sm font-medium">{lead.contact.name}</p>
+            {lead.priority && <PriorityBadge value={lead.priority} />}
+          </div>
           <p className="text-[11px] text-muted-foreground">
             {lead.lastActivityAt
               ? `Actividad: ${formatTime(lead.lastActivityAt)}`

--- a/src/components/pipeline/priority-picker.tsx
+++ b/src/components/pipeline/priority-picker.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { PriorityValue } from "@/lib/types";
+import { PRIORITY_LABELS, PRIORITY_VALUES } from "@/server/leads/priority";
+
+const TONO: Record<PriorityValue, string> = {
+  alta: "border-danger-soft bg-danger-tint text-danger-text",
+  media: "border-warning-soft bg-warning-tint text-warning-text",
+  baja: "border-border bg-secondary text-text-2",
+};
+
+/** Etiqueta de prioridad. Solo se pinta cuando alguien la fijó. */
+export function PriorityBadge({ value }: { value: PriorityValue }) {
+  return (
+    <span
+      className={cn(
+        "rounded-full border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+        TONO[value]
+      )}
+    >
+      {PRIORITY_LABELS[value]}
+    </span>
+  );
+}
+
+/**
+ * Elegir la prioridad de un lead. Incluye "Sin prioridad" a propósito: poder
+ * QUITARLA importa tanto como ponerla — si no, el primer clic por error queda
+ * para siempre y el dueño deja de confiar en la columna.
+ */
+export function PriorityPicker({
+  value,
+  onChange,
+}: {
+  value: PriorityValue | null;
+  onChange: (value: PriorityValue | null) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {PRIORITY_VALUES.map((p) => (
+        <button
+          key={p}
+          onClick={() => onChange(p)}
+          aria-pressed={value === p}
+          className={cn(
+            "rounded-full border px-2.5 py-1 text-xs transition-colors",
+            value === p ? TONO[p] : "text-text-2 hover:bg-accent"
+          )}
+        >
+          {PRIORITY_LABELS[p]}
+        </button>
+      ))}
+      <button
+        onClick={() => onChange(null)}
+        aria-pressed={value === null}
+        className={cn(
+          "rounded-full border px-2.5 py-1 text-xs transition-colors",
+          value === null
+            ? "border-border bg-secondary text-text-2"
+            : "text-text-3 hover:bg-accent"
+        )}
+      >
+        Sin prioridad
+      </button>
+    </div>
+  );
+}

--- a/src/components/settings/branding-client.tsx
+++ b/src/components/settings/branding-client.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ACCENT_PRESETS, isValidHex, resolveAccentSet, type Branding } from "@/lib/branding";
+import { CURRENCIES, DEFAULT_CURRENCY, type Currency } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import { useResolvedTheme } from "@/components/use-theme";
 import { Button } from "@/components/ui/button";
@@ -15,6 +16,7 @@ export function BrandingClient() {
   const mode = useResolvedTheme();
   const [name, setName] = useState("");
   const [accent, setAccent] = useState("#3f5972");
+  const [currency, setCurrency] = useState<Currency>(DEFAULT_CURRENCY);
   const [loaded, setLoaded] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -27,6 +29,7 @@ export function BrandingClient() {
         if (d) {
           setName(d.branding.name);
           setAccent(d.branding.accent);
+          if (d.branding.currency) setCurrency(d.branding.currency);
         }
         setLoaded(true);
       })
@@ -45,7 +48,7 @@ export function BrandingClient() {
     const res = await fetch("/api/settings/branding", {
       method: "PUT",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ name: name.trim(), accent }),
+      body: JSON.stringify({ name: name.trim(), accent, currency }),
     }).catch(() => null);
     setSaving(false);
     if (!res?.ok) {
@@ -83,6 +86,26 @@ export function BrandingClient() {
               placeholder="Vocero"
               className="max-w-xs"
             />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="brand-currency">Moneda del negocio</Label>
+            <select
+              id="brand-currency"
+              value={currency}
+              onChange={(e) => setCurrency(e.target.value as Currency)}
+              className="h-9 max-w-xs rounded-md border border-input bg-card px-2 text-sm"
+            >
+              {CURRENCIES.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-text-3">
+              Es la única que el Pipeline suma. Los montos capturados en otra
+              moneda se muestran, pero quedan fuera del total de su columna.
+            </p>
           </div>
 
           <div className="space-y-2">

--- a/src/lib/branding.ts
+++ b/src/lib/branding.ts
@@ -1,5 +1,7 @@
+import { DEFAULT_CURRENCY, isCurrency, type Currency } from "@/lib/money";
+
 /**
- * White-label: nombre del CRM + acento por organización.
+ * White-label: nombre del CRM, acento y moneda por organización.
  * Presets sobrios del sistema Atlas; para un color personalizado se derivan
  * hover/soft/tint/text y se garantiza contraste con texto blanco.
  */
@@ -20,9 +22,15 @@ export type ThemeMode = "light" | "dark";
 export type Branding = {
   name: string;
   accent: string; // hex del acento base elegido
+  /** Moneda del negocio: la única que el tablero suma. */
+  currency: Currency;
 };
 
-export const DEFAULT_BRANDING: Branding = { name: "Vocero", accent: "#3f5972" };
+export const DEFAULT_BRANDING: Branding = {
+  name: "Vocero",
+  accent: "#3f5972",
+  currency: DEFAULT_CURRENCY,
+};
 
 /** Presets del handoff (valores exactos). */
 export const ACCENT_PRESETS: Record<string, { label: string; set: AccentSet }> = {
@@ -178,5 +186,8 @@ export function normalizeBranding(input: Partial<Branding> | null): Branding {
     input?.accent && isValidHex(input.accent)
       ? input.accent.toLowerCase()
       : DEFAULT_BRANDING.accent;
-  return { name, accent };
+  const currency = isCurrency(input?.currency)
+    ? input.currency
+    : DEFAULT_BRANDING.currency;
+  return { name, accent, currency };
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -183,6 +183,14 @@ export const lead = pgTable(
       .notNull()
       .references(() => pipelineStage.id),
     position: integer("position").notNull().default(0),
+    /**
+     * Monto de la negociación en CENTAVOS ENTEROS. NULL = nadie lo capturó, que
+     * no es lo mismo que cero: un trato sin monto no vale $0, simplemente no se
+     * sabe, y el tablero lo dice con palabras en vez de sumar un cero.
+     */
+    amountCents: integer("amount_cents"),
+    /** Moneda del monto; la del negocio al capturarlo (Ajustes → Marca). */
+    currency: text("currency"),
     lastActivityAt: timestamp("last_activity_at"),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -132,6 +132,14 @@ export const contact = pgTable(
      * Merge campo a campo; `null` explícito borra la clave.
      */
     ficha: jsonb("ficha").$type<Record<string, unknown>>(),
+    /**
+     * De dónde salió el prospecto. NULL = nadie la capturó, y entonces la API
+     * la deduce. Así no hace falta backfill ni marcar en falso los contactos
+     * que ya existían.
+     */
+    source: text("source", {
+      enum: ["anuncio", "organico", "referido", "conocido", "otro"],
+    }),
     archivedAt: timestamp("archived_at"),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -191,6 +191,13 @@ export const lead = pgTable(
     amountCents: integer("amount_cents"),
     /** Moneda del monto; la del negocio al capturarlo (Ajustes → Marca). */
     currency: text("currency"),
+    /**
+     * Prioridad de cierre. NULL = nadie la ha decidido, que NO es lo mismo que
+     * "media": nada la escribe automáticamente, así que el dueño puede confiar
+     * en que lo que ve es lo que él puso.
+     */
+    priority: text("priority", { enum: ["alta", "media", "baja"] }),
+    priorityUpdatedAt: timestamp("priority_updated_at"),
     lastActivityAt: timestamp("last_activity_at"),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),

--- a/src/lib/ficha.ts
+++ b/src/lib/ficha.ts
@@ -1,0 +1,63 @@
+import type { FichaDto, FichaValue } from "./types";
+
+/**
+ * Presentación de la ficha del lead.
+ *
+ * Las claves las inventa quien califica —un bot, o el dueño escribiendo—, así
+ * que llegan como `dolor_principal`, `dolorPrincipal` o `dolor-principal`. Aquí
+ * se leen bonito SIN tocar lo guardado: renombrar la clave rompería al agente,
+ * que la busca por su nombre exacto.
+ */
+
+/** `dolor_principal` → `Dolor principal`. No modifica el dato, solo cómo se ve. */
+export function fichaLabel(key: string): string {
+  const palabras = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim()
+    .toLowerCase();
+  if (!palabras) return key;
+  return palabras.charAt(0).toUpperCase() + palabras.slice(1);
+}
+
+/** Cómo se muestra un valor. Los booleanos en Sí/No: nadie califica en `true`. */
+export function fichaValueText(value: FichaValue): string {
+  if (typeof value === "boolean") return value ? "Sí" : "No";
+  if (typeof value === "number") return String(value);
+  return value ?? "";
+}
+
+const SI = new Set(["si", "sí", "true", "1"]);
+const NO = new Set(["no", "false", "0"]);
+
+/**
+ * Lo que el dueño teclea, de vuelta a un valor guardable.
+ *
+ * Regla: **editar no cambia el tipo del dato** salvo que lo escrito ya no sea
+ * de ese tipo. Si el agente guardó `presupuesto: 50000` (número) y el dueño
+ * corrige a "60000", se guarda 60000 y no "60000" — porque del otro lado hay
+ * un bot que puede estar comparando, y convertir en silencio un número a texto
+ * es de esos cambios que solo se descubren cuando algo ya falló.
+ */
+export function parseFichaValue(
+  text: string,
+  previous: FichaValue | undefined
+): FichaValue {
+  const t = text.trim();
+  if (typeof previous === "boolean") {
+    if (SI.has(t.toLowerCase())) return true;
+    if (NO.has(t.toLowerCase())) return false;
+    return t;
+  }
+  if (typeof previous === "number") {
+    const n = Number(t);
+    if (t !== "" && Number.isFinite(n)) return n;
+    return t;
+  }
+  return t;
+}
+
+/** Claves ordenadas para que la ficha no baile de posición entre recargas. */
+export function fichaEntries(ficha: FichaDto): [string, FichaValue][] {
+  return Object.entries(ficha).sort(([a], [b]) => a.localeCompare(b, "es"));
+}

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -1,0 +1,94 @@
+/**
+ * Dinero. Vive en `lib/` (no en `server/`) porque el tablero suma sus columnas
+ * en el cliente y no puede arrastrar la BD al bundle.
+ *
+ * Todo en CENTAVOS ENTEROS, también en el cálculo: sumar pesos en coma flotante
+ * da totales que el dueño no puede cuadrar contra sus propias tarjetas.
+ *
+ * La moneda NO está cableada. Cada instancia elige la suya en Ajustes → Marca,
+ * y todas las funciones la reciben explícitamente: un default global escondido
+ * haría que una instalación fuera de su país sumara mal sin avisar.
+ */
+
+/** Monedas ISO-4217 razonables para un CRM de WhatsApp hispanohablante. */
+export const CURRENCIES = [
+  "MXN",
+  "USD",
+  "EUR",
+  "COP",
+  "ARS",
+  "CLP",
+  "PEN",
+  "GTQ",
+  "DOP",
+  "BRL",
+] as const;
+
+export type Currency = (typeof CURRENCIES)[number];
+
+export const DEFAULT_CURRENCY: Currency = "MXN";
+
+export function isCurrency(v: unknown): v is Currency {
+  return typeof v === "string" && (CURRENCIES as readonly string[]).includes(v);
+}
+
+/**
+ * ¿Este monto entra en el total de su columna? Solo suma lo que está en la
+ * moneda del negocio: convertir exigiría un tipo de cambio, y un CRM que
+ * inventa tipos de cambio miente. Lo que queda fuera se CUENTA aparte para
+ * poder decirlo en pantalla, en vez de desaparecerlo.
+ */
+export function sumable(
+  amount: { amountCents: number | null; currency: string | null },
+  businessCurrency: string
+): boolean {
+  if (amount.amountCents === null) return false;
+  return (amount.currency ?? businessCurrency) === businessCurrency;
+}
+
+/** Dinero para mostrar. Recibe centavos porque es como viaja y como se guarda. */
+export function formatMoneyCents(
+  cents: number | null | undefined,
+  currency: string,
+  locale = "es-MX"
+): string | null {
+  if (cents === null || cents === undefined) return null;
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: "currency",
+      currency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(cents / 100);
+  } catch {
+    // Moneda o locale que el runtime no conoce: mejor un número correcto sin
+    // símbolo que una pantalla rota.
+    return `${(cents / 100).toFixed(2)} ${currency}`;
+  }
+}
+
+/**
+ * Texto libre del dueño → centavos. Acepta "12,500.50", "12500", "$12 500".
+ * Devuelve `null` si no hay un número reconocible, para no guardar un 0 que
+ * después se lea como "no vale nada".
+ */
+export function parseMoneyToCents(input: string): number | null {
+  const limpio = input.replace(/[^\d.,-]/g, "").trim();
+  if (!limpio) return null;
+  // El último separador manda como decimal; el resto son de millares.
+  const ultimoPunto = limpio.lastIndexOf(".");
+  const ultimaComa = limpio.lastIndexOf(",");
+  const corte = Math.max(ultimoPunto, ultimaComa);
+  let entero = limpio;
+  let decimales = "";
+  if (corte !== -1 && limpio.length - corte <= 3) {
+    entero = limpio.slice(0, corte);
+    decimales = limpio.slice(corte + 1);
+  }
+  const soloDigitos = entero.replace(/[^\d-]/g, "");
+  if (!soloDigitos || soloDigitos === "-") return null;
+  const cents =
+    Number(soloDigitos) * 100 + Number((decimales + "00").slice(0, 2)) *
+      (soloDigitos.startsWith("-") ? -1 : 1);
+  return Number.isFinite(cents) ? Math.trunc(cents) : null;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -77,6 +77,8 @@ export type ContactDto = {
   /** Etapa del embudo del lead asociado; null si el contacto no tiene lead. */
   stageName: string | null;
   archivedAt: string | null;
+  /** De dónde salió el prospecto, capturada o deducida. */
+  source?: SourceDto;
 };
 
 /* ============================================================
@@ -104,3 +106,21 @@ export const LOSS_REASON_LABEL: Record<LossReason, string> = {
 
 /** Quién provocó un movimiento de etapa. */
 export type StageChangeSource = "dueno" | "bot" | "sistema" | "migracion";
+
+/* ============================================================
+ * Fuente del prospecto
+ * ============================================================ */
+
+export type SourceValue =
+  | "anuncio"
+  | "organico"
+  | "referido"
+  | "conocido"
+  | "otro";
+
+export type SourceDto = {
+  /** "desconocida" cuando nadie la capturó y no se pudo deducir. */
+  value: SourceValue | "desconocida";
+  /** `deducida` = la infirió el sistema; `capturada` = la puso el dueño. */
+  source: "capturada" | "deducida";
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -68,6 +68,16 @@ export type StageDto = {
   kind: "open" | "won" | "lost";
 };
 
+/** Un dato de la ficha. Escalar a propósito: ver `server/bot/ficha`. */
+export type FichaValue = string | number | boolean;
+
+/**
+ * Ficha de calificación del lead. Claves libres: cada negocio califica
+ * distinto, así que las define quien pregunta —el agente o el dueño— y el CRM
+ * no las cablea.
+ */
+export type FichaDto = Record<string, FichaValue>;
+
 export type ContactDto = {
   id: string;
   name: string;
@@ -81,6 +91,8 @@ export type ContactDto = {
   source?: SourceDto;
   /** Prioridad del lead asociado; null si nadie la fijó. */
   priority?: PriorityValue | null;
+  /** Lo que se sabe del lead. `{}` mientras nadie haya calificado. */
+  ficha?: FichaDto;
 };
 
 /* ============================================================

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -79,6 +79,8 @@ export type ContactDto = {
   archivedAt: string | null;
   /** De dónde salió el prospecto, capturada o deducida. */
   source?: SourceDto;
+  /** Prioridad del lead asociado; null si nadie la fijó. */
+  priority?: PriorityValue | null;
 };
 
 /* ============================================================
@@ -124,3 +126,10 @@ export type SourceDto = {
   /** `deducida` = la infirió el sistema; `capturada` = la puso el dueño. */
   source: "capturada" | "deducida";
 };
+
+/* ============================================================
+ * Prioridad del lead
+ * ============================================================ */
+
+/** La fija el dueño; NULL = nadie la ha decidido (no es "media"). */
+export type PriorityValue = "alta" | "media" | "baja";

--- a/src/server/bot/ficha.ts
+++ b/src/server/bot/ficha.ts
@@ -1,5 +1,6 @@
 import { eq } from "drizzle-orm";
 import { getDb, schema } from "@/lib/db";
+import { scoped } from "@/lib/db/tenant";
 
 /**
  * Ficha de calificación del lead: lo que el cerebro externo va descubriendo
@@ -72,24 +73,48 @@ export function mergeFicha(prev: Ficha | null | undefined, patch: Ficha): Ficha 
   return out;
 }
 
+/**
+ * Escribe la ficha. Es la ÚNICA puerta: por aquí pasa el cerebro externo
+ * (`PUT /api/bot/ficha`) y también el dueño desde la bandeja, así que los dos
+ * heredan el mismo merge —`null` borra— y las mismas cotas.
+ *
+ * Merge y no reemplazo porque los dos escriben a la vez: el bot va llenando
+ * mientras conversa y el dueño corrige lo que ve. Con reemplazo, el último en
+ * guardar le borraría el trabajo al otro sin que nadie se entere.
+ *
+ * Devuelve `null` si el contacto no existe en esa organización.
+ */
 export async function upsertFicha(input: {
+  organizationId: string;
   contactId: string;
   ficha: FichaInput;
-}): Promise<{ ficha: Ficha }> {
+}): Promise<{ ficha: Ficha } | null> {
   const db = getDb();
   const patch = normalizeFicha(input.ficha);
+
+  // El acotamiento va aquí y no en cada llamador: una ficha es información de
+  // calificación de un cliente ajeno, y confiar en que quien llame se acuerde
+  // de filtrar por organización es exactamente como se filtran los datos entre
+  // inquilinos.
+  const alcance = scoped(
+    schema.contact.organizationId,
+    input.organizationId,
+    eq(schema.contact.id, input.contactId)
+  );
 
   const rows = await db
     .select({ ficha: schema.contact.ficha })
     .from(schema.contact)
-    .where(eq(schema.contact.id, input.contactId))
+    .where(alcance)
     .limit(1);
-  const merged = mergeFicha(rows[0]?.ficha as Ficha | null, patch);
+  if (!rows[0]) return null;
+
+  const merged = mergeFicha(rows[0].ficha as Ficha | null, patch);
 
   await db
     .update(schema.contact)
     .set({ ficha: merged, updatedAt: new Date() })
-    .where(eq(schema.contact.id, input.contactId));
+    .where(alcance);
 
   return { ficha: merged };
 }

--- a/src/server/contact-source.ts
+++ b/src/server/contact-source.ts
@@ -1,0 +1,40 @@
+import type { SourceDto, SourceValue } from "@/lib/types";
+
+/**
+ * Fuente del prospecto.
+ *
+ * Lo que el dueño captura MANDA; lo que no, se marca como deducido. Por eso
+ * `contact.source` nace NULL: nadie tiene que capturar a mano la fuente de los
+ * cientos de contactos que ya existían, ni marcarlos en falso con un backfill.
+ * La UI distingue las dos cosas para no presentar una suposición como un dato.
+ */
+
+export const SOURCE_VALUES: readonly SourceValue[] = [
+  "anuncio",
+  "organico",
+  "referido",
+  "conocido",
+  "otro",
+];
+
+export const SOURCE_LABELS: Record<SourceValue | "desconocida", string> = {
+  anuncio: "Anuncio",
+  organico: "Contenido orgánico",
+  referido: "Referido",
+  conocido: "Conocido",
+  otro: "Otro",
+  desconocida: "Sin identificar",
+};
+
+export function isSourceValue(v: unknown): v is SourceValue {
+  return typeof v === "string" && SOURCE_VALUES.includes(v as SourceValue);
+}
+
+/**
+ * Un contacto que llegó solo por WhatsApp no dice de dónde salió, y el CRM no
+ * lo inventa: queda "sin identificar" hasta que alguien lo capture.
+ */
+export function effectiveSource(stored: SourceValue | null): SourceDto {
+  if (stored) return { value: stored, source: "capturada" };
+  return { value: "desconocida", source: "deducida" };
+}

--- a/src/server/contacts.ts
+++ b/src/server/contacts.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import { getDb, schema } from "@/lib/db";
 import { scoped } from "@/lib/db/tenant";
+import { effectiveSource } from "@/server/contact-source";
 
 export function serializeContact(
   c: typeof schema.contact.$inferSelect,
@@ -13,6 +14,7 @@ export function serializeContact(
     notes: c.notes,
     stageName,
     archivedAt: c.archivedAt?.toISOString() ?? null,
+    source: effectiveSource(c.source),
   };
 }
 

--- a/src/server/contacts.ts
+++ b/src/server/contacts.ts
@@ -2,10 +2,12 @@ import { eq } from "drizzle-orm";
 import { getDb, schema } from "@/lib/db";
 import { scoped } from "@/lib/db/tenant";
 import { effectiveSource } from "@/server/contact-source";
+import type { PriorityValue } from "@/lib/types";
 
 export function serializeContact(
   c: typeof schema.contact.$inferSelect,
-  stageName: string | null = null
+  stageName: string | null = null,
+  priority: PriorityValue | null = null
 ) {
   return {
     id: c.id,
@@ -15,6 +17,7 @@ export function serializeContact(
     stageName,
     archivedAt: c.archivedAt?.toISOString() ?? null,
     source: effectiveSource(c.source),
+    priority,
   };
 }
 

--- a/src/server/contacts.ts
+++ b/src/server/contacts.ts
@@ -2,7 +2,7 @@ import { eq } from "drizzle-orm";
 import { getDb, schema } from "@/lib/db";
 import { scoped } from "@/lib/db/tenant";
 import { effectiveSource } from "@/server/contact-source";
-import type { PriorityValue } from "@/lib/types";
+import type { FichaDto, PriorityValue } from "@/lib/types";
 
 export function serializeContact(
   c: typeof schema.contact.$inferSelect,
@@ -18,6 +18,9 @@ export function serializeContact(
     archivedAt: c.archivedAt?.toISOString() ?? null,
     source: effectiveSource(c.source),
     priority,
+    // Viaja siempre, aunque esté vacía: la pantalla necesita distinguir "aún
+    // no la han llenado" de "este contacto no la trae".
+    ficha: (c.ficha as FichaDto | null) ?? {},
   };
 }
 

--- a/src/server/inbox/lead-activity.ts
+++ b/src/server/inbox/lead-activity.ts
@@ -2,6 +2,7 @@ import { and, asc, eq, sql } from "drizzle-orm";
 import { getDb, schema } from "@/lib/db";
 import { newId } from "@/lib/db/ids";
 import { recordLeadCreated } from "@/server/leads/stage-history";
+import type { StageChangeSource } from "@/lib/types";
 
 /**
  * Actividad de lead al recibir un mensaje (US2): si el contacto no tiene lead,
@@ -29,54 +30,89 @@ export async function onLeadActivity(
     return;
   }
 
-  const firstStage = await db
-    .select({ id: schema.pipelineStage.id })
-    .from(schema.pipelineStage)
-    .where(
-      and(
-        eq(schema.pipelineStage.organizationId, organizationId),
-        eq(schema.pipelineStage.kind, "open")
+  await createLeadForContact({ organizationId, contactId, at });
+}
+
+/**
+ * Crea el lead de un contacto. Lo comparten el webhook (sin `stageId`: primera
+ * etapa abierta) y la captura manual (con la etapa que elija el dueño). Vive en
+ * un solo sitio a propósito: el cálculo de la posición, el `onConflictDoNothing`
+ * sobre `lead_contact_uq` y el registro en la bitácora son lo bastante sutiles
+ * como para que dos copias diverjan en el primer cambio.
+ *
+ * Devuelve `null` si el pipeline no tiene etapas abiertas — quien llama decide
+ * si eso es un error que mostrar (captura manual) o un silencio aceptable
+ * (webhook: jamás debe tumbar la ingesta de un mensaje).
+ */
+export async function createLeadForContact(input: {
+  organizationId: string;
+  contactId: string;
+  stageId?: string;
+  at?: Date;
+  /** Quién dio de alta: el webhook es `sistema`, la captura manual `dueno`. */
+  source?: StageChangeSource;
+  actorUserId?: string | null;
+}): Promise<{ id: string; stageId: string } | null> {
+  const db = getDb();
+
+  let stageId = input.stageId;
+  if (!stageId) {
+    const firstStage = await db
+      .select({ id: schema.pipelineStage.id })
+      .from(schema.pipelineStage)
+      .where(
+        and(
+          eq(schema.pipelineStage.organizationId, input.organizationId),
+          eq(schema.pipelineStage.kind, "open")
+        )
       )
-    )
-    .orderBy(asc(schema.pipelineStage.position))
-    .limit(1);
-  if (!firstStage[0]) return; // pipeline sin etapas abiertas: no hay dónde crear
+      .orderBy(asc(schema.pipelineStage.position))
+      .limit(1);
+    if (!firstStage[0]) return null;
+    stageId = firstStage[0].id;
+  }
 
   const maxPos = await db
     .select({ max: sql<number>`coalesce(max(${schema.lead.position}), -1)` })
     .from(schema.lead)
     .where(
       and(
-        eq(schema.lead.organizationId, organizationId),
-        eq(schema.lead.stageId, firstStage[0].id)
+        eq(schema.lead.organizationId, input.organizationId),
+        eq(schema.lead.stageId, stageId)
       )
     );
 
-  const creado = await db
+  const inserted = await db
     .insert(schema.lead)
     .values({
       id: newId("lead"),
-      organizationId,
-      contactId,
-      stageId: firstStage[0].id,
+      organizationId: input.organizationId,
+      contactId: input.contactId,
+      stageId,
       position: (maxPos[0]?.max ?? -1) + 1,
-      lastActivityAt: at,
+      lastActivityAt: input.at ?? null,
     })
     .onConflictDoNothing({ target: [schema.lead.contactId] })
-    .returning({ id: schema.lead.id });
+    .returning({ id: schema.lead.id, stageId: schema.lead.stageId });
+
+  const creado = inserted[0];
+  if (!creado) return null;
 
   // El nacimiento del lead es el primer evento del embudo: sin él, "prospectos
-  // que entraron en el periodo" no se podría contar desde la bitácora. Va
-  // DENTRO del `if (creado)` porque `onConflictDoNothing` no devuelve fila
-  // cuando otro webhook simultáneo ganó la carrera — y ese ya anotó el suyo.
-  if (creado[0]) {
-    await recordLeadCreated({
-      organizationId,
-      leadId: creado[0].id,
-      contactId,
-      stageId: firstStage[0].id,
-      occurredAt: at,
-      source: "sistema",
-    });
-  }
+  // que entraron en el periodo" no se podría contar desde la bitácora. Va aquí
+  // DENTRO y no en quien llama, porque hay dos caminos que crean leads y el
+  // segundo que alguien agregue lo olvidaría. Y va tras comprobar `creado`
+  // porque `onConflictDoNothing` no devuelve fila cuando otro webhook
+  // simultáneo ganó la carrera — ese ya anotó el suyo.
+  await recordLeadCreated({
+    organizationId: input.organizationId,
+    leadId: creado.id,
+    contactId: input.contactId,
+    stageId: creado.stageId,
+    occurredAt: input.at,
+    actorUserId: input.actorUserId ?? null,
+    source: input.source ?? "sistema",
+  });
+
+  return creado;
 }

--- a/src/server/leads/priority.ts
+++ b/src/server/leads/priority.ts
@@ -1,0 +1,46 @@
+import type { PriorityValue } from "@/lib/types";
+
+/**
+ * Prioridad de cierre del lead.
+ *
+ * La fija el dueño y NADA la escribe automáticamente. Un CRM que adivina la
+ * prioridad y la pisa cuando cambia de opinión es un CRM en el que se deja de
+ * confiar: NULL significa "nadie la ha decidido", no "media".
+ *
+ * Sin sugerencias a propósito. Deducirla exigiría señales que este CRM no tiene
+ * (¿está calificado? ¿respondió?), y una sugerencia calculada con dos datos
+ * pobres se equivoca lo bastante como para que el dueño deje de mirarla.
+ */
+
+export const PRIORITY_VALUES: readonly PriorityValue[] = ["alta", "media", "baja"];
+
+export const PRIORITY_LABELS: Record<PriorityValue, string> = {
+  alta: "Alta",
+  media: "Media",
+  baja: "Baja",
+};
+
+export function isPriority(v: unknown): v is PriorityValue {
+  return typeof v === "string" && (PRIORITY_VALUES as readonly string[]).includes(v);
+}
+
+/** Orden de trabajo: alta primero, y lo que no tiene prioridad va al final. */
+export const PRIORITY_RANK: Record<PriorityValue, number> = {
+  alta: 0,
+  media: 1,
+  baja: 2,
+};
+
+export function priorityRank(value: PriorityValue | null): number {
+  return value ? PRIORITY_RANK[value] : 3;
+}
+
+/**
+ * Ordena por prioridad y, a igualdad, deja el orden que traía. Los leads sin
+ * prioridad quedan al final: no son urgentes, pero tampoco se esconden.
+ */
+export function byPriority<T extends { priority: PriorityValue | null }>(
+  leads: readonly T[]
+): T[] {
+  return [...leads].sort((a, b) => priorityRank(a.priority) - priorityRank(b.priority));
+}

--- a/tests/e2e/us1-inbox.md
+++ b/tests/e2e/us1-inbox.md
@@ -39,17 +39,40 @@ Automatizado en `scripts/e2e-envio-instantaneo.mjs`.
    ✅ Cuando el mensaje real llega, la burbuja provisional se retira sin dejar
    duplicado y sin parpadeo.
 
+## Ficha del lead
+
+Automatizado en `scripts/e2e-ficha-lead.mjs`. `PUT /api/bot/ficha` ya dejaba al
+agente guardar lo que averigua; sin esta sección era un cajón que se llenaba y
+no se abría.
+
+10. **Lo que sabe el agente se ve.** En el panel de detalles, bajo la etapa.
+    ✅ Las claves se leen bonito (`dolor_principal` → "Dolor principal") sin que
+    cambie lo guardado: renombrarlas rompería al agente, que las busca exactas.
+    ✅ Los booleanos se muestran Sí/No — nadie califica en `true`.
+    ✅ Aparece en vivo mientras el agente conversa, sin recargar.
+11. **Se puede corregir.** Un dato equivocado que el dueño ve pero no puede
+    arreglar enseña a desconfiar de toda la ficha.
+    ✅ Editar NO cambia el tipo: `presupuesto: 50000` corregido a "60000" sigue
+    siendo número, porque del otro lado hay un bot que puede estar comparando.
+    ✅ El bote de basura quita la clave; vaciar el campo NO la borra.
+12. **Nadie le pisa el trabajo al otro.** El agente sigue escribiendo mientras
+    el dueño corrige.
+    ✅ Es merge, no reemplazo: lo nuevo del agente entra sin borrar la
+    corrección, y viceversa.
+    ✅ Objetos y arreglos se ignoran en silencio en vez de tirar la ficha.
+    ✅ Un contacto de otra organización → **404**, no una escritura a ciegas.
+
 ## Caminos infelices
 
-10. **Dedup (SC-004)**: enviar dos veces el mismo `waMessageId` `wamid.dedup.1`.
+13. **Dedup (SC-004)**: enviar dos veces el mismo `waMessageId` `wamid.dedup.1`.
    ✅ El hilo muestra UNA sola vez el mensaje.
-11. **Ventana cerrada (SC-005)**: inbound de contacto nuevo con
+14. **Ventana cerrada (SC-005)**: inbound de contacto nuevo con
    `timestamp` de hace 25 horas → abrir su conversación.
    ✅ El composer está bloqueado con la explicación de la ventana y ofrece
    plantillas (estado vacío si no hay aprobadas).
    ✅ `POST /api/conversations/:id/messages` responde 409 `window_closed`.
-12. **Webhook segmento incorrecto**: `POST /api/webhooks/wa/token-falso` → 404
+15. **Webhook segmento incorrecto**: `POST /api/webhooks/wa/token-falso` → 404
     y no aparece nada nuevo en la bandeja.
-13. **Reconexión**: (cubierto por diseño: EventSource reconecta y el cliente
+16. **Reconexión**: (cubierto por diseño: EventSource reconecta y el cliente
     refetch-ea con el evento `open`; verificación funcional en el checkpoint
     de compose).

--- a/tests/e2e/us2-pipeline.md
+++ b/tests/e2e/us2-pipeline.md
@@ -49,7 +49,29 @@ cada lead HOY; la bitácora es lo que permite preguntar qué pasó antes.
     movimiento como `sistema`, y eliminar una etapa con reubicación deja un
     evento por cada lead reubicado.
 
+## Alta manual de prospectos
+
+Automatizado en `scripts/e2e-alta-manual.mjs`. El embudo ya no depende de que
+la gente llegue por WhatsApp.
+
+12. **"Nuevo contacto"** en Contactos: nombre, teléfono, fuente y etapa inicial.
+    ✅ El prospecto aparece en el **Pipeline**, en la etapa elegida — no solo en
+    la lista de contactos.
+    ✅ Su nacimiento queda en la bitácora marcado como capturado por el dueño.
+13. **El teléfono exige código de país.** Un número local crearía un contacto
+    que jamás casaría con los mensajes entrantes, porque Meta manda la identidad
+    completa.
+    ✅ Con guiones o letras → **422** explicando la regla.
+    ✅ Un teléfono repetido → **409**, y se ofrece abrir a quien ya existe en vez
+    de un error seco.
+14. **La fuente capturada manda; lo que nadie capturó no se inventa.**
+    ✅ Quien llegó por WhatsApp queda "sin identificar" y marcado como deducido.
+    ✅ La etiqueta de fuente solo se muestra cuando alguien la capturó.
+15. **Escribir primero**: el botón de enviar abre el panel de plantillas.
+    ✅ Solo plantillas aprobadas: iniciar con texto libre lo prohíbe Meta.
+    ✅ Con la ventana de 24 h abierta se avisa en vez de gastar una plantilla.
+
 ## Contactos (FR-013)
 
-12. Buscar por "Frio" → filtra; editar notas → persiste; archivar → desaparece
+16. Buscar por "Frio" → filtra; editar notas → persiste; archivar → desaparece
     de la lista (visible con "Ver archivados"); desarchivar → vuelve.

--- a/tests/e2e/us2-pipeline.md
+++ b/tests/e2e/us2-pipeline.md
@@ -71,7 +71,27 @@ la gente llegue por WhatsApp.
     ✅ Solo plantillas aprobadas: iniciar con texto libre lo prohíbe Meta.
     ✅ Con la ventana de 24 h abierta se avisa en vez de gastar una plantilla.
 
+## Monto de la negociación
+
+Automatizado en `scripts/e2e-monto-pipeline.mjs`. El tablero cuenta personas;
+esto le agrega cuánto dinero hay en cada columna.
+
+16. **Capturar el monto** desde la tarjeta ("+ monto").
+    ✅ Acepta lo que uno teclea: `12500`, `12,500.50`, `$12 500`.
+    ✅ Guardarlo **no mueve** la tarjeta, y mover la tarjeta no borra el monto.
+    ✅ Vacío borra el monto: un trato sin número no vale cero, no se sabe.
+17. **Total por columna** al pie de cada etapa.
+    ✅ Suma solo la moneda del negocio, en centavos enteros.
+    ✅ Sin montos capturados dice "Sin montos capturados" — un `$0.00` se lee
+    como un error del sistema, no como un dato.
+    ✅ Si hay importes en otra moneda, lo **dice** en vez de descartarlos en
+    silencio.
+18. **La moneda se elige** en Ajustes → Marca.
+    ✅ El tablero la refleja.
+    ✅ Un importe ya capturado conserva la suya: cambiar el ajuste no
+    reinterpreta pesos como dólares.
+
 ## Contactos (FR-013)
 
-16. Buscar por "Frio" → filtra; editar notas → persiste; archivar → desaparece
+19. Buscar por "Frio" → filtra; editar notas → persiste; archivar → desaparece
     de la lista (visible con "Ver archivados"); desarchivar → vuelve.

--- a/tests/e2e/us2-pipeline.md
+++ b/tests/e2e/us2-pipeline.md
@@ -91,7 +91,21 @@ esto le agrega cuánto dinero hay en cada columna.
     ✅ Un importe ya capturado conserva la suya: cambiar el ajuste no
     reinterpreta pesos como dólares.
 
+## Prioridad
+
+Automatizado en `scripts/e2e-prioridad.mjs`. A quién llamar primero.
+
+19. **La fija el dueño** desde la tarjeta (Alta / Media / Baja).
+    ✅ Un lead nuevo nace **sin** prioridad — no con una "media" inventada.
+    ✅ Se puede **quitar**: un clic por error no queda para siempre.
+20. **Nada la escribe solo.** Mover la tarjeta de etapa, capturar el monto o
+    recibir un mensaje del cliente NO la cambian. Es la única forma de que el
+    dueño pueda confiar en que lo que ve es lo que él puso.
+21. **Se ve donde se trabaja**: etiqueta en la tarjeta del Pipeline y en la
+    lista de Contactos, que además ordena alta primero y deja al final a quien
+    no tiene prioridad.
+
 ## Contactos (FR-013)
 
-19. Buscar por "Frio" → filtra; editar notas → persiste; archivar → desaparece
+22. Buscar por "Frio" → filtra; editar notas → persiste; archivar → desaparece
     de la lista (visible con "Ver archivados"); desarchivar → vuelve.

--- a/tests/unit/contact-source.test.ts
+++ b/tests/unit/contact-source.test.ts
@@ -1,0 +1,52 @@
+﻿import { describe, expect, it } from "vitest";
+import {
+  effectiveSource,
+  isSourceValue,
+  SOURCE_LABELS,
+  SOURCE_VALUES,
+} from "@/server/contact-source";
+
+/* Fuente del prospecto: lo capturado manda, lo demás queda sin identificar. */
+
+describe("fuente efectiva", () => {
+  it("lo que capturó el dueño se marca como capturado", () => {
+    expect(effectiveSource("referido")).toEqual({
+      value: "referido",
+      source: "capturada",
+    });
+  });
+
+  it("sin captura queda desconocida, y se dice que fue deducida", () => {
+    // No se inventa: un contacto que solo escribió por WhatsApp no dice de
+    // dónde salió, y presentarlo como dato sería mentir en el reporte.
+    expect(effectiveSource(null)).toEqual({
+      value: "desconocida",
+      source: "deducida",
+    });
+  });
+
+  it("nunca inventa: 'desconocida' no es un valor capturable", () => {
+    expect(isSourceValue("desconocida")).toBe(false);
+    expect(SOURCE_VALUES).not.toContain("desconocida");
+  });
+});
+
+describe("catálogo de fuentes", () => {
+  it("es cerrado y cubre lo que el dueño pidió", () => {
+    expect([...SOURCE_VALUES].sort()).toEqual(
+      ["anuncio", "conocido", "organico", "otro", "referido"].sort()
+    );
+  });
+
+  it("toda fuente tiene etiqueta legible, incluida la desconocida", () => {
+    for (const v of [...SOURCE_VALUES, "desconocida" as const]) {
+      expect(SOURCE_LABELS[v]).toBeTruthy();
+    }
+  });
+
+  it("valida entradas basura", () => {
+    expect(isSourceValue("facebook")).toBe(false);
+    expect(isSourceValue(null)).toBe(false);
+    expect(isSourceValue("referido")).toBe(true);
+  });
+});

--- a/tests/unit/ficha-guard.test.ts
+++ b/tests/unit/ficha-guard.test.ts
@@ -1,0 +1,67 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Guardarraíl de la ficha del lead.
+ *
+ * La ficha es información de calificación de los clientes de alguien: qué
+ * presupuesto tiene, qué le duele, si decide él. Se escribe desde dos lados
+ * —el cerebro externo por `PUT /api/bot/ficha` y el dueño desde la bandeja— y
+ * las dos rutas entran por `upsertFicha`.
+ *
+ * Aquí se verifica que esa puerta filtre por organización POR SÍ MISMA, y no
+ * confiando en que el llamador se acuerde. Ese "acuérdate de filtrar" es
+ * exactamente como se filtran datos entre inquilinos: nada truena, y el
+ * incidente se descubre cuando ya salió.
+ *
+ * Si estás leyendo esto porque el test se puso rojo: no lo relajes.
+ */
+
+const SRC = path.resolve(import.meta.dirname, "..", "..", "src");
+const PUERTA = path.join(SRC, "server", "bot", "ficha.ts");
+
+function archivosTs(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...archivosTs(full));
+    else if (/\.(ts|tsx)$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+describe("guardarraíl: la ficha nunca se escribe sin organización", () => {
+  const puerta = readFileSync(PUERTA, "utf8");
+
+  it("`upsertFicha` recibe la organización", () => {
+    const firma = puerta.slice(puerta.indexOf("export async function upsertFicha"));
+    expect(firma.slice(0, 200)).toContain("organizationId");
+  });
+
+  it("y la usa: sus queries pasan por `scoped`, no por un `eq` pelón", () => {
+    const cuerpo = puerta.slice(
+      puerta.indexOf("export async function upsertFicha")
+    );
+    expect(cuerpo).toContain("scoped(");
+    expect(cuerpo).toContain("schema.contact.organizationId");
+  });
+
+  it("nadie más escribe `contact.ficha` por su cuenta", () => {
+    const culpables: string[] = [];
+    for (const file of archivosTs(SRC)) {
+      if (path.resolve(file) === path.resolve(PUERTA)) continue;
+      const code = readFileSync(file, "utf8");
+      // `.set({ … ficha … })` sobre la tabla de contactos, fuera de la puerta.
+      const re = /\.update\(\s*schema\.contact\s*\)/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(code)) !== null) {
+        const bloque = code.slice(m.index, m.index + 400);
+        if (/\bficha\b/.test(bloque)) {
+          culpables.push(path.relative(SRC, file));
+        }
+      }
+    }
+    expect(culpables).toEqual([]);
+  });
+});

--- a/tests/unit/ficha-ui.test.ts
+++ b/tests/unit/ficha-ui.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  fichaEntries,
+  fichaLabel,
+  fichaValueText,
+  parseFichaValue,
+} from "@/lib/ficha";
+
+describe("fichaLabel", () => {
+  it("lee bonito lo que escribió un LLM, en cualquiera de sus manías", () => {
+    expect(fichaLabel("dolor_principal")).toBe("Dolor principal");
+    expect(fichaLabel("dolorPrincipal")).toBe("Dolor principal");
+    expect(fichaLabel("dolor-principal")).toBe("Dolor principal");
+    expect(fichaLabel("presupuesto")).toBe("Presupuesto");
+  });
+
+  it("no se rompe con claves raras", () => {
+    expect(fichaLabel("m2")).toBe("M2");
+    expect(fichaLabel("__")).toBe("__");
+    expect(fichaLabel("ZONA")).toBe("Zona");
+  });
+});
+
+describe("fichaValueText", () => {
+  it("los booleanos se leen Sí/No: nadie califica en true", () => {
+    expect(fichaValueText(true)).toBe("Sí");
+    expect(fichaValueText(false)).toBe("No");
+  });
+
+  it("números y textos pasan tal cual", () => {
+    expect(fichaValueText(50000)).toBe("50000");
+    expect(fichaValueText("Polanco")).toBe("Polanco");
+  });
+});
+
+describe("parseFichaValue", () => {
+  it("editar NO cambia el tipo del dato", () => {
+    // Del otro lado hay un bot que puede estar comparando; convertir en
+    // silencio un número a texto es de los cambios que solo se descubren
+    // cuando algo ya falló.
+    expect(parseFichaValue("60000", 50000)).toBe(60000);
+    expect(parseFichaValue("No", true)).toBe(false);
+    expect(parseFichaValue("sí", false)).toBe(true);
+    expect(parseFichaValue("Polanco", "Roma")).toBe("Polanco");
+  });
+
+  it("pero sí lo cambia si lo escrito ya no es de ese tipo", () => {
+    expect(parseFichaValue("como cinco mil", 5000)).toBe("como cinco mil");
+    expect(parseFichaValue("depende", true)).toBe("depende");
+  });
+
+  it("un dato nuevo entra como texto", () => {
+    expect(parseFichaValue("42", undefined)).toBe("42");
+  });
+
+  it("recorta los espacios de sobra", () => {
+    expect(parseFichaValue("  Polanco  ", "Roma")).toBe("Polanco");
+  });
+});
+
+describe("fichaEntries", () => {
+  it("ordena para que la ficha no baile entre recargas", () => {
+    const claves = fichaEntries({ zona: "Roma", dolor: "x", presupuesto: 1 }).map(
+      ([k]) => k
+    );
+    expect(claves).toEqual(["dolor", "presupuesto", "zona"]);
+  });
+
+  it("una ficha vacía no truena", () => {
+    expect(fichaEntries({})).toEqual([]);
+  });
+});

--- a/tests/unit/money.test.ts
+++ b/tests/unit/money.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatMoneyCents,
+  isCurrency,
+  parseMoneyToCents,
+  sumable,
+} from "@/lib/money";
+
+describe("parseMoneyToCents", () => {
+  it("acepta lo que la gente teclea de verdad", () => {
+    expect(parseMoneyToCents("12500")).toBe(1_250_000);
+    expect(parseMoneyToCents("12,500")).toBe(1_250_000);
+    expect(parseMoneyToCents("12,500.50")).toBe(1_250_050);
+    expect(parseMoneyToCents("$12 500.50")).toBe(1_250_050);
+    expect(parseMoneyToCents("  900  ")).toBe(90_000);
+  });
+
+  it("un decimal solo no se confunde con millares", () => {
+    // "12.5" son doce cincuenta, no doce mil quinientos.
+    expect(parseMoneyToCents("12.5")).toBe(1_250);
+    expect(parseMoneyToCents("12,5")).toBe(1_250);
+  });
+
+  it("trata el punto de millares como millares, no como decimales", () => {
+    // "12.500" con tres dígitos detrás es doce mil quinientos.
+    expect(parseMoneyToCents("12.500")).toBe(1_250_000);
+  });
+
+  it("sin número reconocible devuelve null, no cero", () => {
+    // Un 0 se leería como "este trato no vale nada", que es un dato distinto
+    // de "nadie capturó el monto".
+    expect(parseMoneyToCents("")).toBeNull();
+    expect(parseMoneyToCents("   ")).toBeNull();
+    expect(parseMoneyToCents("$")).toBeNull();
+    expect(parseMoneyToCents("no sé")).toBeNull();
+  });
+
+  it("el cero explícito sí es un cero", () => {
+    expect(parseMoneyToCents("0")).toBe(0);
+  });
+});
+
+describe("sumable", () => {
+  it("solo suma lo que está en la moneda del negocio", () => {
+    expect(sumable({ amountCents: 1000, currency: "MXN" }, "MXN")).toBe(true);
+    expect(sumable({ amountCents: 1000, currency: "USD" }, "MXN")).toBe(false);
+  });
+
+  it("un monto sin moneda se asume en la del negocio", () => {
+    // Es el caso de los leads capturados antes de que existiera la columna.
+    expect(sumable({ amountCents: 1000, currency: null }, "MXN")).toBe(true);
+  });
+
+  it("sin monto no suma, aunque la moneda coincida", () => {
+    expect(sumable({ amountCents: null, currency: "MXN" }, "MXN")).toBe(false);
+  });
+
+  it("cambiar la moneda del negocio cambia lo sumable", () => {
+    const monto = { amountCents: 1000, currency: "USD" };
+    expect(sumable(monto, "MXN")).toBe(false);
+    expect(sumable(monto, "USD")).toBe(true);
+  });
+});
+
+describe("formatMoneyCents", () => {
+  it("formatea en la moneda pedida", () => {
+    const out = formatMoneyCents(1_250_050, "MXN");
+    expect(out).toContain("12,500.50");
+  });
+
+  it("null entra, null sale: no inventa un $0.00", () => {
+    expect(formatMoneyCents(null, "MXN")).toBeNull();
+    expect(formatMoneyCents(undefined, "MXN")).toBeNull();
+  });
+
+  it("una moneda que el runtime no conoce degrada sin romper la pantalla", () => {
+    const out = formatMoneyCents(1_000, "XXX_INVALIDA");
+    expect(out).toBe("10.00 XXX_INVALIDA");
+  });
+});
+
+describe("catálogo de monedas", () => {
+  it("valida entradas basura", () => {
+    expect(isCurrency("MXN")).toBe(true);
+    expect(isCurrency("mxn")).toBe(false);
+    expect(isCurrency("pesos")).toBe(false);
+    expect(isCurrency(null)).toBe(false);
+  });
+});

--- a/tests/unit/priority.test.ts
+++ b/tests/unit/priority.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  byPriority,
+  isPriority,
+  PRIORITY_LABELS,
+  PRIORITY_VALUES,
+  priorityRank,
+} from "@/server/leads/priority";
+
+describe("prioridad del lead", () => {
+  it("nada la escribe sola: no hay función que la sugiera", async () => {
+    // Este test es el contrato del módulo. Si alguien agrega una heurística
+    // que rellene la prioridad, el dueño dejará de poder confiar en que lo que
+    // ve es lo que él puso — y este test es el lugar donde discutirlo.
+    const mod = await import("@/server/leads/priority");
+    expect(Object.keys(mod)).not.toContain("suggestPriority");
+  });
+
+  it("el catálogo es cerrado y todo valor tiene etiqueta", () => {
+    expect([...PRIORITY_VALUES]).toEqual(["alta", "media", "baja"]);
+    for (const p of PRIORITY_VALUES) expect(PRIORITY_LABELS[p]).toBeTruthy();
+  });
+
+  it("valida entradas basura", () => {
+    expect(isPriority("alta")).toBe(true);
+    expect(isPriority("ALTA")).toBe(false);
+    expect(isPriority("urgente")).toBe(false);
+    expect(isPriority(null)).toBe(false);
+  });
+});
+
+describe("orden de trabajo", () => {
+  it("alta primero, y lo que nadie priorizó va al final", () => {
+    expect(priorityRank("alta")).toBeLessThan(priorityRank("media"));
+    expect(priorityRank("media")).toBeLessThan(priorityRank("baja"));
+    expect(priorityRank("baja")).toBeLessThan(priorityRank(null));
+  });
+
+  it("ordena una lista sin perder a nadie", () => {
+    const leads = [
+      { id: "sin", priority: null },
+      { id: "baja", priority: "baja" as const },
+      { id: "alta", priority: "alta" as const },
+      { id: "media", priority: "media" as const },
+    ];
+    expect(byPriority(leads).map((l) => l.id)).toEqual([
+      "alta",
+      "media",
+      "baja",
+      "sin",
+    ]);
+    expect(byPriority(leads)).toHaveLength(leads.length);
+  });
+
+  it("no muta la lista que recibe", () => {
+    const leads = [
+      { priority: "baja" as const },
+      { priority: "alta" as const },
+    ];
+    const copia = [...leads];
+    byPriority(leads);
+    expect(leads).toEqual(copia);
+  });
+
+  it("a igualdad de prioridad conserva el orden que traía", () => {
+    const leads = [
+      { id: "b", priority: "alta" as const },
+      { id: "a", priority: "alta" as const },
+    ];
+    expect(byPriority(leads).map((l) => l.id)).toEqual(["b", "a"]);
+  });
+});


### PR DESCRIPTION
> Incluye el #26 (rescate del tramo B). Si mergeas ese primero, este diff se
> reduce solo; si mergeas este, entran los dos. No hay rama base que pueda
> desaparecer debajo.

`PUT /api/bot/ficha` ya dejaba a un cerebro externo guardar lo que averigua de
cada lead. Pero **ninguna pantalla la mostraba**: los únicos archivos que
mencionaban la ficha eran el esquema, sus dos rutas y su módulo.

```
$ git grep -l ficha -- src/
src/app/api/bot/context/route.ts
src/app/api/bot/ficha/route.ts
src/lib/db/schema.ts
src/server/bot/ficha.ts
```

Un cajón que se llena y no se abre. Este PR lo abre.

## Dónde

En el panel de detalles de la bandeja, bajo la etapa y **antes de las notas**:
lo que se SABE va antes de lo que alguien opina, porque es lo que se consulta a
mitad de una conversación.

```
FICHA                    Agregar
Calificado      Sí
Presupuesto     75000
Tamano equipo   12 personas
```

Las claves se leen bonito (`dolor_principal` → "Dolor principal") **sin tocar
lo guardado**: renombrarlas rompería al agente, que las busca exactas. Los
booleanos se muestran Sí/No, porque nadie califica en `true`. Y se refresca en
vivo: el dato aparece mientras la conversación ocurre.

## Se puede corregir

Un dato equivocado que el dueño ve pero no puede arreglar es peor que no
tenerlo — enseña a desconfiar de toda la ficha.

**Editar no cambia el tipo del dato**, salvo que lo escrito ya no sea de ese
tipo. Si el agente guardó `presupuesto: 50000` y el dueño corrige a "60000", se
guarda `60000` y no `"60000"`: del otro lado hay un bot que puede estar
comparando, y convertir en silencio un número a texto es de esos cambios que
solo se descubren cuando algo ya falló.

El dueño escribe por la **misma puerta** que el bot (`upsertFicha`), así que
hereda su merge. Los dos escriben a la vez y ninguno le borra el trabajo al
otro.

## Un arreglo de camino

`upsertFicha` no filtraba por organización: confiaba en que el llamador ya lo
hubiera hecho. Con un solo llamador se podía vivir con eso; agregando el
segundo, ese "acuérdate de filtrar" es exactamente como se filtran datos entre
inquilinos. Ahora filtra ella misma, y `tests/unit/ficha-guard.test.ts` se pone
rojo si alguien se lo quita.

## Verificación

```
pnpm typecheck   ✓
pnpm lint        ✓
pnpm test        ✓  221 pruebas, 32 archivos (13 nuevas)
pnpm build       ✓
```

| Guion (base fresca) | |
|---|---|
| `e2e-ficha-lead.mjs` (nuevo) | **13/13** |
| `e2e-selftest.mjs` (general) | 87/87 |
| `e2e-bitacora-etapas` · `alta-manual` · `monto-pipeline` · `prioridad` | 19/19 · 14/14 · 14/14 · 13/13 |

**Probado en el navegador, no solo por API**: el agente escribe → aparece en el
panel; se edita `presupuesto` desde la pantalla y queda guardado como **número**
(`typeof === "number"`); el bote de basura quita la clave sin llevarse a las
vecinas; se agrega un dato nuevo; y después el agente vuelve a escribir sin
borrar nada de lo anterior. En tema oscuro, la etiqueta da 4.73:1 y el valor
16.24:1 — ambos pasan AA.

**Prueba en rojo.** Cambiar el merge por un reemplazo tumba 6 de los 13 checks.
Quitar el `scoped` de la puerta pone roja la guarda.

Y un hallazgo del rojo que vale contar: mi check de "otra organización" usaba un
id inexistente, así que daba 404 **aunque** se quitara el acotamiento — probaba
menos de lo que su nombre prometía. Lo renombré a lo que sí prueba y moví esa
garantía a la guarda estática, que sí falla.

## Superficie

Sin migración: la columna `ficha` ya existe. Sin dependencias nuevas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
