### PR TITLE
feat(014): canal de Instagram, opcional por bandera

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,13 @@ META_GRAPH_API_VERSION=v25.0
 # Modelo del juez del Laboratorio (si se omite, usa el principal)
 # OPENROUTER_JUDGE_MODEL=
 
+# --- Canales (opcional) -------------------------------------
+# Canales encendidos, separados por coma. WhatsApp siempre esta activo.
+# Sin esta variable la instancia es solo WhatsApp: las pantallas y webhooks
+# de los demas canales responden 404 y no se piden sus credenciales.
+# Para encender Instagram (ver README - Conexion de Instagram):
+# CHANNELS=whatsapp,instagram
+
 # --- Operación (opcional) -----------------------------------
 # Reabrir el registro público después de la primera organización.
 # ALLOW_SIGNUP=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# eslint-config-next referencia sus plugins por nombre, y el arbol estricto de
+# pnpm no los expone en la raiz: sin esto `pnpm lint` falla nada mas clonar con
+# "couldn't find the plugin", que es un gate que en la practica nadie corre.
+# El patron con scope hace falta aparte: *eslint* no cubre @next/eslint-plugin-next.
+public-hoist-pattern[]=*eslint*
+public-hoist-pattern[]=@next/*

--- a/docs/adr-001-canales-opcionales.md
+++ b/docs/adr-001-canales-opcionales.md
@@ -1,0 +1,88 @@
+# ADR-001 — Los canales opcionales viven en main, apagados por bandera
+
+**Estado**: aceptado · **Fecha**: 2026-08-25 · **Contexto**: feature 014 (canal de Instagram)
+
+## El problema
+
+Vocero debe seguir siendo una herramienta ligera: quien lo instala para un
+negocio que solo vende por WhatsApp no debería ver pantallas, variables ni
+conceptos de canales que no usa. Pero un cliente que sí quiere Instagram debe
+poder tenerlo rápido, sin que su instancia se convierta en un fork.
+
+## Lo que se descartó, y por qué
+
+**Una skill que modifica el código fuente bajo demanda.** Es un parche contra
+un blanco móvil: codifica formas exactas del código, así que cada refactor en
+main la rompe sin que ningún CI lo note. Produce salidas distintas en cada
+instalación, lo que hace irreproducibles los reportes de bugs. Y deja al
+usuario con conflictos de merge en los archivos parcheados cada vez que
+actualiza.
+
+**Una rama por feature opcional.** El costo obvio es mantener cada rama
+compatible con main; el que hunde es que las ramas tienen que ser compatibles
+**entre ellas**. Dos features opcionales que tocan `send.ts` e `ingest.ts`
+chocan entre sí, y la combinación que un usuario quiere es un artefacto que
+nadie ha probado. Con 3 features opcionales hay 7 combinaciones posibles; con
+5, treinta y una.
+
+Y ambas comparten un problema sin solución limpia: **la cadena de migraciones
+de Drizzle es lineal y hasheada**. Dos ramas que agregan un `0008_` no pueden
+coexistir sin renumerar, lo que convierte el merge en algo que no es mecánico.
+
+## La decisión
+
+El código de todos los canales viaja en main. Lo que decide si un canal existe
+para el usuario es la variable de entorno `CHANNELS` (default: `whatsapp`).
+
+Con el canal apagado:
+
+- `/api/settings/<canal>` responde 404
+- `/api/webhooks/<canal>/*` responde 404
+- la salida por ese canal falla con un error claro
+- no se piden variables ni credenciales suyas
+
+La migración se aplica **siempre**. Una columna con default y una tabla vacía
+son inertes, y a cambio todas las instancias del mundo tienen exactamente la
+misma estructura de base de datos: una sola cadena de migraciones, y bugs
+reproducibles.
+
+El concepto de "canal" en el núcleo no es "la feature multicanal": es modelar
+bien. Un CRM de mensajería tiene canales aunque hoy solo uno esté habilitado.
+
+## Lo que esto no resuelve
+
+Las banderas no eliminan la combinatoria: con N banderas siguen existiendo 2^N
+configuraciones y no se prueban todas. Lo que cambia es **dónde se paga**:
+
+| | Ramas | Banderas |
+|---|---|---|
+| Quién resuelve el conflicto | cada usuario, en cada release | el autor, una vez, al mergear |
+| Un refactor de `send.ts` | rompe N ramas en silencio | actualiza todos los caminos a la vez |
+| Cadena de migraciones | una por rama, irreconciliables | una sola |
+| Combinación no probada | build roto o merge imposible | un bug reproducible, en un artefacto que existe |
+
+CI corre la suite con la bandera apagada y encendida. No cubre 2^N, cubre lo
+que la gente usa — y con ramas no habría dónde poner esa prueba.
+
+## Consecuencias
+
+- El núcleo no puede saber las reglas de un canal concreto: las pregunta a
+  `src/server/channels/capabilities.ts`. La ventana, las plantillas, el límite
+  de texto y los acuses de entrega se declaran por canal.
+- Agregar un canal es escribir su adaptador y declarar sus capacidades.
+- main carga código que no todas las instancias usan. Es el costo aceptado; se
+  paga igual desde el momento en que la feature debe existir y funcionar, y la
+  alternativa es pagarlo en soporte a instancias irreproducibles.
+
+## Cuándo revisar esta decisión
+
+Cuando haya del orden de quince banderas, o cuando terceros necesiten publicar
+canales sin pasar por el repo. Ahí toca extraer una interfaz de adaptador y
+paquetes versionados. Construir eso para un solo canal opcional sería
+adelantarse.
+
+**Nota sobre "plugin"**: en Vocero significa *rápido de contribuir y de
+encender*, no *cargable en runtime desde cualquier lado*. Código de terceros
+corriendo en el proceso tendría acceso a la base y podría leer descifrados los
+tokens de WhatsApp de todos los clientes. Ese modelo de amenaza es otro, y no
+se abre esa puerta.

--- a/drizzle/0008_canal_instagram.sql
+++ b/drizzle/0008_canal_instagram.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS "instagram_credentials" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"source" text NOT NULL,
+	"ig_user_id" text NOT NULL,
+	"account_ref" text,
+	"username" text,
+	"token_cipher" text NOT NULL,
+	"token_iv" text NOT NULL,
+	"token_tag" text NOT NULL,
+	"webhook_secret" text,
+	"status" text DEFAULT 'connected' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "contact" ADD COLUMN "channel" text DEFAULT 'whatsapp' NOT NULL;--> statement-breakpoint
+ALTER TABLE "conversation" ADD COLUMN "channel" text DEFAULT 'whatsapp' NOT NULL;--> statement-breakpoint
+ALTER TABLE "conversation" ADD COLUMN "channel_thread_ref" text;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "instagram_credentials" ADD CONSTRAINT "instagram_credentials_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DROP INDEX IF EXISTS "contact_org_wa_identity_uq";--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "contact_org_channel_identity_uq" ON "contact" USING btree ("organization_id","channel","wa_identity");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "instagram_credentials_org_uq" ON "instagram_credentials" USING btree ("organization_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "instagram_credentials_ig_user_uq" ON "instagram_credentials" USING btree ("ig_user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "instagram_credentials_account_ref_idx" ON "instagram_credentials" USING btree ("account_ref");

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,2605 @@
+{
+  "id": "a0eeb00d-456e-43de-8fa9-471f3676d054",
+  "prevId": "e3ece8e8-09fd-474a-a25c-254150b3e735",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_profile": {
+      "name": "agent_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asistente'"
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalation_rules": {
+          "name": "escalation_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_profile_org_uq": {
+          "name": "agent_profile_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_profile_organization_id_organization_id_fk": {
+          "name": "agent_profile_organization_id_organization_id_fk",
+          "tableFrom": "agent_profile",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_case": {
+      "name": "agent_test_case",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "veredicto": {
+          "name": "veredicto",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hallazgos": {
+          "name": "hallazgos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_case_run_idx": {
+          "name": "test_case_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_case_organization_id_organization_id_fk": {
+          "name": "agent_test_case_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_run_id_agent_test_run_id_fk": {
+          "name": "agent_test_case_run_id_agent_test_run_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "agent_test_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_conversation_id_conversation_id_fk": {
+          "name": "agent_test_case_conversation_id_conversation_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_run": {
+      "name": "agent_test_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "test_run_org_running_uq": {
+          "name": "test_run_org_running_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_test_run\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_run_org_idx": {
+          "name": "test_run_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_run_organization_id_organization_id_fk": {
+          "name": "agent_test_run_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact": {
+      "name": "contact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'whatsapp'"
+        },
+        "wa_identity": {
+          "name": "wa_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_user_id": {
+          "name": "wa_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ficha": {
+          "name": "ficha",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_org_channel_identity_uq": {
+          "name": "contact_org_channel_identity_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_wa_user_id_idx": {
+          "name": "contact_org_wa_user_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_name_idx": {
+          "name": "contact_org_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_organization_id_organization_id_fk": {
+          "name": "contact_organization_id_organization_id_fk",
+          "tableFrom": "contact",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_test": {
+          "name": "is_test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'whatsapp'"
+        },
+        "channel_thread_ref": {
+          "name": "channel_thread_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_enabled": {
+          "name": "ai_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handoff_at": {
+          "name": "handoff_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_reason": {
+          "name": "handoff_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_inbound_at": {
+          "name": "last_inbound_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_org_contact_real_uq": {
+          "name": "conversation_org_contact_real_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation\".\"is_test\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_org_last_idx": {
+          "name": "conversation_org_last_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_organization_id_organization_id_fk": {
+          "name": "conversation_organization_id_organization_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_contact_id_contact_id_fk": {
+          "name": "conversation_contact_id_contact_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instagram_credentials": {
+      "name": "instagram_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ig_user_id": {
+          "name": "ig_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_ref": {
+          "name": "account_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_cipher": {
+          "name": "token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instagram_credentials_org_uq": {
+          "name": "instagram_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instagram_credentials_ig_user_uq": {
+          "name": "instagram_credentials_ig_user_uq",
+          "columns": [
+            {
+              "expression": "ig_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instagram_credentials_account_ref_idx": {
+          "name": "instagram_credentials_account_ref_idx",
+          "columns": [
+            {
+              "expression": "account_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instagram_credentials_organization_id_organization_id_fk": {
+          "name": "instagram_credentials_organization_id_organization_id_fk",
+          "tableFrom": "instagram_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_entry": {
+      "name": "kb_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kb_org_idx": {
+          "name": "kb_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_entry_organization_id_organization_id_fk": {
+          "name": "kb_entry_organization_id_organization_id_fk",
+          "tableFrom": "kb_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead": {
+      "name": "lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_updated_at": {
+          "name": "priority_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lead_contact_uq": {
+          "name": "lead_contact_uq",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lead_org_stage_idx": {
+          "name": "lead_org_stage_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_organization_id_organization_id_fk": {
+          "name": "lead_organization_id_organization_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_contact_id_contact_id_fk": {
+          "name": "lead_contact_id_contact_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead_stage_event": {
+      "name": "lead_stage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_stage_id": {
+          "name": "from_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_stage_name": {
+          "name": "from_stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage_id": {
+          "name": "to_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage_name": {
+          "name": "to_stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_stage_kind": {
+          "name": "to_stage_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dueno'"
+        },
+        "approximate": {
+          "name": "approximate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "loss_reason": {
+          "name": "loss_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loss_note": {
+          "name": "loss_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lse_org_occurred_idx": {
+          "name": "lse_org_occurred_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lse_lead_occurred_idx": {
+          "name": "lse_lead_occurred_idx",
+          "columns": [
+            {
+              "expression": "lead_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lse_org_kind_occurred_idx": {
+          "name": "lse_org_kind_occurred_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_stage_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_stage_event_organization_id_organization_id_fk": {
+          "name": "lead_stage_event_organization_id_organization_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_lead_id_lead_id_fk": {
+          "name": "lead_stage_event_lead_id_lead_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "lead",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_contact_id_contact_id_fk": {
+          "name": "lead_stage_event_contact_id_contact_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_from_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_event_from_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "from_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_to_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_event_to_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "to_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_actor_user_id_user_id_fk": {
+          "name": "lead_stage_event_actor_user_id_user_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lse_loss_reason_ck": {
+          "name": "lse_loss_reason_ck",
+          "value": "\"lead_stage_event\".\"to_stage_kind\" <> 'lost' OR \"lead_stage_event\".\"approximate\" = true OR \"lead_stage_event\".\"loss_reason\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_asset": {
+      "name": "media_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_media_id": {
+          "name": "wa_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_status": {
+          "name": "fetch_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_asset_org_idx": {
+          "name": "media_asset_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_asset_wa_media_idx": {
+          "name": "media_asset_wa_media_idx",
+          "columns": [
+            {
+              "expression": "wa_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_asset_organization_id_organization_id_fk": {
+          "name": "media_asset_organization_id_organization_id_fk",
+          "tableFrom": "media_asset",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_message_id": {
+          "name": "wa_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated": {
+          "name": "ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'operator'"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_timestamp": {
+          "name": "wa_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_org_conv_idx": {
+          "name": "message_org_conv_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_organization_id_organization_id_fk": {
+          "name": "message_organization_id_organization_id_fk",
+          "tableFrom": "message",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_media_asset_id_media_asset_id_fk": {
+          "name": "message_media_asset_id_media_asset_id_fk",
+          "tableFrom": "message",
+          "tableTo": "media_asset",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_wa_message_id_unique": {
+          "name": "message_wa_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wa_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_credentials": {
+      "name": "meta_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waba_id": {
+          "name": "waba_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number_id": {
+          "name": "phone_number_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_phone_number": {
+          "name": "display_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_name": {
+          "name": "verified_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_cipher": {
+          "name": "token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meta_credentials_org_uq": {
+          "name": "meta_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meta_credentials_phone_uq": {
+          "name": "meta_credentials_phone_uq",
+          "columns": [
+            {
+              "expression": "phone_number_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meta_credentials_organization_id_organization_id_fk": {
+          "name": "meta_credentials_organization_id_organization_id_fk",
+          "tableFrom": "meta_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_stage": {
+      "name": "pipeline_stage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stage_org_pos_idx": {
+          "name": "stage_org_pos_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_stage_organization_id_organization_id_fk": {
+          "name": "pipeline_stage_organization_id_organization_id_fk",
+          "tableFrom": "pipeline_stage",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_template_id": {
+          "name": "wa_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_org_name_lang_uq": {
+          "name": "template_org_name_lang_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_organization_id_organization_id_fk": {
+          "name": "template_organization_id_organization_id_fk",
+          "tableFrom": "template",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1786856261073,
       "tag": "0007_confused_zaran",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1787000000000,
+      "tag": "0008_canal_instagram",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
+    "@next/eslint-plugin-next": "^15.5.20",
     "@types/node": "^22.10.5",
     "@types/react": "^19.0.2",
     "@types/react-dom": "^19.0.2",
@@ -48,6 +49,7 @@
     "esbuild": "^0.24.2",
     "eslint": "^9.17.0",
     "eslint-config-next": "^15.1.3",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "playwright": "^1.61.1",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3.2.0
         version: 3.3.5
+      '@next/eslint-plugin-next':
+        specifier: ^15.5.20
+        version: 15.5.20
       '@types/node':
         specifier: ^22.10.5
         version: 22.20.1
@@ -78,6 +81,9 @@ importers:
       eslint-config-next:
         specifier: ^15.1.3
         version: 15.5.20(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      eslint-plugin-react-hooks:
+        specifier: ^5.2.0
+        version: 5.2.0(eslint@9.39.4(jiti@1.21.7))
       playwright:
         specifier: ^1.61.1
         version: 1.61.1
@@ -2104,6 +2110,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'

--- a/specs/014-canal-instagram/spec.md
+++ b/specs/014-canal-instagram/spec.md
@@ -1,0 +1,71 @@
+# 014 — Canal de Instagram en la bandeja
+
+**Carril**: ciclo completo. Criterio objetivo de la constitución (Principio VI):
+toca el modelo de datos (migración) **y** un contrato publicado
+(`/api/bot/context`, que expone `waIdentity`).
+
+## Problema
+
+Vocero es WhatsApp puro en el modelo de datos, no solo en la UI:
+`contact.wa_identity` es NOT NULL y único por organización, `conversation` no
+tiene canal, la ingesta solo entiende `whatsapp_business_account` y la salida
+va siempre a `POST /{phone_number_id}/messages`. Un negocio que vende por
+WhatsApp **y** por Instagram tiene que vivir en dos pantallas, y el pipeline,
+la ficha y el agente solo ven la mitad de sus conversaciones.
+
+## Escenarios
+
+1. **Recibir**: un cliente manda un DM al perfil de Instagram del negocio; el
+   mensaje aparece en la bandeja de Vocero en segundos, con su distintivo de
+   canal, creando contacto y conversación si no existían.
+2. **Responder**: el operador responde desde la misma bandeja y el mensaje
+   llega al DM.
+3. **Convivir**: un WhatsApp al número de la misma instancia sigue entrando y
+   saliendo igual que antes, sin regresión.
+4. **Reconocer**: el operador distingue de un vistazo qué conversación es de
+   qué canal.
+
+## Requisitos
+
+- **FR-101** El contacto y la conversación llevan canal (`whatsapp` |
+  `instagram`), con `whatsapp` por defecto para todo lo existente.
+- **FR-102** La identidad de un contacto de Instagram es su IGSID, guardada
+  como `ig:<IGSID>`, análoga al `bsuid:` que ya existe para WhatsApp sin
+  teléfono.
+- **FR-103** Dos contactos de canales distintos pueden compartir identidad sin
+  colisionar (el índice único incluye el canal).
+- **FR-104** Las credenciales de Instagram se guardan cifradas en reposo con el
+  mismo AES-256-GCM que las de WhatsApp.
+- **FR-105** La ingesta acepta dos fuentes —Zernio y Meta directo— por un
+  endpoint con segmento secreto, valida la firma cuando hay secreto y es
+  idempotente por id de evento.
+- **FR-106** La salida enruta por canal de la conversación; Instagram no tiene
+  plantillas, y fuera de la ventana de 24 h usa la etiqueta `HUMAN_AGENT`.
+- **FR-107** El Laboratorio sigue sin tocar ninguna API real, tampoco la de
+  Instagram (Principio: sandbox duro).
+- **FR-108** `/api/bot/context` sigue aceptando y devolviendo `waIdentity` sin
+  cambios de nombre: hay cerebros externos que dependen de él.
+
+## Criterios de éxito
+
+- Un DM real entra a la bandeja con distintivo de Instagram y crea un solo
+  contacto (no uno por mensaje).
+- Una respuesta desde la bandeja llega al DM.
+- Un WhatsApp real sigue entrando y saliendo en la misma instancia.
+- Los gates del repo pasan: typecheck, lint, test, build.
+
+## Constitution Check
+
+- **I. Seguridad de datos**: token cifrado en reposo con la clave existente;
+  webhook con segmento secreto + firma HMAC. Sin secretos en logs.
+- **II. Frontera de salida única**: el transporte de Instagram vive en
+  `src/server/instagram/`, y el ruteo se decide en `prepareSend`, no regado.
+- **VI. Specs antes de código**: este documento.
+- Sandbox del Laboratorio: la aserción de `isTest` queda ANTES de la
+  bifurcación por canal.
+
+## Fuera de alcance
+
+Comentarios, historias, reacciones, automatizaciones de comentario-a-DM,
+adjuntos salientes e importación del historial previo. Mensajería de texto,
+entrante y saliente, es el alcance.

--- a/src/app/(app)/inbox/page.tsx
+++ b/src/app/(app)/inbox/page.tsx
@@ -1,7 +1,19 @@
 import { InboxClient } from "@/components/inbox/inbox-client";
+import { CHANNEL_ORDER } from "@/lib/channels";
+import { enabledChannels } from "@/server/channels/enabled";
 
 export const dynamic = "force-dynamic";
 
 export default function InboxPage() {
-  return <InboxClient />;
+  /**
+   * 014 — Qué bandejas existen se decide en el servidor, no mirando los datos.
+   * Si se dedujera de las conversaciones cargadas, la marca de canal aparecería
+   * y desaparecería sola: una instancia con Instagram encendido pero sin DMs
+   * todavía se vería como una instancia de un solo canal, y el primer mensaje
+   * repintaría la lista entera.
+   */
+  const enabled = enabledChannels();
+  const channels = CHANNEL_ORDER.filter((c) => enabled.has(c));
+
+  return <InboxClient channels={channels} />;
 }

--- a/src/app/api/bot/context/route.ts
+++ b/src/app/api/bot/context/route.ts
@@ -9,7 +9,12 @@ export const dynamic = "force-dynamic";
 
 /**
  * Contexto conversacional para un cerebro externo (solo lectura).
- * GET /api/bot/context?waIdentity=... | ?conversationId=...
+ * GET /api/bot/context?identity=... | ?waIdentity=... | ?conversationId=...
+ *
+ * `identity` es el nombre neutro (hay contactos que no son de WhatsApp).
+ * `waIdentity` se mantiene aceptado y presente en la respuesta porque es
+ * contrato publicado: hay cerebros externos en produccion que dependen de el.
+ * No tiene fecha de retiro.
  *
  * NO devuelve el historial de mensajes: el bot lleva su propia memoria de la
  * conversación. Lo que aquí sale es lo que solo el CRM sabe — quién es la
@@ -25,10 +30,11 @@ export async function GET(req: Request) {
   }
 
   const url = new URL(req.url);
-  const waIdentity = url.searchParams.get("waIdentity");
+  const waIdentity =
+    url.searchParams.get("identity") ?? url.searchParams.get("waIdentity");
   const conversationId = url.searchParams.get("conversationId");
   if (!waIdentity && !conversationId) {
-    return apiError(422, "invalid", "Falta waIdentity o conversationId");
+    return apiError(422, "invalid", "Falta identity (o waIdentity) o conversationId");
   }
 
   const db = getDb();
@@ -107,7 +113,11 @@ export async function GET(req: Request) {
     contact: {
       id: contact.id,
       name: contact.name,
+      /** Nombre neutro (014). Preferir este en clientes nuevos. */
+      identity: contact.waIdentity,
+      /** Alias heredado: sigue aqui para no romper bots ya desplegados. */
       waIdentity: contact.waIdentity,
+      channel: contact.channel,
       phone: contact.phone,
       ficha: serializeFicha(contact),
     },

--- a/src/app/api/settings/instagram/route.ts
+++ b/src/app/api/settings/instagram/route.ts
@@ -5,11 +5,16 @@ import {
   saveInstagramCredentials,
   tokenLast4,
 } from "@/server/instagram/credentials";
+import {
+  channelDisabledResponse,
+  isChannelEnabled,
+} from "@/server/channels/enabled";
 
 export const dynamic = "force-dynamic";
 
 /** 014 — Estado de la conexión de Instagram (el token nunca sale entero). */
 export const GET = withAuth(async (session) => {
+  if (!isChannelEnabled("instagram")) return channelDisabledResponse();
   const creds = await getInstagramCredentialsByOrg(session.organizationId);
   if (!creds) return Response.json({ connection: null });
   return Response.json({
@@ -38,6 +43,7 @@ const putSchema = z.object({
  * wizard de WhatsApp: un token que no sirve no llega a la base.
  */
 export const PUT = withAuth(async (session, req: Request) => {
+  if (!isChannelEnabled("instagram")) return channelDisabledResponse();
   const body = await parseBody(req, putSchema);
   if (!body.ok) return body.response;
   const data = body.data;

--- a/src/app/api/settings/instagram/route.ts
+++ b/src/app/api/settings/instagram/route.ts
@@ -1,0 +1,126 @@
+import { z } from "zod";
+import { apiError, parseBody, withAuth } from "@/lib/api";
+import {
+  getInstagramCredentialsByOrg,
+  saveInstagramCredentials,
+  tokenLast4,
+} from "@/server/instagram/credentials";
+
+export const dynamic = "force-dynamic";
+
+/** 014 — Estado de la conexión de Instagram (el token nunca sale entero). */
+export const GET = withAuth(async (session) => {
+  const creds = await getInstagramCredentialsByOrg(session.organizationId);
+  if (!creds) return Response.json({ connection: null });
+  return Response.json({
+    connection: {
+      source: creds.source,
+      igUserId: creds.igUserId,
+      accountRef: creds.accountRef,
+      username: creds.username,
+      status: creds.status,
+      tokenLast4: tokenLast4(creds.token),
+    },
+  });
+});
+
+const putSchema = z.object({
+  source: z.enum(["zernio", "meta"]),
+  igUserId: z.string().trim().min(1),
+  accountRef: z.string().trim().min(1).nullish(),
+  username: z.string().trim().nullish(),
+  token: z.string().trim().min(1),
+  webhookSecret: z.string().trim().min(1).nullish(),
+});
+
+/**
+ * Guarda la conexión validando ANTES contra la plataforma, igual que el
+ * wizard de WhatsApp: un token que no sirve no llega a la base.
+ */
+export const PUT = withAuth(async (session, req: Request) => {
+  const body = await parseBody(req, putSchema);
+  if (!body.ok) return body.response;
+  const data = body.data;
+
+  if (data.source === "zernio" && !data.accountRef) {
+    return apiError(
+      422,
+      "invalid_body",
+      "En modo Zernio hace falta el accountId de la cuenta conectada"
+    );
+  }
+
+  const check = await verify(data);
+  if (!check.ok) {
+    return apiError(check.status, check.code, check.message);
+  }
+
+  await saveInstagramCredentials({
+    organizationId: session.organizationId,
+    source: data.source,
+    igUserId: data.igUserId,
+    accountRef: data.accountRef ?? null,
+    username: check.username ?? data.username ?? null,
+    token: data.token,
+    webhookSecret: data.webhookSecret ?? null,
+  });
+
+  return Response.json({ ok: true, username: check.username ?? null });
+});
+
+type Check =
+  | { ok: true; username: string | null }
+  | { ok: false; status: number; code: string; message: string };
+
+async function verify(data: z.infer<typeof putSchema>): Promise<Check> {
+  const url =
+    data.source === "meta"
+      ? `${process.env.IG_GRAPH_BASE_URL ?? "https://graph.instagram.com"}/${
+          process.env.META_GRAPH_API_VERSION ?? "v25.0"
+        }/me?fields=id,username`
+      : `${process.env.ZERNIO_BASE_URL ?? "https://zernio.com/api/v1"}/inbox/conversations?limit=1`;
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { Authorization: `Bearer ${data.token}` },
+    });
+  } catch {
+    return {
+      ok: false,
+      status: 503,
+      code: "platform_unavailable",
+      message: "No se pudo contactar la plataforma; intenta de nuevo",
+    };
+  }
+
+  if (!res.ok) {
+    return {
+      ok: false,
+      status: 422,
+      code: "invalid_token",
+      message:
+        data.source === "meta"
+          ? "El token de Instagram no es válido o no tiene permiso de mensajes"
+          : "La API key de Zernio no es válida",
+    };
+  }
+
+  if (data.source === "meta") {
+    const json = (await res.json().catch(() => null)) as {
+      id?: string;
+      username?: string;
+    } | null;
+    if (json?.id && json.id !== data.igUserId) {
+      return {
+        ok: false,
+        status: 422,
+        code: "id_mismatch",
+        message: `El IG_ID del token es ${json.id}, no ${data.igUserId}`,
+      };
+    }
+    return { ok: true, username: json?.username ?? null };
+  }
+
+  return { ok: true, username: null };
+}

--- a/src/app/api/webhooks/ig/[webhookToken]/route.ts
+++ b/src/app/api/webhooks/ig/[webhookToken]/route.ts
@@ -1,6 +1,6 @@
 import { after } from "next/server";
 import { getEnv } from "@/lib/env";
-import { isValidWebhookToken } from "@/server/inbox/webhook";
+import { isValidSignature, isValidWebhookToken } from "@/server/inbox/webhook";
 import {
   isValidZernioSignature,
   processMetaInstagramPayload,
@@ -62,7 +62,15 @@ export async function POST(req: Request, { params }: Params) {
     payload !== null &&
     (payload as { object?: string }).object === "instagram";
 
-  if (!isMeta) {
+  if (isMeta) {
+    // Meta firma cada entrega con el App Secret, igual que en WhatsApp. Sin
+    // esta capa, quien conozca la URL secreta puede inyectar DMs falsos: el
+    // agente los contestaria enviando un DM REAL desde la cuenta del cliente
+    // al destinatario que el atacante elija.
+    if (!isValidSignature(rawBody, req.headers.get("x-hub-signature-256"), env.META_APP_SECRET)) {
+      return new Response(null, { status: 401 });
+    }
+  } else {
     // Zernio: la firma se valida contra el secreto de ESTA cuenta, que hay que
     // resolver leyendo el cuerpo primero.
     const { secret } = await resolveZernioSecret(rawBody);

--- a/src/app/api/webhooks/ig/[webhookToken]/route.ts
+++ b/src/app/api/webhooks/ig/[webhookToken]/route.ts
@@ -1,0 +1,92 @@
+import { after } from "next/server";
+import { getEnv } from "@/lib/env";
+import { isValidWebhookToken } from "@/server/inbox/webhook";
+import {
+  isValidZernioSignature,
+  processMetaInstagramPayload,
+  processZernioEvent,
+  resolveZernioSecret,
+} from "@/server/instagram/ingest";
+
+/**
+ * 014 — Webhook público del canal de Instagram.
+ *
+ * Mismo patrón de dos capas que el de WhatsApp: el segmento [webhookToken]
+ * debe coincidir (si no → 404 sin efectos), y encima la firma cuando la
+ * fuente la provee. Acepta las dos fuentes por la misma URL porque sus
+ * payloads son inconfundibles: Meta manda `object: "instagram"`, Zernio manda
+ * un evento plano con `account`.
+ */
+export const dynamic = "force-dynamic";
+
+type Params = { params: Promise<{ webhookToken: string }> };
+
+export async function GET(req: Request, { params }: Params) {
+  const { webhookToken } = await params;
+  const env = getEnv();
+  if (!isValidWebhookToken(webhookToken, env.META_WEBHOOK_VERIFY_TOKEN)) {
+    return new Response(null, { status: 404 });
+  }
+
+  // Handshake de Meta (Zernio no lo hace, pero responderlo no estorba).
+  const url = new URL(req.url);
+  const mode = url.searchParams.get("hub.mode");
+  const token = url.searchParams.get("hub.verify_token");
+  const challenge = url.searchParams.get("hub.challenge");
+
+  if (mode === "subscribe" && token === env.META_WEBHOOK_VERIFY_TOKEN) {
+    return new Response(challenge ?? "", { status: 200 });
+  }
+  return new Response(null, { status: 403 });
+}
+
+export async function POST(req: Request, { params }: Params) {
+  const { webhookToken } = await params;
+  const env = getEnv();
+  if (!isValidWebhookToken(webhookToken, env.META_WEBHOOK_VERIFY_TOKEN)) {
+    return new Response(null, { status: 404 });
+  }
+
+  const rawBody = await req.text();
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    // Cuerpo ilegible: 200 igualmente para que la fuente no reintente en vano.
+    return Response.json({ received: true });
+  }
+
+  const isMeta =
+    typeof payload === "object" &&
+    payload !== null &&
+    (payload as { object?: string }).object === "instagram";
+
+  if (!isMeta) {
+    // Zernio: la firma se valida contra el secreto de ESTA cuenta, que hay que
+    // resolver leyendo el cuerpo primero.
+    const { secret } = await resolveZernioSecret(rawBody);
+    const signature =
+      req.headers.get("x-zernio-signature") ??
+      req.headers.get("x-late-signature");
+    if (!isValidZernioSignature(rawBody, signature, secret)) {
+      return new Response(null, { status: 401 });
+    }
+  }
+
+  // Zernio corta a los 5 segundos y reintenta: se acusa recibo YA y se procesa
+  // fuera de la ruta.
+  after(async () => {
+    try {
+      if (isMeta) {
+        await processMetaInstagramPayload(payload);
+      } else {
+        await processZernioEvent(payload);
+      }
+    } catch (err) {
+      console.error("[ig] error procesando payload:", err);
+    }
+  });
+
+  return Response.json({ received: true });
+}

--- a/src/app/api/webhooks/ig/[webhookToken]/route.ts
+++ b/src/app/api/webhooks/ig/[webhookToken]/route.ts
@@ -7,6 +7,10 @@ import {
   processZernioEvent,
   resolveZernioSecret,
 } from "@/server/instagram/ingest";
+import {
+  channelDisabledResponse,
+  isChannelEnabled,
+} from "@/server/channels/enabled";
 
 /**
  * 014 — Webhook público del canal de Instagram.
@@ -22,6 +26,7 @@ export const dynamic = "force-dynamic";
 type Params = { params: Promise<{ webhookToken: string }> };
 
 export async function GET(req: Request, { params }: Params) {
+  if (!isChannelEnabled("instagram")) return channelDisabledResponse();
   const { webhookToken } = await params;
   const env = getEnv();
   if (!isValidWebhookToken(webhookToken, env.META_WEBHOOK_VERIFY_TOKEN)) {
@@ -41,6 +46,7 @@ export async function GET(req: Request, { params }: Params) {
 }
 
 export async function POST(req: Request, { params }: Params) {
+  if (!isChannelEnabled("instagram")) return channelDisabledResponse();
   const { webhookToken } = await params;
   const env = getEnv();
   if (!isValidWebhookToken(webhookToken, env.META_WEBHOOK_VERIFY_TOKEN)) {

--- a/src/components/channel-badge.tsx
+++ b/src/components/channel-badge.tsx
@@ -1,0 +1,77 @@
+import type { Channel } from "@/lib/channels";
+import { CHANNEL_LABEL } from "@/lib/channels";
+import { cn } from "@/lib/utils";
+
+/**
+ * 014 — Distintivo de bandeja.
+ *
+ * Se dibuja como el ícono de la aplicación (mosaico de color con el glifo en
+ * blanco) y no como un texto "WA"/"IG": el ícono se reconoce de un vistazo
+ * mientras se recorre la lista, la sigla hay que leerla.
+ *
+ * Solo aparece cuando la instancia tiene más de un canal encendido. Con un
+ * solo canal no hay nada que distinguir, y marcar cada renglón con el mismo
+ * sello sería ruido — la misma razón por la que un canal apagado no tiene
+ * pantalla ni webhook (ADR-001).
+ *
+ * Los trazos son las marcas oficiales de simple-icons (CC0).
+ */
+
+const WHATSAPP_PATH =
+  "M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.872.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z";
+
+const INSTAGRAM_PATH =
+  "M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zM12 16a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 100 2.881 1.44 1.44 0 000-2.881z";
+
+const MARK: Record<Channel, { path: string; tile: string }> = {
+  whatsapp: { path: WHATSAPP_PATH, tile: "bg-[#25d366]" },
+  instagram: {
+    path: INSTAGRAM_PATH,
+    tile: "bg-gradient-to-tr from-[#f9ce34] via-[#ee2a7b] to-[#6228d7]",
+  },
+};
+
+/**
+ * La marca de un canal, o null si no la tiene. Separada del componente para
+ * poder afirmar en una prueba que TODO canal del catalogo tiene glifo: sin
+ * eso, agregar un canal y olvidar su dibujo no rompe nada — el distintivo
+ * simplemente no aparece y la bandeja se ve como si no tuviera canal.
+ */
+export function channelMark(channel: Channel) {
+  return MARK[channel] ?? null;
+}
+
+export function ChannelBadge({
+  channel,
+  className,
+}: {
+  channel: Channel;
+  /** Para ajustar el tamaño del mosaico donde haga falta (encabezados). */
+  className?: string;
+}) {
+  // Un canal desconocido (fila vieja, dato ajeno) no debe tumbar la bandeja.
+  const mark = channelMark(channel);
+  if (!mark) return null;
+  const label = CHANNEL_LABEL[channel] ?? channel;
+
+  return (
+    <span
+      role="img"
+      title={label}
+      aria-label={label}
+      className={cn(
+        "inline-flex h-[15px] w-[15px] shrink-0 items-center justify-center rounded-[4.5px]",
+        mark.tile,
+        className
+      )}
+    >
+      <svg
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        className="h-[10px] w-[10px] fill-white"
+      >
+        <path d={mark.path} />
+      </svg>
+    </span>
+  );
+}

--- a/src/components/inbox/conversation-list.tsx
+++ b/src/components/inbox/conversation-list.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef, useState } from "react";
 import { Search, Sparkles, UserRound, X } from "lucide-react";
 import type { ConversationDto } from "@/lib/types";
+import { CHANNEL_LABEL, type Channel } from "@/lib/channels";
+import { ChannelBadge } from "@/components/channel-badge";
 import { matchesQuery } from "@/lib/search";
 import { cn } from "@/lib/utils";
 import { ContactAvatar } from "@/components/avatar";
@@ -55,11 +57,14 @@ function EmptyState({ onSeeded }: { onSeeded: () => void }) {
 
 export function ConversationList({
   conversations: conversationsProp,
+  channels,
   selectedId,
   onSelect,
   onSeeded,
 }: {
   conversations: ConversationDto[] | null;
+  /** Canales encendidos en esta instancia (ADR-001). */
+  channels: readonly Channel[];
   selectedId: string | null;
   onSelect: (id: string) => void;
   onSeeded: () => void;
@@ -67,6 +72,7 @@ export function ConversationList({
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<"all" | "unread">("all");
   const [stage, setStage] = useState<string>("all");
+  const [inbox, setInbox] = useState<Channel | "all">("all");
   const inputRef = useRef<HTMLInputElement>(null);
 
   /**
@@ -94,9 +100,18 @@ export function ConversationList({
         phone: c.contact.phone,
       }) && (stage === "all" || c.stageName === stage)
   );
-  const unreadCount = searched.filter((c) => c.unreadCount > 0).length;
+  // La bandeja elegida es el filtro de AFUERA: "Todas" y "No leídas" cuentan
+  // dentro de ella, no sobre la suma de los dos canales.
+  const inInbox =
+    inbox === "all" ? searched : searched.filter((c) => c.channel === inbox);
+  const inboxCount = (ch: Channel) =>
+    searched.filter((c) => c.channel === ch).length;
+  const unreadCount = inInbox.filter((c) => c.unreadCount > 0).length;
   const visible =
-    filter === "unread" ? searched.filter((c) => c.unreadCount > 0) : searched;
+    filter === "unread" ? inInbox.filter((c) => c.unreadCount > 0) : inInbox;
+  // Con un solo canal encendido no hay bandejas que distinguir: ni marca en
+  // los renglones ni filtro. La pantalla queda exactamente como antes de 014.
+  const multiChannel = channels.length > 1;
 
   // Etapas presentes en la bandeja, en el orden en que llegan del pipeline.
   const stages: string[] = [];
@@ -113,9 +128,41 @@ export function ConversationList({
   return (
     <div className="flex h-full flex-col">
       <header className="border-b px-4 pb-3 pt-4">
-        <div className="mb-3 flex items-baseline gap-2">
+        <div className="mb-3 flex items-center gap-2">
           <h2 className="text-[17px] font-[650] tracking-tight">Bandeja</h2>
           <span className="text-sm text-text-3">{conversations.length}</span>
+          {multiChannel && (
+            <div className="ml-auto flex items-center gap-1">
+              {channels.map((ch) => {
+                const on = inbox === ch;
+                return (
+                  <button
+                    key={ch}
+                    onClick={() => setInbox(on ? "all" : ch)}
+                    aria-pressed={on}
+                    title={
+                      on
+                        ? "Ver todas las bandejas"
+                        : `Ver solo ${CHANNEL_LABEL[ch]}`
+                    }
+                    className={cn(
+                      "flex items-center gap-1 rounded-full border py-[3px] pl-[5px] pr-2 text-[11.5px] font-medium transition-colors",
+                      on
+                        ? "border-brand bg-brand-veil text-foreground"
+                        : "text-text-3 hover:bg-accent",
+                      inbox !== "all" && !on && "opacity-45"
+                    )}
+                  >
+                    <ChannelBadge
+                      channel={ch}
+                      className="h-[13px] w-[13px] rounded-[4px]"
+                    />
+                    {inboxCount(ch)}
+                  </button>
+                );
+              })}
+            </div>
+          )}
         </div>
         <div className="flex items-center gap-2 rounded-md border bg-secondary px-3 py-[7px] transition-colors focus-within:border-brand focus-within:bg-background focus-within:ring-[3px] focus-within:ring-brand-soft">
           <Search className="h-4 w-4 shrink-0 text-text-3" strokeWidth={1.7} />
@@ -142,7 +189,7 @@ export function ConversationList({
       <div className="flex items-center gap-1.5 border-b px-4 py-2.5">
         {(
           [
-            { id: "all", label: "Todas", count: searched.length },
+            { id: "all", label: "Todas", count: inInbox.length },
             { id: "unread", label: "No leídas", count: unreadCount },
           ] as const
         ).map((f) => (
@@ -225,15 +272,7 @@ export function ConversationList({
                     <span className="min-w-0 flex-1">
                       <span className="flex items-center justify-between gap-2">
                         <span className="flex min-w-0 items-center gap-1.5">
-                          {c.channel === "instagram" && (
-                            <span
-                              title="Instagram"
-                              aria-label="Instagram"
-                              className="shrink-0 rounded-[5px] bg-gradient-to-tr from-[#f9ce34] via-[#ee2a7b] to-[#6228d7] px-1.5 py-[1px] text-[9.5px] font-bold uppercase tracking-wide text-white"
-                            >
-                              IG
-                            </span>
-                          )}
+                          {multiChannel && <ChannelBadge channel={c.channel} />}
                           <span
                             className={cn(
                               "truncate text-sm",

--- a/src/components/inbox/conversation-list.tsx
+++ b/src/components/inbox/conversation-list.tsx
@@ -224,13 +224,24 @@ export function ConversationList({
                     </span>
                     <span className="min-w-0 flex-1">
                       <span className="flex items-center justify-between gap-2">
-                        <span
-                          className={cn(
-                            "truncate text-sm",
-                            unread ? "font-[680]" : "font-semibold"
+                        <span className="flex min-w-0 items-center gap-1.5">
+                          {c.channel === "instagram" && (
+                            <span
+                              title="Instagram"
+                              aria-label="Instagram"
+                              className="shrink-0 rounded-[5px] bg-gradient-to-tr from-[#f9ce34] via-[#ee2a7b] to-[#6228d7] px-1.5 py-[1px] text-[9.5px] font-bold uppercase tracking-wide text-white"
+                            >
+                              IG
+                            </span>
                           )}
-                        >
-                          {c.contact.name}
+                          <span
+                            className={cn(
+                              "truncate text-sm",
+                              unread ? "font-[680]" : "font-semibold"
+                            )}
+                          >
+                            {c.contact.name}
+                          </span>
                         </span>
                         <span
                           className={cn(

--- a/src/components/inbox/inbox-client.tsx
+++ b/src/components/inbox/inbox-client.tsx
@@ -6,6 +6,8 @@ import { ChevronLeft, PanelRight } from "lucide-react";
 import { cn, formatPhone } from "@/lib/utils";
 import { ContactAvatar } from "@/components/avatar";
 import type { ConversationDto, MessageDto } from "@/lib/types";
+import { CHANNEL_LABEL, type Channel } from "@/lib/channels";
+import { ChannelBadge } from "@/components/channel-badge";
 import { useEvents } from "@/components/use-events";
 import { ConversationList } from "./conversation-list";
 import { MessageThread } from "./message-thread";
@@ -33,7 +35,8 @@ const PANEL_MEDIA_QUERY = "(min-width: 1280px)";
 const isWideEnoughForPanel = () =>
   typeof window !== "undefined" && window.matchMedia(PANEL_MEDIA_QUERY).matches;
 
-export function InboxClient() {
+export function InboxClient({ channels }: { channels: readonly Channel[] }) {
+  const multiChannel = channels.length > 1;
   const [conversations, setConversations] = useState<ConversationDto[] | null>(
     null
   );
@@ -279,6 +282,7 @@ export function InboxClient() {
       >
         <ConversationList
           conversations={conversations}
+          channels={channels}
           selectedId={selectedId}
           onSelect={select}
           onSeeded={() => void refetchConversations()}
@@ -309,8 +313,9 @@ export function InboxClient() {
                   size="md"
                 />
                 <div className="min-w-0">
-                  <p className="truncate text-[15px] font-[650] leading-tight">
-                    {selected.contact.name}
+                  <p className="flex min-w-0 items-center gap-1.5 text-[15px] font-[650] leading-tight">
+                    {multiChannel && <ChannelBadge channel={selected.channel} />}
+                    <span className="truncate">{selected.contact.name}</span>
                   </p>
                   <p
                     className={
@@ -321,7 +326,11 @@ export function InboxClient() {
                   >
                     {selected.windowOpen
                       ? "ventana abierta"
-                      : formatPhone(selected.contact.phone)}
+                      : selected.contact.phone
+                        ? formatPhone(selected.contact.phone)
+                        : // Instagram no tiene teléfono: decir "Sin teléfono"
+                          // sería contestar una pregunta que nadie hizo.
+                          CHANNEL_LABEL[selected.channel]}
                   </p>
                 </div>
               </div>

--- a/src/lib/channels.ts
+++ b/src/lib/channels.ts
@@ -1,0 +1,28 @@
+/**
+ * 014 — El canal, en un solo lugar y sin dependencias de servidor.
+ *
+ * Vive en `lib/` y no en `server/` porque la interfaz también necesita saber
+ * qué canales existen y cómo se llaman. Antes el tipo estaba declarado dos
+ * veces (en `server/inbox/identity.ts` y otra vez a mano dentro del DTO de
+ * `lib/types.ts`): agregar un canal obligaba a acordarse de los dos sitios, y
+ * olvidarse de uno no rompía la compilación — solo dejaba una pantalla
+ * mintiendo.
+ */
+
+export type Channel = "whatsapp" | "instagram";
+
+/**
+ * Orden en que los canales se presentan al operador. WhatsApp primero: es el
+ * canal que toda instancia tiene encendido.
+ */
+export const CHANNEL_ORDER: readonly Channel[] = ["whatsapp", "instagram"];
+
+/** Nombre visible del canal, para la interfaz y para los errores del operador. */
+export const CHANNEL_LABEL: Record<Channel, string> = {
+  whatsapp: "WhatsApp",
+  instagram: "Instagram",
+};
+
+export function isChannel(value: string): value is Channel {
+  return (CHANNEL_ORDER as readonly string[]).includes(value);
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -116,6 +116,20 @@ export const contact = pgTable(
      * Llave de resolución WhatsApp (003): teléfono normalizado (521→52) o
      * `bsuid:<id>` cuando Meta no manda wa_id. Estable de por vida.
      */
+    /**
+     * 014: canal por el que vive este contacto. Aditivo y con default: toda
+     * fila existente sigue significando exactamente lo mismo.
+     */
+    channel: text("channel", { enum: ["whatsapp", "instagram"] })
+      .notNull()
+      .default("whatsapp"),
+    /**
+     * Llave de resolucion. WhatsApp: telefono normalizado (521 a 52) o
+     * `bsuid:<id>`. Instagram (014): `ig:<IGSID>`. Estable de por vida.
+     * El nombre `wa_identity` se conserva porque es contrato publicado:
+     * `/api/bot/context?waIdentity=...` lo recibe y lo devuelve, y hay
+     * cerebros externos que dependen de el.
+     */
     waIdentity: text("wa_identity").notNull(),
     /** Teléfono como ATRIBUTO opcional (003): falta en contactos BSUID. */
     phone: text("phone"),
@@ -145,7 +159,13 @@ export const contact = pgTable(
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
   },
   (t) => [
-    uniqueIndex("contact_org_wa_identity_uq").on(t.organizationId, t.waIdentity),
+    // 014: el canal entra en la llave. Sin el, un IGSID que coincidiera con
+    // un telefono normalizado mezclaria dos personas en silencio.
+    uniqueIndex("contact_org_channel_identity_uq").on(
+      t.organizationId,
+      t.channel,
+      t.waIdentity
+    ),
     index("contact_org_wa_user_id_idx").on(t.organizationId, t.waUserId),
     index("contact_org_name_idx").on(t.organizationId, t.name),
   ]
@@ -306,6 +326,19 @@ export const conversation = pgTable(
       .references(() => contact.id, { onDelete: "cascade" }),
     /** Conversación del Laboratorio: jamás toca la API de WhatsApp. */
     isTest: boolean("is_test").notNull().default(false),
+    /**
+     * 014: canal de la conversacion. Denormalizado del contacto a proposito:
+     * el ruteo de salida y el filtro de la bandeja lo leen en cada mensaje.
+     */
+    channel: text("channel", { enum: ["whatsapp", "instagram"] })
+      .notNull()
+      .default("whatsapp"),
+    /**
+     * 014: identificador del hilo en la plataforma de origen. Zernio entrega
+     * un conversationId opaco ("no asumas su formato") que hace falta para
+     * responder; WhatsApp no lo necesita y queda null.
+     */
+    channelThreadRef: text("channel_thread_ref"),
     aiEnabled: boolean("ai_enabled").notNull().default(true),
     handoffAt: timestamp("handoff_at"),
     handoffReason: text("handoff_reason", {
@@ -456,6 +489,45 @@ export const metaCredentials = pgTable(
     uniqueIndex("meta_credentials_org_uq").on(t.organizationId),
     // El webhook enruta por phone_number_id: debe ser único en la instancia.
     uniqueIndex("meta_credentials_phone_uq").on(t.phoneNumberId),
+  ]
+);
+
+/**
+ * 014 - Credenciales del canal de Instagram. Tabla explicita (no un jsonb
+ * generico) porque unas credenciales tienen forma fija y conocida: asi
+ * conservan tipado e indices. El token se cifra con los mismos helpers que el
+ * de WhatsApp; un segundo mecanismo de cifrado seria un segundo mecanismo que
+ * auditar.
+ */
+export const instagramCredentials = pgTable(
+  "instagram_credentials",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    /** De donde vienen los mensajes: API unificada o app propia de Meta. */
+    source: text("source", { enum: ["zernio", "meta"] }).notNull(),
+    /** IG_ID del perfil profesional: por el enruta el webhook. */
+    igUserId: text("ig_user_id").notNull(),
+    /** Zernio: accountId de la cuenta conectada. Meta directo: null. */
+    accountRef: text("account_ref"),
+    username: text("username"),
+    tokenCipher: text("token_cipher").notNull(),
+    tokenIv: text("token_iv").notNull(),
+    tokenTag: text("token_tag").notNull(),
+    /** Secreto HMAC de las entregas (Zernio); null en modo Meta. */
+    webhookSecret: text("webhook_secret"),
+    status: text("status", { enum: ["connected", "reconnect_required"] })
+      .notNull()
+      .default("connected"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex("instagram_credentials_org_uq").on(t.organizationId),
+    uniqueIndex("instagram_credentials_ig_user_uq").on(t.igUserId),
+    index("instagram_credentials_account_ref_idx").on(t.accountRef),
   ]
 );
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -26,6 +26,10 @@ const envSchema = z.object({
   OPENROUTER_BASE_URL: z.string().url().default("https://openrouter.ai/api"),
   OPENROUTER_MODEL: z.string().optional(),
   OPENROUTER_JUDGE_MODEL: z.string().optional(),
+  // 014: canales encendidos, separados por coma. WhatsApp siempre esta on.
+  // Ej.: CHANNELS=whatsapp,instagram. Sin ella, la instancia es solo WhatsApp
+  // y las superficies de los demas canales responden 404.
+  CHANNELS: z.string().optional(),
   ALLOW_SIGNUP: z.string().optional(),
   AGENT_COALESCE_MS: z.coerce.number().int().min(0).default(6000),
   WA_MOCK_ENABLED: z.string().optional(),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,6 +2,8 @@
 
 export type ConversationDto = {
   id: string;
+  /** 014: canal de la conversacion, para el distintivo de la bandeja. */
+  channel: "whatsapp" | "instagram";
   contact: { id: string; name: string; phone: string | null };
   stageName: string | null;
   aiEnabled: boolean;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,9 +1,11 @@
 /** DTOs que viajan por la API interna (lado cliente). */
 
+import type { Channel } from "@/lib/channels";
+
 export type ConversationDto = {
   id: string;
   /** 014: canal de la conversacion, para el distintivo de la bandeja. */
-  channel: "whatsapp" | "instagram";
+  channel: Channel;
   contact: { id: string; name: string; phone: string | null };
   stageName: string | null;
   aiEnabled: boolean;

--- a/src/server/channels/capabilities.ts
+++ b/src/server/channels/capabilities.ts
@@ -1,4 +1,4 @@
-import type { Channel } from "@/server/inbox/identity";
+import { CHANNEL_LABEL, type Channel } from "@/lib/channels";
 
 /**
  * 014 — Capacidades declaradas por canal.
@@ -44,7 +44,7 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 
 export const CHANNEL_CAPABILITIES: Record<Channel, ChannelCapabilities> = {
   whatsapp: {
-    label: "WhatsApp",
+    label: CHANNEL_LABEL.whatsapp,
     windowMs: DAY_MS,
     outsideWindow: "template",
     maxTextBytes: null,
@@ -52,7 +52,7 @@ export const CHANNEL_CAPABILITIES: Record<Channel, ChannelCapabilities> = {
     deliveryReceipts: true,
   },
   instagram: {
-    label: "Instagram",
+    label: CHANNEL_LABEL.instagram,
     windowMs: DAY_MS,
     outsideWindow: "human_agent_tag",
     // Meta corta en 1000 bytes: con acentos y emojis el margen real es menor

--- a/src/server/channels/capabilities.ts
+++ b/src/server/channels/capabilities.ts
@@ -1,0 +1,89 @@
+import type { Channel } from "@/server/inbox/identity";
+
+/**
+ * 014 — Capacidades declaradas por canal.
+ *
+ * El núcleo NO debe saber las reglas de WhatsApp: debe preguntarlas. Antes,
+ * la ventana de 24 h y el "usa una plantilla aprobada" vivían incrustados en
+ * el camino genérico de envío, así que cada canal nuevo tenía que pelearse con
+ * suposiciones que no eran suyas — Instagram no tiene plantillas, y su salida
+ * fuera de ventana es una etiqueta.
+ *
+ * Agregar un canal debería ser: escribir su adaptador y declarar aquí lo que
+ * puede y no puede hacer.
+ */
+
+export type OutsideWindowStrategy =
+  /** Solo se puede reabrir con una plantilla aprobada (WhatsApp). */
+  | "template"
+  /** Se marca el mensaje como respuesta de agente humano (Instagram). */
+  | "human_agent_tag"
+  /** No hay forma: fuera de ventana no se envía. */
+  | "none";
+
+export type ChannelCapabilities = {
+  /** Etiqueta legible, para mensajes de error dirigidos al operador. */
+  label: string;
+  /** Ventana de servicio en ms desde el último entrante; null = sin ventana. */
+  windowMs: number | null;
+  /** Qué se puede hacer cuando la ventana está cerrada. */
+  outsideWindow: OutsideWindowStrategy;
+  /** Límite de texto en BYTES (no caracteres); null = sin límite práctico. */
+  maxTextBytes: number | null;
+  /** ¿Se pueden mandar adjuntos por este canal hoy? */
+  outboundMedia: boolean;
+  /**
+   * ¿El estado del mensaje avanza por webhook (entregado/leído)? Si no, la
+   * aceptación de la plataforma es la confirmación y el mensaje nace `sent`
+   * — sin esto se queda con el reloj puesto para siempre.
+   */
+  deliveryReceipts: boolean;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const CHANNEL_CAPABILITIES: Record<Channel, ChannelCapabilities> = {
+  whatsapp: {
+    label: "WhatsApp",
+    windowMs: DAY_MS,
+    outsideWindow: "template",
+    maxTextBytes: null,
+    outboundMedia: true,
+    deliveryReceipts: true,
+  },
+  instagram: {
+    label: "Instagram",
+    windowMs: DAY_MS,
+    outsideWindow: "human_agent_tag",
+    // Meta corta en 1000 bytes: con acentos y emojis el margen real es menor
+    // de lo que aparenta al contar caracteres.
+    maxTextBytes: 1000,
+    outboundMedia: false,
+    deliveryReceipts: false,
+  },
+};
+
+export function capabilitiesFor(channel: Channel): ChannelCapabilities {
+  return CHANNEL_CAPABILITIES[channel] ?? CHANNEL_CAPABILITIES.whatsapp;
+}
+
+/** Mensaje para el operador cuando la ventana está cerrada, según el canal. */
+export function windowClosedMessage(channel: Channel): string {
+  const caps = capabilitiesFor(channel);
+  switch (caps.outsideWindow) {
+    case "template":
+      return "La ventana de 24 horas está cerrada; usa una plantilla aprobada";
+    case "human_agent_tag":
+      // No se le pide nada al operador: el envío sale etiquetado solo.
+      return "";
+    case "none":
+      return `La ventana de ${caps.label} está cerrada y este canal no permite reabrirla`;
+  }
+}
+
+/** ¿Este texto cabe en el canal? */
+export function textFits(channel: Channel, text: string): boolean {
+  const max = capabilitiesFor(channel).maxTextBytes;
+  if (max === null) return true;
+  return Buffer.byteLength(text, "utf8") <= max;
+}

--- a/src/server/channels/enabled.ts
+++ b/src/server/channels/enabled.ts
@@ -1,0 +1,49 @@
+import { getEnv } from "@/lib/env";
+import type { Channel } from "@/server/inbox/identity";
+
+/**
+ * 014 — Qué canales están encendidos en esta instancia.
+ *
+ * El código de todos los canales viaja siempre en main; lo que decide si
+ * existen para el usuario es la variable `CHANNELS`. Una instalación normal
+ * (`CHANNELS=whatsapp`, el default) no ve Instagram por ningún lado: ni
+ * pantalla, ni webhook, ni variables que llenar.
+ *
+ * Se hace así, y no con una rama por feature, porque una rama tiene que
+ * mantenerse compatible con main Y con las demás ramas opcionales, y su
+ * cadena de migraciones diverge sin arreglo posible. Con la bandera hay UNA
+ * cadena de migraciones para todo el mundo y los conflictos los resuelve el
+ * autor una vez, no cada usuario en cada actualización.
+ *
+ * La migración se aplica siempre: una columna con default y una tabla vacía
+ * son inertes, y a cambio todas las instancias tienen la misma estructura.
+ */
+
+/** WhatsApp no se puede apagar: es el canal por el que existe el producto. */
+const ALWAYS_ON: Channel = "whatsapp";
+
+function parseChannels(raw: string | undefined): Set<Channel> {
+  const enabled = new Set<Channel>([ALWAYS_ON]);
+  for (const part of (raw ?? "").split(",")) {
+    const name = part.trim().toLowerCase();
+    if (name === "instagram") enabled.add("instagram");
+  }
+  return enabled;
+}
+
+export function enabledChannels(): Set<Channel> {
+  return parseChannels(getEnv().CHANNELS);
+}
+
+export function isChannelEnabled(channel: Channel): boolean {
+  return enabledChannels().has(channel);
+}
+
+/**
+ * Respuesta para una superficie de un canal apagado. 404 y no 403 a
+ * propósito: si el canal no está encendido, ese endpoint no existe en esta
+ * instancia — no hay nada que revelar sobre él.
+ */
+export function channelDisabledResponse(): Response {
+  return new Response(null, { status: 404 });
+}

--- a/src/server/channels/enabled.ts
+++ b/src/server/channels/enabled.ts
@@ -1,5 +1,5 @@
 import { getEnv } from "@/lib/env";
-import type { Channel } from "@/server/inbox/identity";
+import { isChannel, type Channel } from "@/lib/channels";
 
 /**
  * 014 — Qué canales están encendidos en esta instancia.
@@ -22,11 +22,13 @@ import type { Channel } from "@/server/inbox/identity";
 /** WhatsApp no se puede apagar: es el canal por el que existe el producto. */
 const ALWAYS_ON: Channel = "whatsapp";
 
-function parseChannels(raw: string | undefined): Set<Channel> {
+export function parseChannels(raw: string | undefined): Set<Channel> {
   const enabled = new Set<Channel>([ALWAYS_ON]);
   for (const part of (raw ?? "").split(",")) {
     const name = part.trim().toLowerCase();
-    if (name === "instagram") enabled.add("instagram");
+    // Cualquier canal del catalogo, no una lista escrita a mano aqui: el
+    // canal siguiente solo tiene que existir en lib/channels.ts.
+    if (isChannel(name)) enabled.add(name);
   }
   return enabled;
 }

--- a/src/server/inbox/identity.ts
+++ b/src/server/inbox/identity.ts
@@ -15,10 +15,16 @@ import type { WebhookMessage, WebhookValue } from "@/server/inbox/webhook";
  */
 
 export const BSUID_PREFIX = "bsuid:";
+/** 014: identidad de Instagram, analoga al BSUID de WhatsApp. */
+export const IG_PREFIX = "ig:";
+
+export type Channel = "whatsapp" | "instagram";
 
 export type ResolvedIdentity = {
   /** Llave estable de resolución: teléfono normalizado o `bsuid:<id>`. */
   identity: string;
+  /** 014: canal del contacto. Ausente = whatsapp (compatibilidad). */
+  channel?: Channel;
   phone: string | null;
   waUserId: string | null;
   profileName: string | null;
@@ -76,6 +82,70 @@ export async function getOrCreateContactByIdentity(
 ) {
   const db = getDb();
 
+  const channel: Channel = resolved.channel ?? "whatsapp";
+
+  // 014: Instagram no comparte espacio de identidades con WhatsApp. La
+  // reconciliacion telefono<->BSUID es exclusiva de WhatsApp, asi que en
+  // Instagram la busqueda es directa por identidad.
+  if (channel === "instagram") {
+    const found = await db
+      .select()
+      .from(schema.contact)
+      .where(
+        and(
+          eq(schema.contact.organizationId, organizationId),
+          eq(schema.contact.channel, "instagram"),
+          eq(schema.contact.waIdentity, resolved.identity)
+        )
+      )
+      .limit(1);
+    const existingIg = found[0];
+    if (existingIg) {
+      if (existingIg.archivedAt) {
+        await db
+          .update(schema.contact)
+          .set({ archivedAt: null, updatedAt: new Date() })
+          .where(eq(schema.contact.id, existingIg.id));
+        existingIg.archivedAt = null;
+      }
+      return { contact: existingIg, isNew: false };
+    }
+    const createdIg = await db
+      .insert(schema.contact)
+      .values({
+        id: newId("contact"),
+        organizationId,
+        channel: "instagram",
+        waIdentity: resolved.identity,
+        phone: null,
+        waUserId: null,
+        name: resolved.profileName?.trim() || "Contacto de Instagram",
+      })
+      .onConflictDoNothing({
+        target: [
+          schema.contact.organizationId,
+          schema.contact.channel,
+          schema.contact.waIdentity,
+        ],
+      })
+      .returning();
+    if (createdIg[0]) return { contact: createdIg[0], isNew: true };
+    const racedIg = await db
+      .select()
+      .from(schema.contact)
+      .where(
+        and(
+          eq(schema.contact.organizationId, organizationId),
+          eq(schema.contact.channel, "instagram"),
+          eq(schema.contact.waIdentity, resolved.identity)
+        )
+      )
+      .limit(1);
+    const contactIg = racedIg[0];
+    if (!contactIg) throw new Error("contacto no encontrado tras upsert");
+    return { contact: contactIg, isNew: false };
+  }
+
   const matchers = [eq(schema.contact.waIdentity, resolved.identity)];
   if (resolved.waUserId) {
     matchers.push(eq(schema.contact.waUserId, resolved.waUserId));
@@ -90,7 +160,13 @@ export async function getOrCreateContactByIdentity(
   const rows = await db
     .select()
     .from(schema.contact)
-    .where(and(eq(schema.contact.organizationId, organizationId), or(...matchers)))
+    .where(
+      and(
+        eq(schema.contact.organizationId, organizationId),
+        eq(schema.contact.channel, "whatsapp"),
+        or(...matchers)
+      )
+    )
     .orderBy(schema.contact.createdAt)
     .limit(1);
 
@@ -123,7 +199,11 @@ export async function getOrCreateContactByIdentity(
       name: resolved.profileName?.trim() || displayFallback(resolved),
     })
     .onConflictDoNothing({
-      target: [schema.contact.organizationId, schema.contact.waIdentity],
+      target: [
+        schema.contact.organizationId,
+        schema.contact.channel,
+        schema.contact.waIdentity,
+      ],
     })
     .returning();
   if (inserted[0]) return { contact: inserted[0], isNew: true };

--- a/src/server/inbox/identity.ts
+++ b/src/server/inbox/identity.ts
@@ -1,4 +1,5 @@
 import { and, eq, or } from "drizzle-orm";
+import type { Channel } from "@/lib/channels";
 import { getDb, schema } from "@/lib/db";
 import { newId } from "@/lib/db/ids";
 import { normalizeMx } from "@/lib/meta/client";
@@ -18,7 +19,9 @@ export const BSUID_PREFIX = "bsuid:";
 /** 014: identidad de Instagram, analoga al BSUID de WhatsApp. */
 export const IG_PREFIX = "ig:";
 
-export type Channel = "whatsapp" | "instagram";
+// El tipo vive en lib/ porque la interfaz tambien lo necesita; se reexporta
+// aqui para no tocar a quien ya lo importaba de este modulo.
+export type { Channel };
 
 export type ResolvedIdentity = {
   /** Llave estable de resolución: teléfono normalizado o `bsuid:<id>`. */

--- a/src/server/inbox/ingest.ts
+++ b/src/server/inbox/ingest.ts
@@ -162,12 +162,19 @@ export async function getOrCreateContact(
 
 export async function getOrCreateConversation(
   organizationId: string,
-  contactId: string
+  contactId: string,
+  opts?: { channel?: "whatsapp" | "instagram"; threadRef?: string | null }
 ) {
   const db = getDb();
   const inserted = await db
     .insert(schema.conversation)
-    .values({ id: newId("conversation"), organizationId, contactId })
+    .values({
+      id: newId("conversation"),
+      organizationId,
+      contactId,
+      channel: opts?.channel ?? "whatsapp",
+      channelThreadRef: opts?.threadRef ?? null,
+    })
     .onConflictDoNothing()
     .returning();
   if (inserted[0]) return inserted[0];
@@ -185,6 +192,15 @@ export async function getOrCreateConversation(
     .limit(1);
   const existing = rows[0];
   if (!existing) throw new Error("conversación no encontrada tras upsert");
+  // 014: el hilo de la plataforma puede aparecer despues (o cambiar); se
+  // guarda en cuanto se conoce para poder responder.
+  if (opts?.threadRef && existing.channelThreadRef !== opts.threadRef) {
+    await db
+      .update(schema.conversation)
+      .set({ channelThreadRef: opts.threadRef, updatedAt: new Date() })
+      .where(eq(schema.conversation.id, existing.id));
+    existing.channelThreadRef = opts.threadRef;
+  }
   return existing;
 }
 
@@ -363,6 +379,8 @@ export async function ingestInboundMessage(input: {
   text: string | null;
   timestamp: string;
   media?: MediaInput | null;
+  /** 014: hilo en la plataforma de origen (Zernio); null en WhatsApp. */
+  threadRef?: string | null;
 }): Promise<void> {
   const db = getDb();
   const { organizationId } = input;
@@ -373,7 +391,8 @@ export async function ingestInboundMessage(input: {
   );
   const conversation = await getOrCreateConversation(
     organizationId,
-    contact.id
+    contact.id,
+    { channel: contact.channel, threadRef: input.threadRef ?? null }
   );
 
   const waTimestamp = toDate(input.timestamp);

--- a/src/server/inbox/queries.ts
+++ b/src/server/inbox/queries.ts
@@ -2,23 +2,7 @@ import { and, desc, eq, gt, sql } from "drizzle-orm";
 import { getDb, schema } from "@/lib/db";
 import { scoped } from "@/lib/db/tenant";
 import { isWindowOpen, windowRemainingMs } from "@/server/inbox/window";
-
-export type ConversationDto = {
-  id: string;
-  /** 014: canal de la conversacion, para el distintivo de la bandeja. */
-  channel: "whatsapp" | "instagram";
-  contact: { id: string; name: string; phone: string | null };
-  stageName: string | null;
-  aiEnabled: boolean;
-  handoffAt: string | null;
-  handoffReason: string | null;
-  lastInboundAt: string | null;
-  lastMessageAt: string | null;
-  unreadCount: number;
-  windowOpen: boolean;
-  windowRemainingMs: number;
-  preview: string | null;
-};
+import type { ConversationDto } from "@/lib/types";
 
 export async function listConversations(
   organizationId: string,

--- a/src/server/inbox/queries.ts
+++ b/src/server/inbox/queries.ts
@@ -5,6 +5,8 @@ import { isWindowOpen, windowRemainingMs } from "@/server/inbox/window";
 
 export type ConversationDto = {
   id: string;
+  /** 014: canal de la conversacion, para el distintivo de la bandeja. */
+  channel: "whatsapp" | "instagram";
   contact: { id: string; name: string; phone: string | null };
   stageName: string | null;
   aiEnabled: boolean;
@@ -119,6 +121,7 @@ export function serializeConversation(
 ): ConversationDto {
   return {
     id: c.id,
+    channel: c.channel,
     contact: { id: contact.id, name: contact.name, phone: contact.phone },
     stageName,
     aiEnabled: c.aiEnabled,

--- a/src/server/inbox/send.ts
+++ b/src/server/inbox/send.ts
@@ -21,6 +21,7 @@ import {
   textFits,
   windowClosedMessage,
 } from "@/server/channels/capabilities";
+import { isChannelEnabled } from "@/server/channels/enabled";
 import { serializeMessage } from "@/server/inbox/ingest";
 import {
   saveMediaFile,
@@ -97,6 +98,14 @@ async function prepareSend(
   // plantillas. Se resuelve antes que las credenciales de WhatsApp para no
   // exigirle a una instancia de solo-Instagram un numero conectado.
   if (row.conversation.channel === "instagram") {
+    // Una conversacion de un canal apagado puede existir (se apago despues de
+    // recibirla): falla claro en vez de intentar un transporte que no aplica.
+    if (!isChannelEnabled("instagram")) {
+      throw new SendError(
+        "not_connected",
+        "El canal de Instagram está desactivado en esta instancia"
+      );
+    }
     const igCreds = await getInstagramCredentialsByOrg(organizationId);
     if (!igCreds) {
       throw new SendError(

--- a/src/server/inbox/send.ts
+++ b/src/server/inbox/send.ts
@@ -155,7 +155,14 @@ async function persistOutbound(input: {
   waMessageId: string | null;
   type: string;
   text: string | null;
-  status: "pending" | "failed";
+  /**
+   * 014: 'sent' existe porque no todos los canales confirman por webhook.
+   * WhatsApp entra como 'pending' y avanza con los `statuses` de Meta;
+   * Instagram no manda ese evento salvo que se suscriba aparte, asi que la
+   * aceptacion de la plataforma ES la confirmacion. Sin esto el mensaje se
+   * queda con el reloj puesto para siempre aunque ya se haya entregado.
+   */
+  status: "pending" | "sent" | "failed";
   error?: string | null;
   aiGenerated?: boolean;
   origin: "ai" | "operator";
@@ -223,7 +230,9 @@ export async function sendText(input: {
     waMessageId,
     type: "text",
     text: input.text,
-    status: "pending",
+    // Instagram no reporta entrega por este webhook: si la plataforma acepto
+    // el mensaje, esta enviado. WhatsApp sigue avanzando por sus statuses.
+    status: target.instagram ? "sent" : "pending",
     aiGenerated: input.aiGenerated,
     origin: input.aiGenerated ? "ai" : "operator",
   });

--- a/src/server/inbox/send.ts
+++ b/src/server/inbox/send.ts
@@ -15,7 +15,12 @@ import {
   markInstagramReconnectRequired,
   type InstagramCredentials,
 } from "@/server/instagram/credentials";
-import { fitsInstagramText, sendInstagramText } from "@/server/instagram/send";
+import { sendInstagramText } from "@/server/instagram/send";
+import {
+  capabilitiesFor,
+  textFits,
+  windowClosedMessage,
+} from "@/server/channels/capabilities";
 import { serializeMessage } from "@/server/inbox/ingest";
 import {
   saveMediaFile,
@@ -116,10 +121,18 @@ async function prepareSend(
     };
   }
 
-  if (!isWindowOpen(row.conversation.lastInboundAt)) {
+  // El nucleo no decide la politica: la consulta. WhatsApp exige plantilla
+  // fuera de ventana; Instagram etiqueta y sigue; otro canal podria no tener
+  // ventana en absoluto.
+  const caps = capabilitiesFor(row.conversation.channel);
+  if (
+    caps.windowMs !== null &&
+    caps.outsideWindow === "template" &&
+    !isWindowOpen(row.conversation.lastInboundAt)
+  ) {
     throw new SendError(
       "window_closed",
-      "La ventana de 24 horas está cerrada; usa una plantilla aprobada"
+      windowClosedMessage(row.conversation.channel)
     );
   }
 
@@ -230,9 +243,12 @@ export async function sendText(input: {
     waMessageId,
     type: "text",
     text: input.text,
-    // Instagram no reporta entrega por este webhook: si la plataforma acepto
-    // el mensaje, esta enviado. WhatsApp sigue avanzando por sus statuses.
-    status: target.instagram ? "sent" : "pending",
+    // Un canal sin acuses de entrega confirma al aceptar; uno con acuses
+    // avanza despues por webhook. Sin esta distincion el mensaje se queda
+    // con el reloj puesto para siempre.
+    status: capabilitiesFor(target.conversation.channel).deliveryReceipts
+      ? "pending"
+      : "sent",
     aiGenerated: input.aiGenerated,
     origin: input.aiGenerated ? "ai" : "operator",
   });
@@ -257,12 +273,11 @@ export async function sendMediaMessage(input: {
 
   const target = await prepareSend(input.conversationId, input.organizationId);
   const { credentials, recipient } = target;
-  if (target.instagram) {
-    // 014 fuera de alcance: adjuntos salientes en Instagram. Fallar claro es
-    // mejor que mandarlo por el transporte equivocado.
+  const sendCaps = capabilitiesFor(target.conversation.channel);
+  if (!sendCaps.outboundMedia) {
     throw new SendError(
       "meta_error",
-      "Todavía no se pueden enviar adjuntos por Instagram; manda el texto"
+      `Todavía no se pueden enviar adjuntos por ${sendCaps.label}; manda el texto`
     );
   }
 
@@ -465,10 +480,11 @@ async function callInstagramSend(
 ): Promise<string> {
   const creds = target.instagram!;
 
-  if (!fitsInstagramText(text)) {
+  const caps = capabilitiesFor("instagram");
+  if (!textFits("instagram", text)) {
     throw new SendError(
       "meta_error",
-      "Instagram no acepta mensajes de más de 1000 bytes: acorta el texto"
+      `${caps.label} no acepta mensajes de más de ${caps.maxTextBytes} bytes: acorta el texto`
     );
   }
 

--- a/src/server/inbox/send.ts
+++ b/src/server/inbox/send.ts
@@ -9,6 +9,13 @@ import {
   type Credentials,
 } from "@/server/whatsapp/credentials";
 import { isWindowOpen } from "@/server/inbox/window";
+import { IG_PREFIX } from "@/server/inbox/identity";
+import {
+  getInstagramCredentialsByOrg,
+  markInstagramReconnectRequired,
+  type InstagramCredentials,
+} from "@/server/instagram/credentials";
+import { fitsInstagramText, sendInstagramText } from "@/server/instagram/send";
 import { serializeMessage } from "@/server/inbox/ingest";
 import {
   saveMediaFile,
@@ -40,8 +47,11 @@ type SendResult = { messageId: string };
 
 type SendTarget = {
   conversation: typeof schema.conversation.$inferSelect;
-  credentials: Credentials;
+  /** null cuando el destino no es WhatsApp (014). */
+  credentials: Credentials | null;
   recipient: string;
+  /** 014: presente solo en conversaciones de Instagram. */
+  instagram?: InstagramCredentials;
 };
 
 /**
@@ -76,6 +86,34 @@ async function prepareSend(
       "sandbox_violation",
       "Conversación de prueba del Laboratorio: el envío real está prohibido"
     );
+  }
+
+  // 014: Instagram tiene su propio transporte, su propia ventana y NO tiene
+  // plantillas. Se resuelve antes que las credenciales de WhatsApp para no
+  // exigirle a una instancia de solo-Instagram un numero conectado.
+  if (row.conversation.channel === "instagram") {
+    const igCreds = await getInstagramCredentialsByOrg(organizationId);
+    if (!igCreds) {
+      throw new SendError(
+        "not_connected",
+        "No hay cuenta de Instagram conectada"
+      );
+    }
+    if (igCreds.status === "reconnect_required") {
+      throw new SendError(
+        "reconnect_required",
+        "El token de Instagram expiró: reconecta la cuenta en Configuración"
+      );
+    }
+    const igRecipient = row.contact.waIdentity.startsWith(IG_PREFIX)
+      ? row.contact.waIdentity.slice(IG_PREFIX.length)
+      : row.contact.waIdentity;
+    return {
+      conversation: row.conversation,
+      credentials: null,
+      recipient: igRecipient,
+      instagram: igCreds,
+    };
   }
 
   if (!isWindowOpen(row.conversation.lastInboundAt)) {
@@ -167,17 +205,17 @@ export async function sendText(input: {
   text: string;
   aiGenerated?: boolean;
 }): Promise<SendResult> {
-  const { credentials, recipient } = await prepareSend(
-    input.conversationId,
-    input.organizationId
-  );
+  const target = await prepareSend(input.conversationId, input.organizationId);
+  const { credentials, recipient } = target;
 
-  const waMessageId = await callGraphSend(credentials, {
-    messaging_product: "whatsapp",
-    to: recipient,
-    type: "text",
-    text: { body: input.text },
-  });
+  const waMessageId = target.instagram
+    ? await callInstagramSend(target, input.text)
+    : await callGraphSend(credentials!, {
+        messaging_product: "whatsapp",
+        to: recipient,
+        type: "text",
+        text: { body: input.text },
+      });
 
   const messageId = await persistOutbound({
     organizationId: input.organizationId,
@@ -208,10 +246,16 @@ export async function sendMediaMessage(input: {
   // Validación previa (FR-007): tipo y tamaño antes de tocar disco o red.
   const kind = validateOutgoing(input.file.mimeType, input.file.data.byteLength);
 
-  const { credentials, recipient } = await prepareSend(
-    input.conversationId,
-    input.organizationId
-  );
+  const target = await prepareSend(input.conversationId, input.organizationId);
+  const { credentials, recipient } = target;
+  if (target.instagram) {
+    // 014 fuera de alcance: adjuntos salientes en Instagram. Fallar claro es
+    // mejor que mandarlo por el transporte equivocado.
+    throw new SendError(
+      "meta_error",
+      "Todavía no se pueden enviar adjuntos por Instagram; manda el texto"
+    );
+  }
 
   const db = getDb();
   const assetId = newId("mediaAsset");
@@ -237,7 +281,7 @@ export async function sendMediaMessage(input: {
   const asset = assetRows[0]!;
 
   try {
-    const waMediaId = await uploadGraphMedia(credentials, input.file);
+    const waMediaId = await uploadGraphMedia(credentials!, input.file);
     await db
       .update(schema.mediaAsset)
       .set({ waMediaId, updatedAt: new Date() })
@@ -248,7 +292,7 @@ export async function sendMediaMessage(input: {
     if (kind === "document" && input.file.fileName) {
       mediaPayload.filename = input.file.fileName;
     }
-    const waMessageId = await callGraphSend(credentials, {
+    const waMessageId = await callGraphSend(credentials!, {
       messaging_product: "whatsapp",
       to: recipient,
       type: kind,
@@ -336,7 +380,7 @@ export async function sendStructured(
           })),
         };
 
-  const waMessageId = await callGraphSend(credentials, {
+  const waMessageId = await callGraphSend(credentials!, {
     messaging_product: "whatsapp",
     to: recipient,
     ...payload,
@@ -393,6 +437,59 @@ export async function callGraphSend(
       }
       if (err.status === 0 || err.status >= 500) {
         throw new SendError("meta_unavailable", "Meta no está disponible ahora");
+      }
+      throw new SendError("meta_error", err.message);
+    }
+    throw err;
+  }
+}
+
+
+/**
+ * 014 — Envío por el canal de Instagram. Traduce los fallos al mismo
+ * vocabulario de SendError que ya usa WhatsApp, para que la bandeja no tenga
+ * que aprender un idioma por plataforma.
+ */
+async function callInstagramSend(
+  target: SendTarget,
+  text: string
+): Promise<string> {
+  const creds = target.instagram!;
+
+  if (!fitsInstagramText(text)) {
+    throw new SendError(
+      "meta_error",
+      "Instagram no acepta mensajes de más de 1000 bytes: acorta el texto"
+    );
+  }
+
+  // Instagram no tiene plantillas: fuera de la ventana de 24 h la única vía
+  // es la etiqueta de agente humano (hasta 7 días).
+  const humanAgentTag = !isWindowOpen(target.conversation.lastInboundAt);
+
+  try {
+    const res = await sendInstagramText({
+      credentials: creds,
+      recipient: target.recipient,
+      threadRef: target.conversation.channelThreadRef,
+      text,
+      humanAgentTag,
+    });
+    return res.platformMessageId;
+  } catch (err) {
+    if (err instanceof MetaApiError) {
+      if (err.isAuthError) {
+        await markInstagramReconnectRequired(creds.organizationId);
+        throw new SendError(
+          "reconnect_required",
+          "El token de Instagram expiró o fue revocado: reconecta la cuenta"
+        );
+      }
+      if (err.status === 0 || err.status >= 500) {
+        throw new SendError(
+          "meta_unavailable",
+          "Instagram no está disponible en este momento; intenta de nuevo"
+        );
       }
       throw new SendError("meta_error", err.message);
     }

--- a/src/server/instagram/credentials.ts
+++ b/src/server/instagram/credentials.ts
@@ -1,0 +1,132 @@
+import { eq } from "drizzle-orm";
+import { getDb, schema } from "@/lib/db";
+import { newId } from "@/lib/db/ids";
+import { decryptSecret, encryptSecret } from "@/lib/crypto";
+
+/**
+ * 014 — Credenciales del canal de Instagram.
+ *
+ * Mismo contrato que las de WhatsApp (`server/whatsapp/credentials.ts`): el
+ * token viaja descifrado solo en memoria y nunca sale en una respuesta de la
+ * API — hacia fuera se expone únicamente su cola.
+ */
+
+export type InstagramCredentials = {
+  id: string;
+  organizationId: string;
+  source: "zernio" | "meta";
+  igUserId: string;
+  accountRef: string | null;
+  username: string | null;
+  webhookSecret: string | null;
+  status: "connected" | "reconnect_required";
+  token: string;
+};
+
+type Row = typeof schema.instagramCredentials.$inferSelect;
+
+function toCredentials(row: Row): InstagramCredentials {
+  return {
+    id: row.id,
+    organizationId: row.organizationId,
+    source: row.source,
+    igUserId: row.igUserId,
+    accountRef: row.accountRef,
+    username: row.username,
+    webhookSecret: row.webhookSecret,
+    status: row.status,
+    token: decryptSecret({
+      cipher: row.tokenCipher,
+      iv: row.tokenIv,
+      tag: row.tokenTag,
+    }),
+  };
+}
+
+export async function getInstagramCredentialsByOrg(
+  organizationId: string
+): Promise<InstagramCredentials | null> {
+  const rows = await getDb()
+    .select()
+    .from(schema.instagramCredentials)
+    .where(eq(schema.instagramCredentials.organizationId, organizationId))
+    .limit(1);
+  return rows[0] ? toCredentials(rows[0]) : null;
+}
+
+/** Enrutado del webhook de Meta: `entry[].id` es el IG_ID del perfil. */
+export async function getInstagramCredentialsByIgUserId(
+  igUserId: string
+): Promise<InstagramCredentials | null> {
+  const rows = await getDb()
+    .select()
+    .from(schema.instagramCredentials)
+    .where(eq(schema.instagramCredentials.igUserId, igUserId))
+    .limit(1);
+  return rows[0] ? toCredentials(rows[0]) : null;
+}
+
+/** Enrutado del webhook de Zernio: el evento trae `account.id`, no el perfil. */
+export async function getInstagramCredentialsByAccountRef(
+  accountRef: string
+): Promise<InstagramCredentials | null> {
+  const rows = await getDb()
+    .select()
+    .from(schema.instagramCredentials)
+    .where(eq(schema.instagramCredentials.accountRef, accountRef))
+    .limit(1);
+  return rows[0] ? toCredentials(rows[0]) : null;
+}
+
+export async function saveInstagramCredentials(input: {
+  organizationId: string;
+  source: "zernio" | "meta";
+  igUserId: string;
+  accountRef: string | null;
+  username: string | null;
+  token: string;
+  webhookSecret: string | null;
+}): Promise<void> {
+  const db = getDb();
+  const enc = encryptSecret(input.token);
+  const existing = await getInstagramCredentialsByOrg(input.organizationId);
+
+  const values = {
+    organizationId: input.organizationId,
+    source: input.source,
+    igUserId: input.igUserId,
+    accountRef: input.accountRef,
+    username: input.username,
+    tokenCipher: enc.cipher,
+    tokenIv: enc.iv,
+    tokenTag: enc.tag,
+    webhookSecret: input.webhookSecret,
+    status: "connected" as const,
+    updatedAt: new Date(),
+  };
+
+  if (existing) {
+    await db
+      .update(schema.instagramCredentials)
+      .set(values)
+      .where(eq(schema.instagramCredentials.id, existing.id));
+    return;
+  }
+  await db
+    .insert(schema.instagramCredentials)
+    .values({ id: newId("credentials"), ...values });
+}
+
+/** El token murió: se pausan los envíos y la UI pide reconectar. */
+export async function markInstagramReconnectRequired(
+  organizationId: string
+): Promise<void> {
+  await getDb()
+    .update(schema.instagramCredentials)
+    .set({ status: "reconnect_required", updatedAt: new Date() })
+    .where(eq(schema.instagramCredentials.organizationId, organizationId));
+}
+
+export function tokenLast4(token: string): string {
+  return token.slice(-4);
+}

--- a/src/server/instagram/ingest.ts
+++ b/src/server/instagram/ingest.ts
@@ -1,0 +1,192 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { IG_PREFIX } from "@/server/inbox/identity";
+import { ingestInboundMessage } from "@/server/inbox/ingest";
+import {
+  getInstagramCredentialsByAccountRef,
+  getInstagramCredentialsByIgUserId,
+} from "@/server/instagram/credentials";
+
+/**
+ * 014 — Adaptadores de entrada del canal de Instagram.
+ *
+ * Dos fuentes con formatos que no se parecen en nada: Zernio manda un evento
+ * plano y Meta manda `entry[].messaging[]` al estilo Messenger. Cada una se
+ * normaliza aquí y de ahí en adelante corre el MISMO núcleo de ingesta que ya
+ * resuelve contacto, conversación, idempotencia y bus de eventos.
+ */
+
+/** Firma de Zernio: HMAC-SHA256 hex del cuerpo CRUDO, con el secreto. */
+export function isValidZernioSignature(
+  rawBody: string,
+  signature: string | null,
+  secret: string | null
+): boolean {
+  if (!secret) return true; // sin secreto configurado, protege la URL secreta
+  if (!signature) return false;
+  const expected = createHmac("sha256", secret).update(rawBody).digest("hex");
+  const a = Buffer.from(expected, "utf8");
+  const b = Buffer.from(signature.trim().toLowerCase(), "utf8");
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+type ZernioEvent = {
+  id?: string;
+  event?: string;
+  message?: {
+    id?: string;
+    conversationId?: string;
+    direction?: string;
+    text?: string | null;
+    sender?: { id?: string; name?: string | null; username?: string | null };
+  };
+  account?: { id?: string; platform?: string };
+};
+
+/**
+ * Evento de Zernio. Devuelve el secreto esperado para poder validar la firma
+ * ANTES de procesar: el enrutado por `account.id` necesita leer el cuerpo, así
+ * que la validación ocurre en dos tiempos (resolver cuenta, luego firmar).
+ */
+export async function resolveZernioSecret(
+  rawBody: string
+): Promise<{ secret: string | null; accountRef: string | null }> {
+  let parsed: ZernioEvent | null = null;
+  try {
+    parsed = JSON.parse(rawBody) as ZernioEvent;
+  } catch {
+    return { secret: null, accountRef: null };
+  }
+  const accountRef = parsed.account?.id ?? null;
+  if (!accountRef) return { secret: null, accountRef: null };
+  const creds = await getInstagramCredentialsByAccountRef(accountRef);
+  return { secret: creds?.webhookSecret ?? null, accountRef };
+}
+
+export async function processZernioEvent(payload: unknown): Promise<void> {
+  const evt = payload as ZernioEvent;
+
+  // El mismo webhook trae WhatsApp, Facebook y X si esas cuentas estan
+  // conectadas: sin este filtro acabariamos ingiriendo otra plataforma como
+  // si fueran DMs de Instagram.
+  if (evt.account?.platform !== "instagram") return;
+  if (evt.event !== "message.received") return;
+  if (evt.message?.direction && evt.message.direction !== "incoming") return;
+
+  const accountRef = evt.account?.id;
+  if (!accountRef) return;
+
+  const creds = await getInstagramCredentialsByAccountRef(accountRef);
+  if (!creds) {
+    console.warn(
+      `[ig] evento para accountId desconocido (${accountRef}): ` +
+        "guarda la conexion en Configuracion -> Instagram para recibir mensajes"
+    );
+    return;
+  }
+
+  const igsid = evt.message?.sender?.id;
+  if (!igsid) {
+    console.warn(`[ig] evento ${evt.id ?? "?"} sin sender.id: descartado`);
+    return;
+  }
+
+  const text = evt.message?.text ?? null;
+  const platformMessageId = evt.message?.id;
+  if (!platformMessageId) {
+    console.warn(`[ig] evento ${evt.id ?? "?"} sin id de mensaje: descartado`);
+    return;
+  }
+
+  await ingestInboundMessage({
+    organizationId: creds.organizationId,
+    identity: {
+      identity: `${IG_PREFIX}${igsid}`,
+      channel: "instagram",
+      phone: null,
+      waUserId: null,
+      profileName:
+        evt.message?.sender?.name ??
+        (evt.message?.sender?.username
+          ? `@${evt.message.sender.username}`
+          : null),
+    },
+    // Prefijado para que no colisione jamas con un id de WhatsApp en el
+    // indice unico de mensajes.
+    waMessageId: `ig_${platformMessageId}`,
+    type: "text",
+    text,
+    timestamp: String(Math.floor(Date.now() / 1000)),
+    threadRef: evt.message?.conversationId ?? null,
+  });
+}
+
+type MetaIgPayload = {
+  object?: string;
+  entry?: Array<{
+    id?: string;
+    time?: number;
+    messaging?: Array<{
+      sender?: { id?: string };
+      recipient?: { id?: string };
+      timestamp?: number;
+      message?: {
+        mid?: string;
+        text?: string;
+        is_echo?: boolean;
+      };
+    }>;
+  }>;
+};
+
+export async function processMetaInstagramPayload(
+  payload: unknown
+): Promise<void> {
+  const body = payload as MetaIgPayload;
+  if (body.object !== "instagram") return;
+
+  for (const entry of body.entry ?? []) {
+    const igUserId = entry.id;
+    if (!igUserId) continue;
+
+    const creds = await getInstagramCredentialsByIgUserId(igUserId);
+    if (!creds) {
+      console.warn(
+        `[ig] evento para IG_ID desconocido (${igUserId}): ` +
+          "guarda la conexion en Configuracion -> Instagram para recibir mensajes"
+      );
+      continue;
+    }
+
+    for (const m of entry.messaging ?? []) {
+      // Los echos son mensajes que el dueno mando desde la app de Instagram.
+      // Fuera del alcance del 014: se ignoran sin ruido.
+      if (m.message?.is_echo) continue;
+
+      const igsid = m.sender?.id;
+      const mid = m.message?.mid;
+      if (!igsid || !mid) continue;
+      if (typeof m.message?.text !== "string") continue; // solo texto (014)
+
+      await ingestInboundMessage({
+        organizationId: creds.organizationId,
+        identity: {
+          identity: `${IG_PREFIX}${igsid}`,
+          channel: "instagram",
+          phone: null,
+          waUserId: null,
+          // Meta no manda nombre ni usuario en el webhook: queda el respaldo
+          // hasta que alguien edite el contacto.
+          profileName: null,
+        },
+        waMessageId: `ig_${mid}`,
+        type: "text",
+        text: m.message.text,
+        timestamp: String(
+          m.timestamp ? Math.floor(m.timestamp / 1000) : Math.floor(Date.now() / 1000)
+        ),
+        threadRef: null,
+      });
+    }
+  }
+}

--- a/src/server/instagram/ingest.ts
+++ b/src/server/instagram/ingest.ts
@@ -84,6 +84,15 @@ export async function processZernioEvent(payload: unknown): Promise<void> {
     );
     return;
   }
+  if (creds.source !== "zernio") {
+    // Defensa en profundidad: esta instancia no habla con Zernio, asi que un
+    // payload con su forma no puede ser legitimo aunque llegue por la URL
+    // correcta. Sin esto, la unica barrera de la forma ajena es la URL.
+    console.warn(
+      `[ig] payload de Zernio en una instancia configurada como '${creds.source}': descartado`
+    );
+    return;
+  }
 
   const igsid = evt.message?.sender?.id;
   if (!igsid) {
@@ -154,6 +163,15 @@ export async function processMetaInstagramPayload(
       console.warn(
         `[ig] evento para IG_ID desconocido (${igUserId}): ` +
           "guarda la conexion en Configuracion -> Instagram para recibir mensajes"
+      );
+      continue;
+    }
+    if (creds.source !== "meta") {
+      // Idem: sin app propia de Meta, un payload con su forma no puede venir
+      // de Meta. Cierra la inyeccion en instancias que solo usan Zernio, donde
+      // META_APP_SECRET no existe y la firma no se puede verificar.
+      console.warn(
+        `[ig] payload de Meta en una instancia configurada como '${creds.source}': descartado`
       );
       continue;
     }

--- a/src/server/instagram/send.ts
+++ b/src/server/instagram/send.ts
@@ -1,0 +1,165 @@
+import { MetaApiError } from "@/lib/meta/client";
+import type { InstagramCredentials } from "@/server/instagram/credentials";
+
+/**
+ * 014 — Frontera de salida del canal de Instagram (Constitución II: todo
+ * request a una plataforma pasa por un único módulo).
+ *
+ * Dos transportes, misma firma: Zernio (API unificada) y Meta directo
+ * (graph.instagram.com). Ambos devuelven el id del mensaje en la plataforma.
+ */
+
+const ZERNIO_BASE = process.env.ZERNIO_BASE_URL ?? "https://zernio.com/api/v1";
+const IG_GRAPH_BASE =
+  process.env.IG_GRAPH_BASE_URL ?? "https://graph.instagram.com";
+const IG_GRAPH_VERSION = process.env.META_GRAPH_API_VERSION ?? "v25.0";
+
+/** Instagram corta el texto en 1000 BYTES (no caracteres): con acentos y
+ * emojis el margen real es menor de lo que aparenta. */
+export const IG_TEXT_MAX_BYTES = 1000;
+
+export function fitsInstagramText(text: string): boolean {
+  return Buffer.byteLength(text, "utf8") <= IG_TEXT_MAX_BYTES;
+}
+
+export type InstagramSendResult = { platformMessageId: string };
+
+/**
+ * Envía texto por el transporte que corresponda.
+ *
+ * `recipient` es el IGSID (sin el prefijo `ig:`); `threadRef` es el
+ * conversationId opaco de Zernio, que solo hace falta en ese transporte.
+ */
+export async function sendInstagramText(input: {
+  credentials: InstagramCredentials;
+  recipient: string;
+  threadRef: string | null;
+  text: string;
+  /** Fuera de la ventana de 24 h Instagram solo admite HUMAN_AGENT. */
+  humanAgentTag?: boolean;
+}): Promise<InstagramSendResult> {
+  return input.credentials.source === "zernio"
+    ? sendViaZernio(input)
+    : sendViaMeta(input);
+}
+
+async function sendViaZernio(input: {
+  credentials: InstagramCredentials;
+  recipient: string;
+  threadRef: string | null;
+  text: string;
+  humanAgentTag?: boolean;
+}): Promise<InstagramSendResult> {
+  const { credentials, threadRef } = input;
+  if (!threadRef) {
+    throw new MetaApiError(
+      "La conversacion no tiene referencia de hilo en Zernio",
+      { status: 400 }
+    );
+  }
+  const body: Record<string, unknown> = {
+    accountId: credentials.accountRef,
+    message: input.text,
+  };
+  if (input.humanAgentTag) {
+    body.messagingType = "MESSAGE_TAG";
+    body.messageTag = "HUMAN_AGENT";
+  }
+
+  const res = await fetchJson(
+    `${ZERNIO_BASE}/inbox/conversations/${encodeURIComponent(threadRef)}/messages`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${credentials.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }
+  );
+
+  const id =
+    (res as { message?: { id?: string }; id?: string }).message?.id ??
+    (res as { id?: string }).id ??
+    `zernio_${Date.now()}`;
+  return { platformMessageId: String(id) };
+}
+
+async function sendViaMeta(input: {
+  credentials: InstagramCredentials;
+  recipient: string;
+  text: string;
+  humanAgentTag?: boolean;
+}): Promise<InstagramSendResult> {
+  const { credentials } = input;
+  const body: Record<string, unknown> = {
+    recipient: { id: input.recipient },
+    message: { text: input.text },
+  };
+  if (input.humanAgentTag) {
+    body.messaging_type = "MESSAGE_TAG";
+    body.tag = "HUMAN_AGENT";
+  }
+
+  // El host es graph.instagram.com, NO graph.facebook.com: es el error mas
+  // comun de esta integracion y devuelve un fallo de permisos que despista.
+  const res = await fetchJson(
+    `${IG_GRAPH_BASE}/${IG_GRAPH_VERSION}/${credentials.igUserId}/messages`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${credentials.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }
+  );
+
+  const id = (res as { message_id?: string }).message_id ?? `ig_${Date.now()}`;
+  return { platformMessageId: String(id) };
+}
+
+/**
+ * Traduce los fallos de ambas plataformas al MetaApiError que el resto del
+ * CRM ya sabe interpretar (incluido `isAuthError`, que distingue token muerto
+ * de hipo transitorio y costó un incidente aprender).
+ */
+async function fetchJson(
+  url: string,
+  init: RequestInit
+): Promise<unknown> {
+  let res: Response;
+  try {
+    res = await fetch(url, init);
+  } catch (cause) {
+    throw new MetaApiError("No se pudo contactar la API de Instagram", {
+      status: 0,
+      details: cause,
+    });
+  }
+
+  const text = await res.text();
+  let json: unknown = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    // respuesta no-JSON: se conserva el texto crudo
+  }
+
+  if (!res.ok) {
+    const err = json as
+      | { error?: { message?: string; code?: number } | string }
+      | null;
+    const message =
+      typeof err?.error === "string"
+        ? err.error
+        : err?.error?.message ?? `HTTP ${res.status}`;
+    const code = typeof err?.error === "object" ? err.error?.code ?? null : null;
+    throw new MetaApiError(message, {
+      status: res.status,
+      code,
+      details: json ?? text,
+    });
+  }
+  return json;
+}

--- a/tests/unit/channels.test.ts
+++ b/tests/unit/channels.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { CHANNEL_LABEL, CHANNEL_ORDER, isChannel } from "@/lib/channels";
+import { parseChannels } from "@/server/channels/enabled";
+import { capabilitiesFor, textFits } from "@/server/channels/capabilities";
+import { channelMark } from "@/components/channel-badge";
+
+describe("CHANNELS: qué bandejas enciende la instancia (ADR-001)", () => {
+  it("sin la variable, la instancia es de un solo canal", () => {
+    expect([...parseChannels(undefined)]).toEqual(["whatsapp"]);
+    expect([...parseChannels("")]).toEqual(["whatsapp"]);
+  });
+
+  it("enciende lo que se le pida, con espacios y mayúsculas de por medio", () => {
+    const on = parseChannels("  Instagram , WHATSAPP ");
+    expect(on.has("instagram")).toBe(true);
+    expect(on.has("whatsapp")).toBe(true);
+  });
+
+  it("WhatsApp no se puede apagar: es el canal por el que existe el producto", () => {
+    expect(parseChannels("instagram").has("whatsapp")).toBe(true);
+  });
+
+  it("un canal que no existe se ignora, no tumba el arranque", () => {
+    const on = parseChannels("telegram,instagram,,");
+    expect([...on].sort()).toEqual(["instagram", "whatsapp"]);
+  });
+
+  it("isChannel es la única lista: no hay uniones sueltas por ahí", () => {
+    expect(isChannel("whatsapp")).toBe(true);
+    expect(isChannel("instagram")).toBe(true);
+    expect(isChannel("telegram")).toBe(false);
+    expect(isChannel("")).toBe(false);
+  });
+});
+
+describe("capacidades por canal", () => {
+  it("el nombre visible sale de un solo lugar", () => {
+    for (const ch of CHANNEL_ORDER) {
+      expect(capabilitiesFor(ch).label).toBe(CHANNEL_LABEL[ch]);
+    }
+  });
+
+  it("un canal desconocido cae en WhatsApp en vez de reventar", () => {
+    const caps = capabilitiesFor("telegram" as never);
+    expect(caps.label).toBe(CHANNEL_LABEL.whatsapp);
+  });
+
+  it("el límite de Instagram es en BYTES: los acentos cuentan doble", () => {
+    // 600 acentos = 1200 bytes. Contando caracteres esto pasaría, y Meta
+    // rechazaría el envío con un 400 que el operador no sabría leer.
+    expect(textFits("instagram", "é".repeat(600))).toBe(false);
+    expect(textFits("instagram", "a".repeat(600))).toBe(true);
+    expect(textFits("instagram", "a".repeat(1001))).toBe(false);
+  });
+
+  it("WhatsApp no tiene límite práctico de texto", () => {
+    expect(textFits("whatsapp", "a".repeat(5000))).toBe(true);
+  });
+});
+
+describe("distintivo de bandeja", () => {
+  it("todo canal del catálogo tiene su marca dibujada", () => {
+    // Sin esto, agregar un canal y olvidar su glifo no rompe nada: el
+    // distintivo devuelve null y la bandeja se ve como si no tuviera canal.
+    for (const ch of CHANNEL_ORDER) {
+      expect(channelMark(ch)).not.toBeNull();
+    }
+  });
+
+  it("un canal desconocido no pinta nada en vez de tumbar la lista", () => {
+    expect(channelMark("telegram" as never)).toBeNull();
+  });
+});


### PR DESCRIPTION
Bandeja multicanal: WhatsApp e Instagram en la misma conversación, mismo pipeline y mismo agente. El canal viaja apagado por defecto — una instalación normal es indistinguible de la de hoy.

## Cómo se enciende

```
CHANNELS=whatsapp,instagram
```

Sin esa variable: `/api/settings/instagram` y `/api/webhooks/ig/*` responden 404, la salida por ese canal falla con un error claro, y no se piden credenciales suyas.

## Por qué una bandera y no una rama

Está razonado en `docs/adr-001-canales-opcionales.md`. El resumen: una rama por feature opcional tiene que ser compatible con `main` **y con las demás ramas opcionales**, y su cadena de migraciones de Drizzle diverge sin arreglo posible (dos ramas con un `0008_` no coexisten sin renumerar, y eso no es un merge mecánico). Con la bandera hay una sola cadena de migraciones para todo el mundo, y los conflictos los resuelve el autor una vez en vez de cada usuario en cada actualización.

## Modelo de datos (migración aditiva)

- `contact.channel` y `conversation.channel`, con default `whatsapp`: ninguna fila existente cambia de significado, sin backfill.
- El canal entra en el índice único de contacto. Sin eso, un IGSID que coincidiera con un teléfono normalizado mezclaría dos personas en silencio.
- Identidad `ig:<IGSID>`, análoga al `bsuid:` que ya existía para WhatsApp sin teléfono.
- `conversation.channel_thread_ref` guarda el hilo opaco de la plataforma de origen.
- `instagram_credentials`, con el token cifrado por los mismos helpers AES-256-GCM.

**`wa_identity` conserva su nombre a propósito**: es contrato publicado en `/api/bot/context` y hay cerebros externos en producción que dependen de él. Se agrega `identity` como nombre neutro y `waIdentity` queda como alias sin fecha de retiro.

## Capacidades por canal

`src/server/channels/capabilities.ts`. El núcleo ya no sabe las reglas de WhatsApp: las pregunta. La ventana de 24 h, el límite de texto, los adjuntos salientes y los acuses de entrega se declaran por canal. Instagram no tiene plantillas — fuera de ventana usa la etiqueta `HUMAN_AGENT`; y como no reporta entrega por este webhook, su mensaje nace `sent` en vez de quedarse con el reloj puesto para siempre.

## Dos fuentes, un solo canal

Entra por `/api/webhooks/ig/<token>` con dos adaptadores que normalizan al mismo núcleo de ingesta ya existente:

- **Zernio** — firma HMAC-SHA256 sobre el cuerpo crudo, dedupe por id de evento, acuse en menos de 5 s (su timeout).
- **Meta directo** — app propia con el perfil como tester, firma `x-hub-signature-256` como WhatsApp.

Además, la forma del payload debe coincidir con la fuente configurada: una instancia de Zernio descarta los payloads con forma de Meta y viceversa. Cierra la inyección en instancias sin `META_APP_SECRET`, donde la firma no se puede verificar.

## En la bandeja

Cada canal trae su marca, dibujada como el ícono de su aplicación. Aparecen las dos o ninguna: con un solo canal encendido no hay bandejas que distinguir y el sello sería ruido — la misma regla que apaga pantalla y webhook.

Qué bandejas existen lo decide el servidor, no los datos cargados. Si se dedujera de las conversaciones, una instancia con Instagram encendido pero sin DMs todavía se vería de un solo canal, y el primer mensaje repintaría la lista entera.

El encabezado de la lista gana el selector de bandeja con el conteo de cada una. Es el filtro de **afuera**: "Todas" y "No leídas" cuentan dentro de la bandeja elegida, no sobre la suma de los canales.

## Una sola declaración de canal

`src/lib/channels.ts`. El tipo `Channel` estaba declarado dos veces —en `identity.ts` y otra vez a mano dentro del DTO— y el nombre visible del canal otras dos. Agregar un canal obligaba a acordarse de los cuatro sitios, y olvidarse de uno no rompía la compilación: solo dejaba una pantalla mintiendo. Vive en `lib/` porque la interfaz también lo necesita, y la bandera `CHANNELS` deja de traer escrito `"instagram"` — reconoce cualquier canal del catálogo.

## Verificado

- Los cuatro gates pasan con `CHANNELS=whatsapp` y con `CHANNELS=whatsapp,instagram` (257 tests). El CI corre las dos configuraciones en cada PR: una suite que solo prueba una deja el otro camino sin vigilar, y el camino no vigilado es justo el que la bandera del ADR-001 pretendía proteger.
- El canal no tenía pruebas unitarias; se agregan en `tests/unit/channels.test.ts`: el parseo de la bandera (incluido que WhatsApp no se puede apagar), que el límite de Instagram es en **bytes** y no en caracteres —600 acentos son 1200 bytes, y contando caracteres eso pasaría para estrellarse contra un 400 de Meta—, y que todo canal del catálogo tenga su glifo, que si no se olvida en silencio.
- En una instancia real: DM de Instagram entra con su distintivo, respuesta sale, y WhatsApp sigue recibiendo y enviando en la misma instancia.
- El guardrail del Laboratorio (`isTest`) se evalúa antes de la bifurcación por canal: el canal nuevo no puede mandar un mensaje real por ningún camino.
- Una auditoría de seguridad sobre esta rama levantó dos hallazgos en este código; ambos están corregidos aquí (firma de Meta sin verificar, y la migración sin snapshot).

## Fuera de alcance

Comentarios, historias, reacciones, adjuntos salientes por Instagram e importación del historial previo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6eyRCpJJpPWe3NLz6XiZh

