### PR TITLE
chore: 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vocero-crm",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "CRM de WhatsApp open source y self-hosted con agente de IA y Laboratorio de auto-evaluación",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Desde `1.1.0` entraron el **cajón del trato** en el Pipeline (#29) y el **icono de la pestaña** configurable (#30).

Menor y no parche, según la tabla del README: son funciones nuevas y actualizar es solo redesplegar — nadie tiene que tocar una variable ni migrar datos.

Una línea en `package.json`. La insignia y `/api/health` la toman de ahí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)