### PR TITLE
docs(specs): decir la verdad sobre dónde vive la especificación

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -1,22 +1,53 @@
 # specs/
 
-Aquí aterriza el trabajo SDD. Cada feature crea su propia carpeta numerada:
+Especificaciones de Vocero CRM. **Esta carpeta no es el mapa completo del
+producto** — y saberlo antes de leerla ahorra una confusión.
 
-```
-specs/
-└─ NNN-nombre-feature/
-   ├─ spec.md         # QUÉ y POR QUÉ (comportamiento observable, sin implementación)
-   ├─ plan.md         # CÓMO (decisiones técnicas, Constitution Check)
-   ├─ research.md     # decisiones a verificar (DV-...) y su resolución
-   ├─ data-model.md   # entidades y relaciones
-   ├─ contracts/      # contratos de API/endpoints
-   ├─ quickstart.md   # cómo probar la feature
-   ├─ checklists/     # checklists de calidad
-   └─ tasks.md        # tareas dependency-ordered (tu estado durable)
-```
+## Qué hay aquí
 
-No crees estas carpetas a mano: las generan los comandos de Spec Kit
-(`/speckit-specify`, `/speckit-plan`, `/speckit-tasks`). El número `NNN` lo asigna
-`/speckit-git-feature` (o el script `create-new-feature.ps1`).
+| | Carril | Artefactos |
+|---|---|---|
+| `001-vocero-core` | Ciclo completo | spec, plan, research, data-model, 5 contratos, tasks, checklist |
+| `002-diseno-atlas-white-label` | — | spec + plan |
+| `003-paridad-inbox-whatsapp` | — | spec |
 
-Ver [../docs/sdd-workflow.md](../docs/sdd-workflow.md).
+Los tres carriles —ciclo completo, ligero y exento— están definidos en el
+[Principio VI de la constitución](../.specify/memory/constitution.md). El
+criterio no es el tamaño de la feature: es si toca el **modelo de datos** o un
+**contrato publicado**.
+
+Lo que se ve arriba es esa gradación en la práctica, antes de que estuviera
+escrita: `001` era el producto entero y llevó el ciclo completo; los siguientes
+fueron acotándose.
+
+## Dónde está el resto
+
+Entre `003` y la versión 1.2.0 de la app entraron doce features con
+comportamiento observable —la API de servicio para un cerebro externo, bitácora
+de etapas, alta manual de prospectos, monto, prioridad, ficha del lead, tema
+oscuro, responsividad, plantillas multivariable, envío instantáneo, icono de la
+pestaña y versión visible— **sin spec en esta carpeta**. Se implementaron antes
+de que el Principio VI tuviera un carril intermedio, y esa es la razón, no una
+excusa.
+
+Su comportamiento sí está especificado, en dos sitios mejores que un documento
+escrito a posteriori:
+
+- **[`tests/e2e/`](../tests/e2e/)** — el comportamiento observable, con sus
+  criterios de aceptación. A diferencia de un spec, estos guiones **se
+  ejecutan**: cada uno tiene su `scripts/e2e-*.mjs` o se conduce con Playwright.
+  Si el código deja de cumplirlos, se pone rojo.
+- **El historial de PRs** — el problema que resolvía cada feature, las
+  decisiones de diseño con su motivo, y qué se descartó y por qué.
+
+No se van a escribir specs retroactivos para esas trece. Serían una cuarta copia
+de algo ya documentado, y la única que nadie ejecuta: la que envejece hasta
+contradecir a las otras tres, con el agravante de estar en la carpeta donde uno
+espera encontrar la verdad.
+
+## De aquí en adelante
+
+Toda feature declara su carril **antes** de escribir código y deja su `spec.md`
+aquí, ciclo completo o ligero. Un spec escrito después de implementar se marca
+como tal en su encabezado: es documentación, no diseño, y confundirlos hace
+creer dentro de un año que esas decisiones se tomaron antes de programar.

--- a/tests/e2e/us-diseno-atlas.md
+++ b/tests/e2e/us-diseno-atlas.md
@@ -23,27 +23,70 @@
 9. Unit tests: presets exactos, derivación de color personalizado con ajuste
    de contraste, normalización (vacío→default, hex inválido→default). ✅
 
+## Tema oscuro
+
+Conducido con Playwright (MCP). La preferencia es **por dispositivo** (cookie),
+no por cuenta: quien trabaja de noche en su portátil y de día en la oficina no
+quiere arrastrar la misma elección a los dos sitios.
+
+10. **Alternar desde la barra lateral** cambia el tema y persiste al recargar.
+    ✅ Sin parpadeo: el layout raíz escribe `data-theme` en el HTML del
+    servidor, así que el tema ya viene resuelto en el primer byte. Resolverlo en
+    el cliente daría un destello blanco en cada carga, que en una app que se usa
+    de noche es exactamente lo que se venía a evitar.
+11. **El acento de la marca se aclara en oscuro.** Los presets están calculados
+    para fondo claro y sobre el fondo oscuro se hunden.
+    ✅ `resolveAccentSet(hex, "dark")` sube el color hasta **≥ 3.5:1** contra el
+    fondo del tema, y las variantes soft/tint se mezclan hacia el fondo oscuro,
+    no hacia blanco.
+    ✅ Sobre un acento ya aclarado, la tinta encima deja de ser blanca cuando no
+    se leería (`fg` cae a oscuro bajo 3:1).
+12. **Los dos temas viajan en el mismo CSS.** El servidor no siempre sabe cuál
+    se resolverá (preferencia "sistema"), así que emite ambos bloques.
+    ✅ Texto y superficies usan tokens semánticos, no colores sueltos: cambiar
+    de tema no deja ningún elemento con el color del otro.
+
+## Versión visible
+
+Automatizado en `tests/unit/version.test.ts`; la parte de despliegue se verifica
+con un `curl`. Responde "¿ya se desplegó mi cambio?" sin entrar al servidor.
+
+13. **Abajo en la barra lateral**: `v1.2.0 · 8e62d0b`.
+    ✅ El nombre del tooltip sale de la **marca**, no cableado: una instancia
+    rebautizada no debe decir "Vocero" justo ahí.
+    ✅ Contraste ≥ 4.5:1 en claro y en oscuro — discreta, no ilegible.
+14. **También en `/api/health`**, para confirmar un despliegue desde un script o
+    desde la plataforma de hosting, sin abrir la app ni iniciar sesión.
+    ✅ `{"ok":true,"version":"1.2.0","commit":"8e62d0b"}`.
+15. **El commit se resuelve por dos caminos.** El del build manda; si quien
+    construyó no lo pasó, vale el que la plataforma anuncia en ejecución.
+    ✅ Construir SIN `SOURCE_COMMIT` y arrancar CON él en el entorno enseña el
+    commit igual. Coolify hace exactamente eso, y sin este respaldo la insignia
+    se quedaba solo con la versión — que no se mueve entre despliegues del mismo
+    release, y por tanto no contesta la pregunta.
+    ✅ Sin ninguno de los dos, se ve solo la versión. Nunca rompe el build.
+
 ## Icono de la pestaña
 
 Automatizado en `scripts/e2e-favicon.mjs`. Con cinco instancias abiertas en
 pestañas, el icono genérico del navegador las vuelve indistinguibles.
 
-10. **Toda instancia tiene icono sin configurar nada.**
+16. **Toda instancia tiene icono sin configurar nada.**
     ✅ `GET /api/branding/favicon` devuelve un SVG con la inicial sobre el
     acento, y responde **sin sesión** — el login también tiene pestaña.
     ✅ Si el archivo subido se perdiera (volumen sin montar), cae al generado
     en vez de dejar la pestaña vacía: un 404 ahí se ve como instancia rota.
-11. **El dueño sube su logo** en Ajustes → Marca (PNG, SVG, ICO, JPEG, WebP).
+17. **El dueño sube su logo** en Ajustes → Marca (PNG, SVG, ICO, JPEG, WebP).
     ✅ Se sirve byte por byte con su tipo real.
     ✅ Se puede **quitar** y volver al generado.
     ✅ Guardar nombre o color **no** borra el logo: son formularios distintos.
-12. **No se cuela un documento disfrazado de imagen.** El tipo sale de los
+18. **No se cuela un documento disfrazado de imagen.** El tipo sale de los
     BYTES, no del `content-type` que declare el cliente.
     ✅ Declarar `image/png` y mandar HTML → **422**, y el icono bueno intacto.
     ✅ Más de 256 KB → **413**. Cuerpo vacío → **422**.
     ✅ Todo icono se sirve con `Content-Security-Policy: default-src 'none'` y
     `nosniff`: un SVG subido no ejecuta nada si alguien navega a su URL.
-13. **El navegador suelta el icono viejo.** La URL lleva `?v=`.
+19. **El navegador suelta el icono viejo.** La URL lleva `?v=`.
     ✅ Cambia al subir, al quitar y al cambiar nombre o acento.
     ✅ Quitar y volver a subir **no repite** una URL ya cacheada.
 


### PR DESCRIPTION
`specs/` tiene 001, 002 y 003, y **se lee como el mapa del producto**. No lo es: entre la 003 y la app 1.2.0 entraron doce features con comportamiento observable que no tienen spec ahí. Ya hay dos colaboradores externos navegando este repo.

## Lo que hace

Un `specs/README.md` de ~390 palabras que dice qué hay, con qué carril se hizo cada uno, y **dónde está el resto**: en [`tests/e2e/`](../tests/e2e/) —que a diferencia de un spec **se ejecuta**— y en el historial de PRs.

Y deja escrito que **no se escribirán specs retroactivos** para esas doce, con el motivo: serían una cuarta copia de algo ya documentado, y la única que nadie corre. Esa es la que envejece hasta contradecir a las otras tres, con el agravante de vivir en la carpeta donde uno espera encontrar la verdad.

## Lo que salió al escribirlo

La afirmación "su comportamiento sí está especificado" **no era cierta del todo**. Fui a comprobarla y dos features no tenían guion en ningún sitio:

- **tema oscuro** (#16)
- **versión visible** (#28)

Ahora lo tienen, en `us-diseno-atlas.md`, con los hechos verificados leyendo el código y no de memoria: preferencia por dispositivo en cookie, `data-theme` escrito en SSR para que no haya destello, acento aclarado hasta **≥3.5:1** contra el fondo oscuro con las variantes mezcladas hacia ese fondo, y el commit resuelto por build **o** por la plataforma.

Sin eso, este PR habría puesto en el repo una afirmación falsa — y en el archivo cuyo único trabajo es decir dónde está la verdad.

## Superficie

Dos archivos de documentación. Sin código. Gates en verde por higiene: 246 pruebas, typecheck, lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)