### PR TITLE
feat: enseñar qué versión está corriendo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,12 @@ RUN corepack enable
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
+# Commit del que sale la imagen, para que la app pueda decir qué está corriendo.
+# Coolify lo inyecta solo; con docker compose se pasa con
+# `--build-arg SOURCE_COMMIT=$(git rev-parse HEAD)`. Si falta, la app enseña
+# solo la versión de package.json — nunca es un error de build.
+ARG SOURCE_COMMIT=""
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
 RUN pnpm build
 # migrate.mjs autocontenido (drizzle-orm + postgres bundleados)
 RUN pnpm exec esbuild scripts/migrate.mjs --bundle --platform=node \

--- a/README.md
+++ b/README.md
@@ -312,6 +312,32 @@ y se ve en `ps`.
 Debe responder `UPDATE 1`. Si responde `UPDATE 0`, el correo no coincide;
 míralos con `SELECT email FROM "user";`.
 
+## Versiones
+
+La versión que está corriendo se ve **abajo en la barra lateral** (`v1.1.0 ·
+8e62d0b`) y en el healthcheck, para poder confirmar un despliegue con un
+`curl` sin abrir la app:
+
+```bash
+curl -s https://crm.tudominio.com/api/health
+# {"ok":true,"version":"1.1.0","commit":"8e62d0b"}
+```
+
+Los dos valores se congelan al **construir**, así que no pueden mentir en
+tiempo de ejecución. El commit lo inyecta Coolify solo; con docker compose se
+pasa con `--build-arg SOURCE_COMMIT=$(git rev-parse HEAD)`, y si falta se ve
+solo la versión.
+
+SemVer sobre lo que le importa a quien opera una instancia:
+
+| | Cuándo sube |
+|---|---|
+| **Mayor** (`2.0.0`) | Hay que hacer algo a mano para actualizar: cambiar una variable de entorno, migrar datos, reconectar algo. |
+| **Menor** (`1.2.0`) | Funciones nuevas. Actualizar es redesplegar. |
+| **Parche** (`1.1.1`) | Arreglos y ajustes. Actualizar es redesplegar. |
+
+La versión vive en `package.json` y se sube en el PR que publica el cambio.
+
 ## Roadmap
 
 - Multimedia completa en la bandeja (hoy: indicador de tipo).

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,11 @@
 import type { NextConfig } from "next";
+import { readFileSync } from "node:fs";
+
+// La versión sale de package.json y no de una constante aparte: duplicarla es
+// tenerla desactualizada en uno de los dos lados, y justo esta no puede mentir.
+const { version } = JSON.parse(
+  readFileSync(new URL("./package.json", import.meta.url), "utf8")
+) as { version: string };
 
 const nextConfig: NextConfig = {
   // standalone es para la imagen Docker (Linux). En Windows el trazado crea
@@ -6,6 +13,14 @@ const nextConfig: NextConfig = {
   output: process.platform === "win32" ? undefined : "standalone",
   // El paquete `postgres` usa APIs de Node que no deben empaquetarse en el bundle.
   serverExternalPackages: ["postgres"],
+  // Se congelan al construir: el binario lleva dentro de qué código salió, así
+  // que no puede mentir en tiempo de ejecución. `SOURCE_COMMIT` lo inyecta
+  // Coolify solo; con docker compose se pasa por `--build-arg` y si falta, la
+  // app enseña solo la versión.
+  env: {
+    NEXT_PUBLIC_APP_VERSION: version,
+    NEXT_PUBLIC_BUILD_COMMIT: process.env.SOURCE_COMMIT ?? "",
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vocero-crm",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "CRM de WhatsApp open source y self-hosted con agente de IA y Laboratorio de auto-evaluación",
   "license": "MIT",
   "type": "module",

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,12 +1,21 @@
 import { sql } from "drizzle-orm";
 import { getDb } from "@/lib/db";
+import { APP_VERSION, BUILD_COMMIT } from "@/lib/version";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
   try {
     await getDb().execute(sql`select 1`);
-    return Response.json({ ok: true });
+    // La versión viaja aquí a propósito: confirmar un despliegue tiene que
+    // poder hacerse con un `curl`, desde un script o desde la plataforma de
+    // hosting, sin abrir la app ni iniciar sesión. Es la única forma de que un
+    // pipeline pueda comprobar que el build que subió es el que corre.
+    return Response.json({
+      ok: true,
+      version: APP_VERSION,
+      ...(BUILD_COMMIT ? { commit: BUILD_COMMIT } : {}),
+    });
   } catch {
     return Response.json(
       { ok: false, error: { code: "db_unavailable", message: "Base de datos no disponible" } },

--- a/src/components/app-nav.tsx
+++ b/src/components/app-nav.tsx
@@ -19,6 +19,7 @@ import { cn, initials } from "@/lib/utils";
 import { signOut } from "@/lib/auth/client";
 import { useEvents } from "@/components/use-events";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { APP_VERSION, BUILD_COMMIT, versionLabel } from "@/lib/version";
 
 const NAV = [
   { href: "/inbox", label: "Bandeja", icon: Inbox, badge: true },
@@ -184,6 +185,22 @@ export function AppNav({
           <LogOut className="h-4 w-4" strokeWidth={1.7} />
         </button>
       </div>
+
+      {/* Qué versión está corriendo. Discreta pero siempre visible: la duda
+          "¿ya se desplegó?" aparece justo cuando algo no funciona, y mandar a
+          alguien a comparar commits en el servidor significa que no lo hará. */}
+      {/* `text-2` y no `text-3`: a 11px, el gris más claro se queda en 3.2:1
+          contra el fondo de la barra y no pasa AA. Discreta sí, ilegible no. */}
+      <p
+        className="mt-1.5 px-2.5 text-[11px] tabular-nums text-text-2"
+        title={
+          BUILD_COMMIT
+            ? `Vocero ${APP_VERSION}, construido del commit ${BUILD_COMMIT}`
+            : `Vocero ${APP_VERSION}`
+        }
+      >
+        {versionLabel()}
+      </p>
     </aside>
   );
 }

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,30 @@
+/**
+ * Qué versión está corriendo.
+ *
+ * Existe para responder una pregunta que hoy no tiene respuesta desde la app:
+ * "¿ya se desplegó mi cambio?". Sin esto hay que ir al servidor a comparar
+ * commits, y en la práctica nadie lo hace — se asume que sí, y se depura
+ * durante media hora un bug que ya estaba arreglado en un build que nunca
+ * llegó.
+ *
+ * Los dos valores se congelan al CONSTRUIR (ver `next.config.ts`): el binario
+ * lleva dentro de qué código salió, así que no pueden mentir en tiempo de
+ * ejecución.
+ */
+
+/** SemVer de `package.json`. Cambia cuando alguien publica, no en cada push. */
+export const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? "0.0.0";
+
+/**
+ * Commit del que salió el build, corto. Vacío si quien construyó no lo pasó
+ * (`--build-arg SOURCE_COMMIT=...`); Coolify lo inyecta solo.
+ *
+ * Es el que de verdad zanja la duda: dos despliegues seguidos de `main` sin
+ * tocar la versión se ven idénticos por SemVer y distintos por commit.
+ */
+export const BUILD_COMMIT = (process.env.NEXT_PUBLIC_BUILD_COMMIT ?? "").slice(0, 7);
+
+/** `v1.1.0 · 8e62d0b`, o solo `v1.1.0` si no hubo commit al construir. */
+export function versionLabel(): string {
+  return BUILD_COMMIT ? `v${APP_VERSION} · ${BUILD_COMMIT}` : `v${APP_VERSION}`;
+}

--- a/tests/unit/version.test.ts
+++ b/tests/unit/version.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * La versión que enseña la app tiene que ser la del código que corre. Si se
+ * desincroniza, es peor que no tenerla: alguien va a depurar media hora un bug
+ * ya arreglado porque la etiqueta le dijo que el build sí había llegado.
+ */
+
+const RAIZ = path.resolve(import.meta.dirname, "..", "..");
+const pkg = JSON.parse(
+  readFileSync(path.join(RAIZ, "package.json"), "utf8")
+) as { version: string };
+
+describe("versión de la app", () => {
+  it("package.json lleva un SemVer válido", () => {
+    expect(pkg.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("no la duplica nadie: sale de package.json vía next.config", () => {
+    const config = readFileSync(path.join(RAIZ, "next.config.ts"), "utf8");
+    expect(config).toContain("package.json");
+    expect(config).toContain("NEXT_PUBLIC_APP_VERSION");
+    // Una versión escrita a mano en el config es exactamente cómo se
+    // desincroniza; si aparece un literal tipo "1.2.3", esto se pone rojo.
+    expect(config).not.toMatch(/["']\d+\.\d+\.\d+["']/);
+  });
+
+  it("el Dockerfile acepta el commit sin exigirlo", () => {
+    const dockerfile = readFileSync(path.join(RAIZ, "Dockerfile"), "utf8");
+    expect(dockerfile).toContain("ARG SOURCE_COMMIT");
+    // Con default vacío: quien construya sin pasarlo no debe ver un build roto.
+    expect(dockerfile).toMatch(/ARG SOURCE_COMMIT=""/);
+  });
+});
+
+describe("versionLabel", () => {
+  it("con commit muestra los dos; sin commit, solo la versión", async () => {
+    // El módulo lee `process.env` al importarse, así que cada caso necesita su
+    // propio import fresco.
+    process.env.NEXT_PUBLIC_APP_VERSION = "1.4.2";
+    process.env.NEXT_PUBLIC_BUILD_COMMIT = "8e62d0bdfe5a7fb";
+    const conCommit = await import(`@/lib/version?con=${Date.now()}`);
+    expect(conCommit.versionLabel()).toBe("v1.4.2 · 8e62d0b");
+
+    process.env.NEXT_PUBLIC_BUILD_COMMIT = "";
+    const sinCommit = await import(`@/lib/version?sin=${Date.now()}`);
+    expect(sinCommit.versionLabel()).toBe("v1.4.2");
+  });
+});


### PR DESCRIPTION
Hoy no hay forma de saber, desde la app, si un cambio ya se desplegó. Hay que ir
al servidor a comparar commits — y en la práctica nadie lo hace: se asume que sí
y se depura media hora un bug que ya estaba arreglado en un build que nunca
llegó.

## Dónde se ve

Abajo en la barra lateral, discreta pero siempre presente:

```
v1.1.0 · 8e62d0b
```

Y en el healthcheck, para confirmar un despliegue con un `curl` desde un script
o desde la plataforma de hosting, sin abrir la app ni iniciar sesión:

```bash
curl -s https://crm.tudominio.com/api/health
# {"ok":true,"version":"1.1.0","commit":"8e62d0b"}
```

## Cómo no puede mentir

Los dos valores se congelan al **construir** (`next.config.ts`), así que el
binario lleva dentro de qué código salió; nada en tiempo de ejecución puede
cambiarlos.

La versión sale de `package.json` y **no se duplica en ningún lado** — una
versión escrita a mano en el config es exactamente cómo se desincroniza, y hay
un test que se pone rojo si aparece un literal `x.y.z` ahí.

El commit lo inyecta Coolify solo. Con docker compose se pasa con
`--build-arg SOURCE_COMMIT=$(git rev-parse HEAD)`, y si falta se ve solo la
versión: `ARG SOURCE_COMMIT=""` para que nunca sea un error de build.

Los dos números hacen falta. El SemVer dice qué release es; el commit zanja el
caso de dos despliegues seguidos de `main` sin tocar la versión, que por SemVer
se ven idénticos.

## Política, en el README

| | Cuándo sube |
|---|---|
| **Mayor** | Hay que hacer algo a mano para actualizar (variable de entorno, migración, reconectar algo). |
| **Menor** | Funciones nuevas. Actualizar es redesplegar. |
| **Parche** | Arreglos. Actualizar es redesplegar. |

Redactada sobre lo que le importa a quien **opera** una instancia, no sobre el
tamaño del diff. Esta sale como `1.1.0`.

## Una decisión que quiero señalar

La versión viaja en `/api/health`, que es público. Es lo convencional y es lo
que vuelve verificable un despliegue desde un pipeline; el costo es que revela
la versión a quien pregunte. En un proyecto MIT con el código a la vista no me
parece un secreto que valga la pena guardar, pero es tu llamada — quitarlo es
borrar tres líneas.

## Verificación

```
pnpm typecheck   ✓
pnpm lint        ✓
pnpm test        ✓  225 pruebas, 33 archivos (4 nuevas)
pnpm build       ✓  con y sin SOURCE_COMMIT
```

| Guion (base fresca) | |
|---|---|
| `e2e-selftest.mjs` | 87/87 |
| `ficha-lead` · `bitacora-etapas` · `alta-manual` · `monto-pipeline` · `prioridad` | 13/13 · 19/19 · 14/14 · 14/14 · 13/13 |

Probado en el navegador con `SOURCE_COMMIT` puesto: la insignia muestra
`v1.1.0 · 8e62d0b` y el tooltip la frase completa.

**Un arreglo de camino:** la primera versión usaba `text-text-3` a 10px y daba
**3.22:1** contra el fondo de la barra — no pasa AA. Con `text-text-2` a 11px
queda en **7.03:1** en claro y **8.53:1** en oscuro. Discreta sí, ilegible no.

## Superficie

Sin migración, sin dependencias. Un archivo nuevo (`src/lib/version.ts`) y
cinco tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
