### PR TITLE
fix(versión): white-label en el tooltip y commit resuelto de la plataforma

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -5,6 +5,7 @@ import { getSessionOrNull } from "@/lib/auth/session";
 import { normalizeThemePreference, THEME_COOKIE } from "@/lib/theme";
 import { getBranding } from "@/server/branding";
 import { AppShell } from "@/components/app-shell";
+import { resolveBuildCommit } from "@/lib/version";
 
 export default async function AppLayout({
   children,
@@ -25,6 +26,8 @@ export default async function AppLayout({
       userName={authSession?.user.name ?? "Usuario"}
       role={session.role}
       theme={theme}
+      // Se resuelve aquí, en el servidor: el cliente no ve `SOURCE_COMMIT`.
+      commit={resolveBuildCommit()}
     >
       {children}
     </AppShell>

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,6 +1,6 @@
 import { sql } from "drizzle-orm";
 import { getDb } from "@/lib/db";
-import { APP_VERSION, BUILD_COMMIT } from "@/lib/version";
+import { APP_VERSION, resolveBuildCommit } from "@/lib/version";
 
 export const dynamic = "force-dynamic";
 
@@ -11,10 +11,11 @@ export async function GET() {
     // poder hacerse con un `curl`, desde un script o desde la plataforma de
     // hosting, sin abrir la app ni iniciar sesión. Es la única forma de que un
     // pipeline pueda comprobar que el build que subió es el que corre.
+    const commit = resolveBuildCommit();
     return Response.json({
       ok: true,
       version: APP_VERSION,
-      ...(BUILD_COMMIT ? { commit: BUILD_COMMIT } : {}),
+      ...(commit ? { commit } : {}),
     });
   } catch {
     return Response.json(

--- a/src/components/app-nav.tsx
+++ b/src/components/app-nav.tsx
@@ -191,12 +191,15 @@ export function AppNav({
           alguien a comparar commits en el servidor significa que no lo hará. */}
       {/* `text-2` y no `text-3`: a 11px, el gris más claro se queda en 3.2:1
           contra el fondo de la barra y no pasa AA. Discreta sí, ilegible no. */}
+      {/* El nombre sale de la marca, no de una constante: esto es white-label,
+          y una instancia rebautizada que dice "Vocero" en el tooltip delata el
+          producto de debajo justo donde el operador la mira todos los días. */}
       <p
         className="mt-1.5 px-2.5 text-[11px] tabular-nums text-text-2"
         title={
           BUILD_COMMIT
-            ? `Vocero ${APP_VERSION}, construido del commit ${BUILD_COMMIT}`
-            : `Vocero ${APP_VERSION}`
+            ? `${branding.name} ${APP_VERSION}, construido del commit ${BUILD_COMMIT}`
+            : `${branding.name} ${APP_VERSION}`
         }
       >
         {versionLabel()}

--- a/src/components/app-nav.tsx
+++ b/src/components/app-nav.tsx
@@ -34,6 +34,7 @@ export function AppNav({
   userName,
   role,
   theme,
+  commit,
   open = false,
   onClose,
 }: {
@@ -41,6 +42,11 @@ export function AppNav({
   userName: string;
   role: string;
   theme: ThemePreference;
+  /**
+   * Commit resuelto en el servidor. Gana al de build porque puede venir de la
+   * plataforma cuando quien construyó no lo pasó como build-arg.
+   */
+  commit?: string;
   /** Solo aplica por debajo de `lg`: en escritorio el lateral es fijo. */
   open?: boolean;
   onClose?: () => void;
@@ -66,6 +72,8 @@ export function AppNav({
     onMessageNew: () => void refetchUnread(),
     onConversationUpdated: () => void refetchUnread(),
   });
+
+  const sha = commit || BUILD_COMMIT;
 
   return (
     <aside
@@ -197,12 +205,12 @@ export function AppNav({
       <p
         className="mt-1.5 px-2.5 text-[11px] tabular-nums text-text-2"
         title={
-          BUILD_COMMIT
-            ? `${branding.name} ${APP_VERSION}, construido del commit ${BUILD_COMMIT}`
+          sha
+            ? `${branding.name} ${APP_VERSION}, construido del commit ${sha}`
             : `${branding.name} ${APP_VERSION}`
         }
       >
-        {versionLabel()}
+        {versionLabel(sha)}
       </p>
     </aside>
   );

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -24,12 +24,15 @@ export function AppShell({
   userName,
   role,
   theme,
+  commit,
   children,
 }: {
   branding: Branding;
   userName: string;
   role: string;
   theme: ThemePreference;
+  /** Commit resuelto en el servidor (build-arg o variable de la plataforma). */
+  commit?: string;
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
@@ -63,6 +66,7 @@ export function AppShell({
 
       <AppNav
         branding={branding}
+        commit={commit}
         userName={userName}
         role={role}
         theme={theme}

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -24,7 +24,26 @@ export const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? "0.0.0";
  */
 export const BUILD_COMMIT = (process.env.NEXT_PUBLIC_BUILD_COMMIT ?? "").slice(0, 7);
 
-/** `v1.1.0 · 8e62d0b`, o solo `v1.1.0` si no hubo commit al construir. */
-export function versionLabel(): string {
-  return BUILD_COMMIT ? `v${APP_VERSION} · ${BUILD_COMMIT}` : `v${APP_VERSION}`;
+/**
+ * Commit resuelto EN EL SERVIDOR.
+ *
+ * Primero el que se congeló al construir; si quien construyó no lo pasó, el que
+ * la plataforma anuncia en tiempo de ejecución. Coolify, por ejemplo, publica
+ * `SOURCE_COMMIT` en el contenedor pero no siempre lo inyecta como build-arg:
+ * sin este respaldo, la insignia enseñaría solo la versión — que no se mueve
+ * entre despliegues del mismo release y por tanto no responde la pregunta.
+ *
+ * Solo tiene sentido llamarla desde el servidor: en el cliente, `process.env`
+ * únicamente lleva las variables `NEXT_PUBLIC_`.
+ */
+export function resolveBuildCommit(): string {
+  return BUILD_COMMIT || (process.env.SOURCE_COMMIT ?? "").slice(0, 7);
+}
+
+/**
+ * `v1.1.0 · 8e62d0b`, o solo `v1.1.0` si no hay commit por ningún lado.
+ * El `commit` se pasa cuando lo resolvió el servidor.
+ */
+export function versionLabel(commit: string = BUILD_COMMIT): string {
+  return commit ? `v${APP_VERSION} · ${commit}` : `v${APP_VERSION}`;
 }

--- a/tests/unit/version.test.ts
+++ b/tests/unit/version.test.ts
@@ -49,6 +49,38 @@ describe("versión de la app", () => {
 });
 
 describe("versionLabel", () => {
+  it("resuelve el commit de la plataforma cuando el build no lo trajo", async () => {
+    // El caso real: Coolify publica `SOURCE_COMMIT` en el contenedor pero no
+    // siempre lo inyecta como build-arg. Sin este respaldo la insignia enseña
+    // solo la versión, que no se mueve entre despliegues del mismo release —
+    // justo la pregunta que venía a contestar.
+    process.env.NEXT_PUBLIC_APP_VERSION = "1.4.2";
+    process.env.NEXT_PUBLIC_BUILD_COMMIT = "";
+    process.env.SOURCE_COMMIT = "abcdef1234567890";
+    const m = await import(`@/lib/version?plat=${Date.now()}`);
+    expect(m.resolveBuildCommit()).toBe("abcdef1");
+    expect(m.versionLabel(m.resolveBuildCommit())).toBe("v1.4.2 · abcdef1");
+  });
+
+  it("el del build MANDA sobre el de la plataforma", async () => {
+    // Si los dos existen, el congelado en la imagen es el que de verdad
+    // corresponde al código que corre.
+    process.env.NEXT_PUBLIC_APP_VERSION = "1.4.2";
+    process.env.NEXT_PUBLIC_BUILD_COMMIT = "1111111aaaa";
+    process.env.SOURCE_COMMIT = "2222222bbbb";
+    const m = await import(`@/lib/version?both=${Date.now()}`);
+    expect(m.resolveBuildCommit()).toBe("1111111");
+  });
+
+  it("sin ninguno de los dos, solo la versión", async () => {
+    process.env.NEXT_PUBLIC_APP_VERSION = "1.4.2";
+    process.env.NEXT_PUBLIC_BUILD_COMMIT = "";
+    delete process.env.SOURCE_COMMIT;
+    const m = await import(`@/lib/version?none=${Date.now()}`);
+    expect(m.resolveBuildCommit()).toBe("");
+    expect(m.versionLabel(m.resolveBuildCommit())).toBe("v1.4.2");
+  });
+
   it("con commit muestra los dos; sin commit, solo la versión", async () => {
     // El módulo lee `process.env` al importarse, así que cada caso necesita su
     // propio import fresco.

--- a/tests/unit/version.test.ts
+++ b/tests/unit/version.test.ts
@@ -27,6 +27,19 @@ describe("versión de la app", () => {
     expect(config).not.toMatch(/["']\d+\.\d+\.\d+["']/);
   });
 
+  it("la insignia no cablea el nombre del producto", () => {
+    // Esto es white-label: una instancia rebautizada que dice "Vocero" en el
+    // tooltip delata el producto de debajo justo donde el operador la mira
+    // todos los días.
+    const nav = readFileSync(
+      path.join(RAIZ, "src", "components", "app-nav.tsx"),
+      "utf8"
+    );
+    const insignia = nav.slice(nav.indexOf("versionLabel()") - 600);
+    expect(insignia).toContain("branding.name");
+    expect(insignia).not.toMatch(/`Vocero \$\{/);
+  });
+
   it("el Dockerfile acepta el commit sin exigirlo", () => {
     const dockerfile = readFileSync(path.join(RAIZ, "Dockerfile"), "utf8");
     expect(dockerfile).toContain("ARG SOURCE_COMMIT");


### PR DESCRIPTION
Dos arreglos que empujé al #28 **después** de que se mergeara, así que no entraron. GitHub no corre CI sobre una rama cuyo PR ya está cerrado, y por eso tampoco avisó.

## 1. El tooltip cableaba "Vocero"

`Vocero 1.1.0, construido del commit …` con el nombre fijo. En un CRM white-label eso delata el producto de debajo justo donde el operador lo mira todos los días: la instancia se llama como su negocio en toda la app, menos ahí. Sale de `branding.name`, con un test que se pone rojo si alguien lo recablea.

## 2. El commit solo salía del build

Lo descubrí desplegando esto en una instancia real de Coolify: `/api/health` devolvió `{"ok":true,"version":"1.0.0"}` — **sin commit**. Coolify publica `SOURCE_COMMIT` en el contenedor pero no lo inyecta como build-arg.

Degradaba como estaba previsto, pero se perdía la mitad que importa: `version` no se mueve entre despliegues del mismo release, así que sin el commit la insignia no responde "¿ya subió MI cambio?".

Ahora el servidor lo resuelve: primero el del build y, si no lo hubo, el de la plataforma. El del build manda cuando existen los dos, porque ése corresponde con certeza al código que corre. Va como prop desde el layout: en el cliente `process.env` solo lleva variables `NEXT_PUBLIC_`.

## Verificación

Con el escenario real —**construir sin** la variable y **arrancar con** ella— la insignia da `v1.1.0 · deadbee` y el health `{"ok":true,"version":"1.1.0","commit":"deadbee"}`. Tres pruebas nuevas cubren los tres casos: solo plataforma, ambos (gana el del build), ninguno.

Ya está corriendo en producción en una instancia derivada, que es donde salió el fallo.

Gates: typecheck, lint, **229 pruebas**, build. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)