### PR TITLE
feat(015): motor de agendamiento universal detrás de bandera, con conectores

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,24 @@ META_GRAPH_API_VERSION=v25.0
 # Para encender Instagram (ver README - Conexion de Instagram):
 # CHANNELS=whatsapp,instagram
 
+# --- Agenda (opcional) --------------------------------------
+# Motor de agendamiento: horarios, citas y reservas del agente. Apagado por
+# defecto. Sin esta variable no existe para nadie: ni pantalla de Citas, ni
+# Ajustes de Agenda, ni rutas (responden 404), ni instrucciones de agendar en
+# el prompt del agente.
+# AGENDA=on
+#
+# Encenderla NO pide credenciales de terceros: el conector por defecto es
+# "enlace-fijo" (pegas la URL de tu sala de siempre en Ajustes - Agenda).
+# Para que cada cita genere su propia reunion, conecta Zoom o Google Calendar
+# desde esa misma pantalla con las credenciales de TU cuenta (ver
+# docs/agenda-conectores.md). Las variables de abajo solo se tocan para
+# apuntar los conectores a los mocks del self-test:
+# ZOOM_BASE_URL=https://api.zoom.us/v2
+# ZOOM_OAUTH_BASE_URL=https://zoom.us
+# GOOGLE_CAL_BASE_URL=https://www.googleapis.com/calendar/v3
+# GOOGLE_OAUTH_BASE_URL=https://oauth2.googleapis.com
+
 # --- Operación (opcional) -----------------------------------
 # Reabrir el registro público después de la primera organización.
 # ALLOW_SIGNUP=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,31 @@ permissions:
 
 jobs:
   gates:
-    name: typecheck · lint · test · build
+    name: ${{ matrix.config.name }} · typecheck · lint · test · build
     runs-on: ubuntu-latest
+
+    # Los módulos opcionales (canales, agenda) se encienden con variables de
+    # despliegue, así que el código que viaja en main tiene que servir en las
+    # dos configuraciones — y eso no se sabe corriendo solo una.
+    #
+    # `default` es lo que instala la mayoría: sin canales extra y sin agenda.
+    # `completo` es todo encendido. Entre las dos se cubre lo que las banderas
+    # prometen: que apagadas no estorban y encendidas funcionan.
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: default
+            channels: ""
+            agenda: ""
+          - name: completo
+            channels: "whatsapp,instagram"
+            agenda: "on"
+
+    env:
+      CHANNELS: ${{ matrix.config.channels }}
+      AGENDA: ${{ matrix.config.agenda }}
+
     steps:
       - uses: actions/checkout@v7
 

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/001-vocero-core"
+  "feature_directory": "specs/015-motor-agenda-universal"
 }

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,51 +1,53 @@
 <!--
 SYNC IMPACT REPORT
 ==================
-Versión: 1.2.0 → 1.3.0
+Versión: 1.3.0 → 1.4.0
 
 Cambios:
-  - Principio VI "Specs Antes de Código" → EXPANDIDO: se definen tres carriles
-    (ciclo completo / carril ligero / exento) con un criterio objetivo para
-    elegir entre ellos —si toca el modelo de datos o un contrato publicado—, se
-    fija el contenido mínimo del `spec.md` del carril ligero, y se añaden dos
-    reglas: subir de carril al descubrir una migración a mitad de camino, y
-    marcar como tal todo spec escrito a posteriori.
-  - Sección "Flujo de Desarrollo y Puertas de Calidad" → ALINEADA con los carriles:
-    el orden del flujo pasa a depender del carril, y el Constitution Check se
-    declara obligatorio en AMBOS carriles (en el plan si es ciclo completo, en el
-    propio `spec.md` si es carril ligero). Sin esta aclaración el carril ligero
-    habría dejado la puerta constitucional sin sitio donde ocurrir, que sería un
-    debilitamiento —y por tanto un MAJOR—, no una expansión.
-  - Principios I, II, III, IV, V, VII, VIII y IX: íntegros (sin cambio).
+  - Principio II "Soberanía / Self-Hosted" → EXPANDIDO: la lista cerrada de
+    dependencias de runtime gana una tercera categoría, **conectores
+    opcionales**, admisible SOLO bajo cinco condiciones (apagados por defecto
+    tras una bandera de despliegue, aislados tras adaptador dedicado con
+    contrato público, instancia completa sin ellos con degradación definida,
+    credenciales cifradas del propio negocio, y verificables en CI apagados y
+    encendidos). La frase de prohibición se acota: de "PROHIBIDO en v1 … y
+    servicios de Google" a "PROHIBIDO como dependencia del núcleo", con la vía
+    única del conector opcional para servicios de terceros.
+  - Principios I, III, IV, V, VI, VII, VIII y IX: íntegros (sin cambio).
+  - "Restricciones de Plataforma y Seguridad": sin cambio — su regla de
+    aislamiento tras adaptadores dedicados ya cubre a los conectores.
   - Governance: sin cambio.
 
-Bump: MINOR (1.2.0 → 1.3.0) — expansión material de un principio; no elimina ni
-redefine nada de forma incompatible. Lo que antes cumplía el ciclo completo lo
-sigue cumpliendo.
+Bump: MINOR (1.3.0 → 1.4.0) — expansión material de un principio; no elimina ni
+redefine nada de forma incompatible: una instancia default sigue cumpliendo
+exactamente la promesa vigente ("un VPS, un dominio, credenciales de Meta y un
+token de OpenRouter. Nada más").
 
 Motivación:
-  El carril ligero NO es una práctica nueva: es la que el repositorio ya usa.
-  `001-vocero-core` llevó el ciclo completo (12 archivos, ~14.600 palabras)
-  porque era el producto entero; `002-diseno-atlas` se quedó en spec + plan
-  (~1.290 palabras) y `003-paridad-inbox`, en un solo `spec.md` (565 palabras).
-  Esa gradación funcionó, pero nunca se escribió — y sin el escalón intermedio
-  documentado, el siguiente paso hacia abajo acabó siendo ninguno: las features
-  entregadas entre la 003 y la versión 1.2.0 de la app se implementaron sin spec.
-  Esta enmienda ratifica la práctica existente y le pone criterio.
+  El canal de Instagram (014 / ADR-001) entró como integración opcional detrás
+  de CHANNELS sin tocar este principio, porque es la misma Meta Graph API del
+  canal permitido. El motor de agendamiento (feature 015) necesita Zoom y
+  Google — proveedores nuevos — y el principio no daba ninguna vía, ni siquiera
+  apagados por defecto; la única salida habría sido "cada quien su fork", que
+  ADR-001 ya demostró insostenible (la rama 004-motor-agenda quedó irrescatable
+  en 26 días: 76 commits atrás y migración colisionada). La soberanía que el
+  principio protege no se toca: el costo lo paga únicamente la instancia que
+  enciende la bandera y pega SUS credenciales, y la condición 5 lo vuelve
+  verificable en vez de prometido.
+  Propuesta por escrito y ratificación del responsable (2026-08-26):
+  specs/015-motor-agenda-universal/enmienda-constitucional.md.
 
 Plantillas dependientes:
-  - .specify/templates/spec-template.md — ✅ compatible. Sus secciones
-    obligatorias (User Scenarios & Testing, Requirements, Success Criteria)
-    cubren de sobra el mínimo del carril ligero; en ese carril se rellenan solo
-    ellas y se omiten las opcionales.
-  - .specify/templates/plan-template.md — ✅ compatible (solo aplica al ciclo
-    completo; su Constitution Check se evalúa contra esta versión).
-  - .specify/templates/tasks-template.md — ✅ compatible (ídem).
-  - CLAUDE.md — ⚠ conviene reflejar los tres carriles cuando se actualice.
+  - .specify/templates/spec-template.md — ✅ compatible (sin cambios).
+  - .specify/templates/plan-template.md — ✅ compatible; su Constitution Check
+    se evalúa contra esta versión (un conector externo pasa el gate si y solo
+    si cumple las cinco condiciones).
+  - .specify/templates/tasks-template.md — ✅ compatible.
+  - CLAUDE.md — ✅ actualizado en este mismo cambio (regla de Soberanía).
 
 TODOs diferidos:
-  - Deuda documental: las features entregadas entre `003` y la app 1.2.0 siguen
-    sin spec. Se pagan a posteriori y marcadas como tales (ver Principio VI).
+  - Deuda documental heredada de la 1.3.0 (features entre `003` y la app 1.2.0
+    sin spec): sigue igual; esta enmienda no la toca.
 -->
 
 # Vocero CRM Constitution
@@ -86,9 +88,28 @@ dependencias externas en runtime es CERRADA:
   2. **El proveedor LLM**, opcional, accedido EXCLUSIVAMENTE a través del adaptador
      OpenRouter-compatible (`OPENROUTER_BASE_URL` / `OPENROUTER_MODEL`). Sin token
      configurado, el producto funciona como CRM sin agente de IA.
-- **PROHIBIDO en v1**: almacenamiento de objetos externo (S3/R2), servicios de
-  email, Stripe u otro billing, y servicios de Google. Cualquier feature que los
-  requiera queda fuera del alcance de v1.
+  3. **Conectores opcionales**, únicamente bajo TODAS estas condiciones:
+     1. **Apagados por defecto**: se encienden con una bandera de despliegue
+        explícita (patrón ADR-001); una instancia default no los carga, no los
+        menciona y no pide sus credenciales.
+     2. **Aislados tras un adaptador dedicado** con contrato público estable,
+        como el cliente Graph API y el adaptador LLM; el dominio no conoce al
+        proveedor.
+     3. **La instancia funciona completa sin ellos**: existe un camino sin
+        dependencia externa para la misma capacidad (p. ej. el conector
+        `enlace-fijo` de la agenda), y el fallo del proveedor degrada de forma
+        definida — NUNCA bloquea ni pierde la operación core (la cita se crea
+        con link pendiente; el mensaje se responde; el dato se guarda).
+     4. **Credenciales del propio negocio, cifradas en reposo** (Principio I):
+        cada instancia habla con SU cuenta del proveedor; jamás credenciales de
+        una plataforma central.
+     5. **Verificables apagados y encendidos**: la CI ejercita ambas
+        configuraciones y cada conector externo tiene mock con camino infeliz.
+- **PROHIBIDO como dependencia del núcleo** (todo lo que el producto necesite
+  para operar sin banderas): almacenamiento de objetos externo (S3/R2),
+  servicios de email, billing (Stripe u otro) y cualquier servicio de terceros.
+  Un servicio de terceros solo puede entrar como conector opcional bajo las
+  cinco condiciones anteriores.
 - El instalador solo necesita: un VPS con Coolify o Docker, un dominio, credenciales
   de Meta y (opcional) un token de OpenRouter. Nada más.
 - Las funciones core —autenticación y base de datos— corren self-hosted (Better
@@ -313,4 +334,4 @@ práctica, convención o preferencia; ante un conflicto, gana la constitución.
 - **Propagación**: al enmendar la constitución se revisan y, si procede, se actualizan
   las plantillas dependientes (plan, spec, tasks).
 
-**Version**: 1.3.0 | **Ratified**: 2026-07-09 | **Last Amended**: 2026-08-17
+**Version**: 1.4.0 | **Ratified**: 2026-07-09 | **Last Amended**: 2026-08-26

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ externas: el trabajo en segundo plano (agente, Laboratorio) es in-process.
 | La ingesta/envío de mensajes | `src/server/inbox/` (ingest idempotente, send con guard de sandbox, ventana 24h) |
 | Cómo se identifica a un contacto | `src/server/inbox/identity.ts` (teléfono normalizado o `bsuid:<id>`) |
 | Conectar TU propio bot en vez del agente | `src/app/api/bot/*` + `src/server/bot/auth.ts` (X-API-Key) |
+| La agenda (horarios, huecos, citas) | `src/server/agenda/` — detrás de la bandera `AGENDA` (`flag.ts`) |
+| Cómo se entrega la reunión (Zoom, Meet…) | `src/server/agenda/connectors/` + catálogo en `src/lib/agenda-connectors.ts` · guía: [docs/agenda-conectores.md](docs/agenda-conectores.md) |
 | UI | `src/components/` + `src/app/(app)/` |
 
 Los mocks del entorno de pruebas viven en `src/app/api/dev/` (wa-mock +
@@ -70,7 +72,13 @@ Ver [.specify/memory/constitution.md](.specify/memory/constitution.md).
 - **Idempotencia (IV)**: webhooks dedup por `wa_message_id` UNIQUE; estados
   monotónicos; seeds y migraciones re-ejecutables.
 - **Sandbox del Laboratorio**: las conversaciones `is_test` JAMÁS tocan la API
-  real — el sender lanza excepción (no lo "arregles": es un guardrail).
+  real — el sender lanza excepción (no lo "arregles": es un guardrail). Lo
+  mismo vale para la agenda: una cita de prueba nunca llega a un conector.
+- **Módulos opcionales (015)**: lo que no usa toda instancia va detrás de una
+  bandera de despliegue, apagado por defecto, con su superficie en 404 y la
+  migración aplicada igual. Nunca en una rama aparte
+  ([ADR-001](docs/adr-001-canales-opcionales.md),
+  [ADR-002](docs/adr-002-conectores-de-agenda.md)).
 
 ## Variables de entorno
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,10 +55,14 @@ funciona igual.
 
 Ver [.specify/memory/constitution.md](.specify/memory/constitution.md).
 
-- **Soberanía (II, endurecida)**: dependencias de runtime SOLO WhatsApp Cloud
-  API + proveedor LLM OpenRouter-compatible opcional. PROHIBIDO en v1
-  introducir S3/R2, email, Stripe, Google u otros servicios externos. Auth y
-  BD self-hosted.
+- **Soberanía (II, endurecida — 1.4.0)**: el NÚCLEO depende solo de WhatsApp
+  Cloud API + proveedor LLM OpenRouter-compatible opcional; prohibido meterle
+  S3/R2, email, billing u otros terceros. Un servicio de terceros solo entra
+  como **conector opcional**: apagado por defecto tras bandera (patrón
+  ADR-001), aislado tras adaptador con contrato público, con camino sin
+  dependencia externa y degradación definida (su fallo jamás bloquea la
+  operación core), credenciales del negocio cifradas, y CI que lo prueba
+  apagado y encendido. Auth y BD self-hosted.
 - **Seguridad (I)**: secretos cifrados en reposo (AES-256-GCM, `lib/crypto`);
   jamás al cliente ni a logs. El token de WhatsApp solo muestra sus últimos 4.
 - **Multi-tenancy (III)**: `organization_id` NOT NULL en toda tabla de dominio;

--- a/README.md
+++ b/README.md
@@ -99,6 +99,30 @@ está en [`tests/e2e/us-bot-api.md`](tests/e2e/us-bot-api.md).
 
 Agente de referencia: [nea-agent](https://github.com/kevinrivm/nea-agent), MIT.
 
+### 📅 Agenda con huecos reales (opcional, apagada por defecto)
+
+Enciéndela con `AGENDA=on` y el CRM sabe cuándo estás libre: defines tu horario
+en Ajustes → Agenda y tu agente ofrece huecos concretos, reserva el que el
+cliente elige y lo deja registrado junto a su conversación. Dos garantías que
+no se negocian: **solo se reserva un horario que se ofreció** (nada de que el
+modelo invente un martes a las 10) y **nunca se confirma una cita que no se
+creó** — si el hueco se ocupó a media conversación, la respuesta trae
+alternativas frescas en vez de una promesa falsa.
+
+Cómo se entrega la reunión lo eliges tú, con un **conector**:
+
+| Conector | Qué hace | Necesita |
+|---|---|---|
+| **Enlace fijo** (default) | Reparte tu sala de siempre | Nada |
+| **Zoom** | Una reunión por cita; mover la mueve, cancelar la borra | Tu app Server-to-Server |
+| **Google Calendar + Meet** | Un evento en tu calendario con su enlace de Meet | Tu app de Google Cloud |
+
+¿Usas otra cosa? El contrato son cuatro operaciones y está publicado: escribe
+tu conector en tu fork siguiendo
+[`docs/agenda-conectores.md`](docs/agenda-conectores.md). Y si tu proveedor se
+cae, la cita **se agenda igual** con el enlace pendiente de reintentar: un
+tercero caído no te cuesta la conversión.
+
 ### 📄 Plantillas · 👥 Multi-usuario · 🔐 Self-hosted
 
 Plantillas con varias variables `{{1}}…{{n}}` y aprobación de Meta
@@ -347,18 +371,31 @@ La versión vive en `package.json` y se sube en el PR que publica el cambio.
 - Analytics de conversación y plantillas.
 - Broadcast con opt-in verificado.
 
-### Fuera de alcance a propósito
+### Antes fuera de alcance, ahora detrás de una bandera
 
-**Motor de agendamiento** (horarios de atención, huecos, reservas). Son unas
-mil líneas, dos tablas y una dependencia de fechas dentro de un proyecto cuyo
-argumento es ser ligero; y el estado de qué huecos se ofrecieron pertenece a la
-conversación, o sea al agente, no al CRM. Si tu bot agenda, el contrato que
-esperan `/api/bot/availability` y `/api/bot/bookings` está documentado en el
-[issue #8](https://github.com/kevinrivm/vocero-crm/issues/8) para que lo
-implementes donde te convenga.
+**El motor de agendamiento ya está en el core**, apagado por defecto. Aquí
+decía que quedaba fuera a propósito, con dos razones. Las dos eran buenas y
+las dos cambiaron; se dejan escritas porque el porqué importa más que la
+conclusión:
 
-Si viste algún video donde digo que Vocero trae el motor de agendamiento: me
-adelanté, y esta es la aclaración.
+- *"Son mil líneas y una dependencia de fechas en un proyecto cuyo argumento es
+  ser ligero."* — Cierto, y por eso vive detrás de `AGENDA`: una instancia que
+  no agenda no ve pantallas, ni rutas, ni una instrucción de agendar en el
+  prompt de su agente, ni se le pide una sola credencial. El peso lo paga quien
+  la enciende. Lo de la dependencia de fechas ya no aplica: el motor no agregó
+  ninguna (la aritmética de zonas usa `Intl` de la plataforma).
+- *"El estado de qué huecos se ofrecieron pertenece a la conversación, o sea al
+  agente, no al CRM."* — Pertenecía al agente mientras el CRM no ofreciera la
+  garantía. Al ofrecerla, es el CRM quien tiene que poder probarla: con la
+  memoria del lado del cliente, cualquier cerebro conectado por `/api/bot/*`
+  podría reservar un horario que jamás se ofreció y el CRM lo aceptaría. Ahora
+  la regla es inviolable por construcción y vale igual para el agente incluido,
+  para tu bot y para el que venga.
+
+Lo que sigue fuera, y a propósito: **leer calendarios externos** para descontar
+disponibilidad. El motor calcula con lo suyo y los compromisos de fuera se
+reflejan con bloqueos manuales; meter al proveedor en ese camino acoplaría su
+latencia y sus caídas a la pantalla que más se usa.
 
 ## Stack
 

--- a/docs/adr-002-conectores-de-agenda.md
+++ b/docs/adr-002-conectores-de-agenda.md
@@ -1,0 +1,94 @@
+# ADR-002 — El motor de agenda entra al core, y los proveedores entran como conectores
+
+**Estado**: aceptado · **Fecha**: 2026-08-26 · **Feature**:
+[`015-motor-agenda-universal`](../specs/015-motor-agenda-universal/spec.md)
+
+## Contexto
+
+El README decía que el motor de agendamiento quedaba **fuera de alcance a
+propósito**, con dos razones honestas: pesa demasiado para un producto cuyo
+argumento es ser ligero, y el estado de qué huecos se ofrecieron pertenece a la
+conversación —o sea al agente—, no al CRM.
+
+Mientras tanto, agendar es donde una conversación de WhatsApp se convierte en
+negocio, y el fork de agencia que originó a Vocero lleva meses agendando con
+Zoom en producción. La pregunta no era si el motor servía, sino dónde debía
+vivir sin romper la promesa de ligereza.
+
+[ADR-001](./adr-001-canales-opcionales.md) ya había resuelto la mitad del
+problema para los canales: lo opcional se entrega **en el core, apagado, detrás
+de una bandera**, porque una rama por feature no se sostiene (su cadena de
+migraciones diverge sin arreglo). La prueba está en este mismo repositorio: la
+rama `004-motor-agenda`, con el motor entero escrito, quedó irrescatable en 26
+días —76 commits atrás y con su migración colisionada— sin que nadie hiciera
+nada mal.
+
+## Decisión
+
+**1. El motor entra al core detrás de la bandera `AGENDA`**, apagada por
+defecto, con los mismos criterios de ADR-001: superficies en 404, sin rastro en
+la UI, sin tokens de prompt, sin pedir credenciales, y la migración aplicada
+siempre (unas tablas vacías son inertes).
+
+No se reutiliza `CHANNELS`: agendar no es un canal, y mezclar las dos
+taxonomías haría que el contrato de capacidades por canal dejara de significar
+lo que dice.
+
+**2. La memoria de lo ofrecido baja al CRM.** El argumento del README era
+correcto mientras el CRM no ofreciera la garantía. Al ofrecerla, es el CRM
+quien tiene que poder probarla: con esa memoria del lado del cliente, cualquier
+cerebro conectado por `/api/bot/*` podría reservar un instante que jamás se
+ofreció, y el CRM lo aceptaría. Vocero promete "conecta tu propio cerebro"; una
+promesa así no puede depender de que todos los cerebros se porten bien.
+
+**3. Los proveedores entran como conectores, no como integraciones.** Un
+contrato público de **cuatro operaciones** —crear, mover, borrar reunión y
+probar conexión— medido del uso real del fork, más una quinta opcional
+(`refreshMeeting`) que apareció al descubrir que Google crea la conferencia de
+forma asíncrona. v1 trae tres: `enlace-fijo` (soberano, default), `zoom` y
+`google`.
+
+**4. La disponibilidad NO lee calendarios externos.** El contrato ni siquiera
+declara la operación. Es una decisión, no un hueco: meter al proveedor en el
+camino caliente acoplaría su latencia y sus caídas a la pantalla que más se
+usa. Los compromisos de fuera se reflejan con bloqueos manuales.
+
+**5. El fallo del proveedor no cuesta la conversión.** Los efectos corren
+después de escribir la verdad del CRM y son best-effort: la cita se crea con
+`link_pending` y el operador reintenta. Sin cola ni cron — el core no tiene
+infraestructura para eso, y el reintento manual entrega el 90% del valor con el
+10% de la maquinaria.
+
+## Lo que se descartó
+
+- **Dejarlo fuera y documentar el contrato en un issue** (lo que decía el
+  README). Traslada al usuario el trabajo de implementar dos endpoints con dos
+  garantías sutiles; el resultado previsible es cada quien reinventándolas mal,
+  y la peor de las dos fallas —confirmar una cita que no se creó— es
+  silenciosa.
+- **Una rama con el motor.** ADR-001 explica por qué; la rama `004` lo
+  demuestra.
+- **Una skill que parchea el código al instalar.** Blanco móvil: cada
+  instalación acaba siendo distinta e irreproducible.
+- **Una integración de Zoom cableada, como en el fork** (`zoom_meeting_id` en
+  la tabla de citas, cliente propio, sin abstracción). Funciona para un
+  proveedor y bloquea al siguiente: el segundo obliga a migrar el esquema.
+- **Una segunda bandera para los conectores** (`AGENDA_CONNECTORS=zoom,google`).
+  El opt-in real ya lo da la configuración: sin conector seleccionado Y
+  credenciales pegadas, ningún código llama a nadie. Sería ceremonia sin
+  garantía nueva.
+
+## Consecuencias
+
+- Una instancia default sigue necesitando exactamente lo mismo que antes: un
+  VPS, un dominio, credenciales de Meta y un token de LLM opcional.
+- La constitución subió a **1.4.0**: el Principio II admite conectores
+  opcionales bajo cinco condiciones. Sin esa enmienda, `zoom` y `google` no
+  podrían existir en el core ni apagados.
+- La CI corre ahora en **dos configuraciones** (todo apagado / todo encendido).
+  Es la matriz que ADR-001 prometió y nunca se implementó: se paga aquí, y
+  cubre las dos banderas a la vez.
+- Van dos banderas (`CHANNELS`, `AGENDA`). El criterio de revisión de ADR-001
+  sigue vigente: **a la tercera** conviene sentarse a ver si merecen una
+  interfaz común, y del orden de quince es señal de que hace falta un mecanismo
+  de extensiones de verdad.

--- a/docs/agenda-conectores.md
+++ b/docs/agenda-conectores.md
@@ -1,0 +1,140 @@
+# Conectores de agenda
+
+Un **conector** es la forma en que una cita del CRM se convierte en una reunión
+de verdad. El motor de agenda no sabe de proveedores: sabe *cuándo* atiende el
+negocio y *quién* reservó. Entregar la reunión es trabajo del conector.
+
+Esa separación es lo que hace que agregar Teams, Outlook, CalDAV o Cal.com en
+tu fork sea escribir un archivo y una tabla — no pelearte con el motor.
+
+> Los conectores que hablan con un servicio externo existen bajo cinco
+> condiciones constitucionales (Principio II, v1.4.0): apagados por defecto,
+> aislados tras su adaptador, con un camino sin dependencia que funcione igual,
+> credenciales cifradas del propio negocio, y probados en CI encendidos y
+> apagados. Un conector que no las cumpla no entra al core.
+
+## Los que vienen incluidos
+
+### Enlace fijo (`enlace-fijo`) — el default
+
+Tu sala de siempre. Pegas la URL una vez en Ajustes → Agenda y cada cita la
+reparte. No habla con nadie, no pide credenciales y no puede fallar. Si lo
+dejas vacío, las citas se agendan igual y sin enlace: nadie promete lo que no
+tiene.
+
+Es también la razón de que encender la agenda no te obligue a conectar nada.
+
+### Zoom (`zoom`)
+
+Cada cita crea su propia reunión de Zoom. Reprogramar la mueve conservando el
+mismo enlace; cancelar la borra.
+
+**Qué necesitas**: una app **Server-to-Server OAuth** en el Marketplace de Zoom
+(la crea el negocio, en su propia cuenta). De ahí salen los tres datos que se
+pegan en Ajustes → Agenda: *Account ID*, *Client ID* y *Client Secret*.
+
+**Los cuatro permisos (scopes)**:
+
+```text
+meeting:write:meeting     crear la reunión
+meeting:update:meeting    moverla al reprogramar
+meeting:delete:meeting    borrarla al cancelar
+user:read:user            leer tu usuario
+```
+
+> ⚠️ El cuarto se olvida siempre. Es el que usa el botón **Probar**: sin él, la
+> conexión falla aunque tus credenciales sirvan perfectamente para crear
+> reuniones, y el mensaje de error no lo dice.
+
+### Google Calendar + Meet (`google`)
+
+Cada cita crea un evento en tu calendario con su enlace de Meet. Su
+diferencial: la cita aparece donde ya miras tu día.
+
+**Qué necesitas**: un proyecto en Google Cloud **del propio negocio** con la
+API de Calendar activada, y de ahí *Client ID*, *Client Secret* y un *refresh
+token* con el permiso `calendar.events`. El calendario destino es `primary`
+salvo que pongas otro.
+
+> ⚠️ **Publica tu app OAuth "en producción".** Si la dejas en modo prueba,
+> Google **revoca el refresh token a los 7 días** y tus citas dejarán de generar
+> enlace sin previo aviso. Cuando pasa, el CRM marca la conexión como rota y te
+> lo muestra en Ajustes — pero la semana perdida no se recupera.
+
+Dos detalles que este conector resuelve por dentro, y que conviene conocer si
+escribes uno parecido: la conferencia de Meet se crea **de forma asíncrona** (la
+respuesta de crear el evento puede venir sin enlace), así que el conector
+re-lee el evento; y si aun así no llegó, la cita se entrega con el evento
+creado y el enlace pendiente — reintentarlo **re-lee ese mismo evento**, nunca
+crea uno duplicado en tu calendario.
+
+## Qué pasa cuando el proveedor falla
+
+Nada que te cueste una cita. El orden es deliberado: **primero se escribe la
+verdad en el CRM, después se habla con el proveedor**. Si el proveedor está
+caído, rechaza las credenciales o simplemente tarda:
+
+1. La cita **se crea igual** y se responde `201`, con `linkPending: true` y sin
+   enlace.
+2. Quien confirma al cliente dice que el enlace llega en un momento, en vez de
+   prometer uno que no existe.
+3. La cita aparece en **Citas** marcada "sin enlace", con un botón para
+   **reintentar**.
+4. Si el fallo fue de autenticación, la conexión queda marcada como rota en
+   Ajustes, con su tarjeta de reconexión.
+
+## Escribe tu conector
+
+El contrato son **cuatro operaciones** (más una opcional). No es un mínimo
+prudente: es exactamente lo que el uso real necesitó en un CRM en producción
+durante meses.
+
+```ts
+// src/server/agenda/connectors/types.ts
+createMeeting(creds, { topic, startUtc, durationMinutes, timezone, notes? })
+  → { externalId, joinUrl }
+updateMeeting(creds, externalId, { startUtc, durationMinutes, timezone })
+  → void                      // al reprogramar; conserva el enlace
+deleteMeeting(creds, externalId) → void   // al cancelar; un 404 es ÉXITO
+testConnection(creds) → { ok: true } | { ok: false, error }
+
+// Opcional, solo si tu proveedor genera el enlace de forma asíncrona:
+refreshMeeting?(creds, externalId) → { externalId, joinUrl }
+```
+
+Reglas que hace cumplir el motor, no tú:
+
+- **Best-effort.** Una excepción tuya jamás revierte ni bloquea la cita.
+- **Sandbox.** Una cita del Laboratorio nunca llega a un conector: la aserción
+  vive antes de elegir cuál. No compruebes `is_test`; no te toca.
+- **Idempotencia.** Borrar algo que ya no está es objetivo cumplido.
+- **Sin free/busy.** El contrato no lee disponibilidad ajena, a propósito: la
+  disponibilidad se calcula local, en una query, y meter al proveedor ahí
+  acoplaría su latencia a la pantalla que más se usa. Si tu fork lo necesita,
+  es una extensión — no un hueco.
+
+### Los seis archivos que tocas
+
+1. `src/lib/agenda-connectors.ts` — tu id y tu ficha (etiqueta, descripción,
+   capacidades). Es lo que la pantalla de Ajustes muestra.
+2. `src/server/agenda/connectors/<id>.ts` — el adaptador.
+3. `src/server/agenda/connectors/<id>-credentials.ts` + `src/lib/db/schema.ts`
+   y una migración aditiva — TU tabla, con TU forma. Tabla explícita, no un
+   jsonb genérico: unas credenciales tienen forma fija y así conservan tipado e
+   índices. Cifra con `@/lib/crypto`, como todos.
+4. `src/server/agenda/connectors/index.ts` — una rama en el `switch`.
+5. `src/app/api/settings/<id>/route.ts` (+ `test/`) — pegar credenciales,
+   **validar contra el proveedor antes de guardar**, exponer solo los últimos 4.
+6. `src/app/api/dev/<id>-mock/` — tu mock, con `_state`, `_reset` y un camino
+   infeliz determinista.
+
+Cero archivos del motor. Si te encuentras editando `service.ts` o
+`availability.ts` para que tu conector funcione, algo se salió del contrato:
+levanta un issue antes de forzarlo.
+
+### Cómo sabes que funciona
+
+`tests/unit/connectors.test.ts` es una suite de contrato **compartida**: la
+misma para todos. Agrega tu conector ahí y haz que pase — es la definición de
+"está bien escrito", y evita descubrir en producción que tu `deleteMeeting`
+revienta con un 404 o que tu enlace no sobrevive a un reprogramado.

--- a/drizzle/0009_motor_agenda.sql
+++ b/drizzle/0009_motor_agenda.sql
@@ -1,0 +1,135 @@
+-- 015 Motor de agendamiento universal (agenda, citas, memoria de lo ofrecido
+-- y credenciales de los conectores).
+--
+-- Editada a mano sobre la generada para ser RE-EJECUTABLE (Constitución IV):
+-- IF NOT EXISTS en tablas e índices, y DO-block en cada clave foránea.
+--
+-- Es puramente ADITIVA: no toca ninguna tabla existente, así que aplicarla
+-- sobre una instancia con datos no puede perder nada. Se aplica SIEMPRE, con
+-- la bandera AGENDA encendida o apagada: unas tablas vacías son inertes y a
+-- cambio todas las instancias comparten la misma estructura (ADR-001).
+
+CREATE TABLE IF NOT EXISTS "calendar_settings" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"weekly_hours" jsonb NOT NULL,
+	"slot_minutes" integer DEFAULT 30 NOT NULL,
+	"buffer_minutes" integer DEFAULT 0 NOT NULL,
+	"min_notice_hours" integer DEFAULT 2 NOT NULL,
+	"max_days_ahead" integer DEFAULT 7 NOT NULL,
+	"timezone" text DEFAULT 'America/Mexico_City' NOT NULL,
+	"connector" text DEFAULT 'enlace-fijo' NOT NULL,
+	"meeting_link" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "booking" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"kind" text DEFAULT 'session' NOT NULL,
+	"status" text DEFAULT 'agendada' NOT NULL,
+	"source" text DEFAULT 'manual' NOT NULL,
+	"contact_id" text,
+	"conversation_id" text,
+	"lead_id" text,
+	"scheduled_at" timestamp NOT NULL,
+	"duration_minutes" integer NOT NULL,
+	"connector" text,
+	"external_ref" text,
+	"meeting_link" text,
+	"link_pending" boolean DEFAULT false NOT NULL,
+	"is_test" boolean DEFAULT false NOT NULL,
+	"notes" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "offered_slot" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"conversation_id" text NOT NULL,
+	"start_utc" timestamp NOT NULL,
+	"label" text NOT NULL,
+	"offered_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "zoom_credentials" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"account_id" text NOT NULL,
+	"client_id" text NOT NULL,
+	"secret_cipher" text NOT NULL,
+	"secret_iv" text NOT NULL,
+	"secret_tag" text NOT NULL,
+	"status" text DEFAULT 'connected' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "google_credentials" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"client_id" text NOT NULL,
+	"client_secret_cipher" text NOT NULL,
+	"client_secret_iv" text NOT NULL,
+	"client_secret_tag" text NOT NULL,
+	"refresh_token_cipher" text NOT NULL,
+	"refresh_token_iv" text NOT NULL,
+	"refresh_token_tag" text NOT NULL,
+	"calendar_id" text DEFAULT 'primary' NOT NULL,
+	"status" text DEFAULT 'connected' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+
+DO $$ BEGIN
+	ALTER TABLE "calendar_settings" ADD CONSTRAINT "calendar_settings_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+	ALTER TABLE "booking" ADD CONSTRAINT "booking_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+	ALTER TABLE "booking" ADD CONSTRAINT "booking_contact_id_contact_id_fk" FOREIGN KEY ("contact_id") REFERENCES "public"."contact"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+	ALTER TABLE "booking" ADD CONSTRAINT "booking_conversation_id_conversation_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversation"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+	ALTER TABLE "booking" ADD CONSTRAINT "booking_lead_id_lead_id_fk" FOREIGN KEY ("lead_id") REFERENCES "public"."lead"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+	ALTER TABLE "offered_slot" ADD CONSTRAINT "offered_slot_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+	ALTER TABLE "offered_slot" ADD CONSTRAINT "offered_slot_conversation_id_conversation_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversation"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+	ALTER TABLE "zoom_credentials" ADD CONSTRAINT "zoom_credentials_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+	ALTER TABLE "google_credentials" ADD CONSTRAINT "google_credentials_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS "calendar_settings_org_uq" ON "calendar_settings" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "booking_org_when_idx" ON "booking" USING btree ("organization_id","scheduled_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "booking_org_status_idx" ON "booking" USING btree ("organization_id","status");--> statement-breakpoint
+
+-- Anti doble-booking ATÓMICO: dos confirmaciones simultáneas sobre el mismo
+-- instante no pueden ganar las dos; la perdedora recibe un 23505 que el
+-- servicio traduce a `slot_taken` con alternativas frescas. Las citas de
+-- prueba del Laboratorio quedan fuera: no consumen la agenda real.
+CREATE UNIQUE INDEX IF NOT EXISTS "booking_org_active_slot_uq" ON "booking" USING btree ("organization_id","scheduled_at") WHERE "booking"."status" in ('agendada','realizada') and "booking"."is_test" = false;--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "offered_slot_conv_idx" ON "offered_slot" USING btree ("conversation_id","start_utc");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "zoom_credentials_org_uq" ON "zoom_credentials" USING btree ("organization_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "google_credentials_org_uq" ON "google_credentials" USING btree ("organization_id");

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,3304 @@
+{
+  "id": "4744308a-ddd1-4ee2-95c3-eda8a9abc9f6",
+  "prevId": "a0eeb00d-456e-43de-8fa9-471f3676d054",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_profile": {
+      "name": "agent_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asistente'"
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalation_rules": {
+          "name": "escalation_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_profile_org_uq": {
+          "name": "agent_profile_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_profile_organization_id_organization_id_fk": {
+          "name": "agent_profile_organization_id_organization_id_fk",
+          "tableFrom": "agent_profile",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_case": {
+      "name": "agent_test_case",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "veredicto": {
+          "name": "veredicto",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hallazgos": {
+          "name": "hallazgos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_case_run_idx": {
+          "name": "test_case_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_case_organization_id_organization_id_fk": {
+          "name": "agent_test_case_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_run_id_agent_test_run_id_fk": {
+          "name": "agent_test_case_run_id_agent_test_run_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "agent_test_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_conversation_id_conversation_id_fk": {
+          "name": "agent_test_case_conversation_id_conversation_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_run": {
+      "name": "agent_test_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "test_run_org_running_uq": {
+          "name": "test_run_org_running_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_test_run\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_run_org_idx": {
+          "name": "test_run_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_run_organization_id_organization_id_fk": {
+          "name": "agent_test_run_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking": {
+      "name": "booking",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'session'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'agendada'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector": {
+          "name": "connector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_link": {
+          "name": "meeting_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_pending": {
+          "name": "link_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_test": {
+          "name": "is_test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "booking_org_when_idx": {
+          "name": "booking_org_when_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_org_status_idx": {
+          "name": "booking_org_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_org_active_slot_uq": {
+          "name": "booking_org_active_slot_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"booking\".\"status\" in ('agendada','realizada') and \"booking\".\"is_test\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_organization_id_organization_id_fk": {
+          "name": "booking_organization_id_organization_id_fk",
+          "tableFrom": "booking",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "booking_contact_id_contact_id_fk": {
+          "name": "booking_contact_id_contact_id_fk",
+          "tableFrom": "booking",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "booking_conversation_id_conversation_id_fk": {
+          "name": "booking_conversation_id_conversation_id_fk",
+          "tableFrom": "booking",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "booking_lead_id_lead_id_fk": {
+          "name": "booking_lead_id_lead_id_fk",
+          "tableFrom": "booking",
+          "tableTo": "lead",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_settings": {
+      "name": "calendar_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_hours": {
+          "name": "weekly_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_minutes": {
+          "name": "slot_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "buffer_minutes": {
+          "name": "buffer_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "min_notice_hours": {
+          "name": "min_notice_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "max_days_ahead": {
+          "name": "max_days_ahead",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/Mexico_City'"
+        },
+        "connector": {
+          "name": "connector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enlace-fijo'"
+        },
+        "meeting_link": {
+          "name": "meeting_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_settings_org_uq": {
+          "name": "calendar_settings_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_settings_organization_id_organization_id_fk": {
+          "name": "calendar_settings_organization_id_organization_id_fk",
+          "tableFrom": "calendar_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact": {
+      "name": "contact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'whatsapp'"
+        },
+        "wa_identity": {
+          "name": "wa_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_user_id": {
+          "name": "wa_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ficha": {
+          "name": "ficha",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_org_channel_identity_uq": {
+          "name": "contact_org_channel_identity_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_wa_user_id_idx": {
+          "name": "contact_org_wa_user_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_name_idx": {
+          "name": "contact_org_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_organization_id_organization_id_fk": {
+          "name": "contact_organization_id_organization_id_fk",
+          "tableFrom": "contact",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_test": {
+          "name": "is_test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'whatsapp'"
+        },
+        "channel_thread_ref": {
+          "name": "channel_thread_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_enabled": {
+          "name": "ai_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handoff_at": {
+          "name": "handoff_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_reason": {
+          "name": "handoff_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_inbound_at": {
+          "name": "last_inbound_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_org_contact_real_uq": {
+          "name": "conversation_org_contact_real_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation\".\"is_test\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_org_last_idx": {
+          "name": "conversation_org_last_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_organization_id_organization_id_fk": {
+          "name": "conversation_organization_id_organization_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_contact_id_contact_id_fk": {
+          "name": "conversation_contact_id_contact_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_credentials": {
+      "name": "google_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_cipher": {
+          "name": "client_secret_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_iv": {
+          "name": "client_secret_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_tag": {
+          "name": "client_secret_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_cipher": {
+          "name": "refresh_token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_iv": {
+          "name": "refresh_token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_tag": {
+          "name": "refresh_token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "google_credentials_org_uq": {
+          "name": "google_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_credentials_organization_id_organization_id_fk": {
+          "name": "google_credentials_organization_id_organization_id_fk",
+          "tableFrom": "google_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instagram_credentials": {
+      "name": "instagram_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ig_user_id": {
+          "name": "ig_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_ref": {
+          "name": "account_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_cipher": {
+          "name": "token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instagram_credentials_org_uq": {
+          "name": "instagram_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instagram_credentials_ig_user_uq": {
+          "name": "instagram_credentials_ig_user_uq",
+          "columns": [
+            {
+              "expression": "ig_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instagram_credentials_account_ref_idx": {
+          "name": "instagram_credentials_account_ref_idx",
+          "columns": [
+            {
+              "expression": "account_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instagram_credentials_organization_id_organization_id_fk": {
+          "name": "instagram_credentials_organization_id_organization_id_fk",
+          "tableFrom": "instagram_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_entry": {
+      "name": "kb_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kb_org_idx": {
+          "name": "kb_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_entry_organization_id_organization_id_fk": {
+          "name": "kb_entry_organization_id_organization_id_fk",
+          "tableFrom": "kb_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead": {
+      "name": "lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_updated_at": {
+          "name": "priority_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lead_contact_uq": {
+          "name": "lead_contact_uq",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lead_org_stage_idx": {
+          "name": "lead_org_stage_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_organization_id_organization_id_fk": {
+          "name": "lead_organization_id_organization_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_contact_id_contact_id_fk": {
+          "name": "lead_contact_id_contact_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead_stage_event": {
+      "name": "lead_stage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_stage_id": {
+          "name": "from_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_stage_name": {
+          "name": "from_stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage_id": {
+          "name": "to_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage_name": {
+          "name": "to_stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_stage_kind": {
+          "name": "to_stage_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dueno'"
+        },
+        "approximate": {
+          "name": "approximate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "loss_reason": {
+          "name": "loss_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loss_note": {
+          "name": "loss_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lse_org_occurred_idx": {
+          "name": "lse_org_occurred_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lse_lead_occurred_idx": {
+          "name": "lse_lead_occurred_idx",
+          "columns": [
+            {
+              "expression": "lead_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lse_org_kind_occurred_idx": {
+          "name": "lse_org_kind_occurred_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_stage_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_stage_event_organization_id_organization_id_fk": {
+          "name": "lead_stage_event_organization_id_organization_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_lead_id_lead_id_fk": {
+          "name": "lead_stage_event_lead_id_lead_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "lead",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_contact_id_contact_id_fk": {
+          "name": "lead_stage_event_contact_id_contact_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_from_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_event_from_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "from_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_to_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_event_to_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "to_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_actor_user_id_user_id_fk": {
+          "name": "lead_stage_event_actor_user_id_user_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lse_loss_reason_ck": {
+          "name": "lse_loss_reason_ck",
+          "value": "\"lead_stage_event\".\"to_stage_kind\" <> 'lost' OR \"lead_stage_event\".\"approximate\" = true OR \"lead_stage_event\".\"loss_reason\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_asset": {
+      "name": "media_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_media_id": {
+          "name": "wa_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_status": {
+          "name": "fetch_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_asset_org_idx": {
+          "name": "media_asset_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_asset_wa_media_idx": {
+          "name": "media_asset_wa_media_idx",
+          "columns": [
+            {
+              "expression": "wa_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_asset_organization_id_organization_id_fk": {
+          "name": "media_asset_organization_id_organization_id_fk",
+          "tableFrom": "media_asset",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_message_id": {
+          "name": "wa_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated": {
+          "name": "ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'operator'"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_timestamp": {
+          "name": "wa_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_org_conv_idx": {
+          "name": "message_org_conv_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_organization_id_organization_id_fk": {
+          "name": "message_organization_id_organization_id_fk",
+          "tableFrom": "message",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_media_asset_id_media_asset_id_fk": {
+          "name": "message_media_asset_id_media_asset_id_fk",
+          "tableFrom": "message",
+          "tableTo": "media_asset",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_wa_message_id_unique": {
+          "name": "message_wa_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wa_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_credentials": {
+      "name": "meta_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waba_id": {
+          "name": "waba_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number_id": {
+          "name": "phone_number_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_phone_number": {
+          "name": "display_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_name": {
+          "name": "verified_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_cipher": {
+          "name": "token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meta_credentials_org_uq": {
+          "name": "meta_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meta_credentials_phone_uq": {
+          "name": "meta_credentials_phone_uq",
+          "columns": [
+            {
+              "expression": "phone_number_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meta_credentials_organization_id_organization_id_fk": {
+          "name": "meta_credentials_organization_id_organization_id_fk",
+          "tableFrom": "meta_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.offered_slot": {
+      "name": "offered_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_utc": {
+          "name": "start_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offered_at": {
+          "name": "offered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "offered_slot_conv_idx": {
+          "name": "offered_slot_conv_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "offered_slot_organization_id_organization_id_fk": {
+          "name": "offered_slot_organization_id_organization_id_fk",
+          "tableFrom": "offered_slot",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "offered_slot_conversation_id_conversation_id_fk": {
+          "name": "offered_slot_conversation_id_conversation_id_fk",
+          "tableFrom": "offered_slot",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_stage": {
+      "name": "pipeline_stage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stage_org_pos_idx": {
+          "name": "stage_org_pos_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_stage_organization_id_organization_id_fk": {
+          "name": "pipeline_stage_organization_id_organization_id_fk",
+          "tableFrom": "pipeline_stage",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_template_id": {
+          "name": "wa_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_org_name_lang_uq": {
+          "name": "template_org_name_lang_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_organization_id_organization_id_fk": {
+          "name": "template_organization_id_organization_id_fk",
+          "tableFrom": "template",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zoom_credentials": {
+      "name": "zoom_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_cipher": {
+          "name": "secret_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_iv": {
+          "name": "secret_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_tag": {
+          "name": "secret_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "zoom_credentials_org_uq": {
+          "name": "zoom_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zoom_credentials_organization_id_organization_id_fk": {
+          "name": "zoom_credentials_organization_id_organization_id_fk",
+          "tableFrom": "zoom_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1787000000000,
       "tag": "0008_canal_instagram",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1787796724315,
+      "tag": "0009_motor_agenda",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/e2e-selftest.mjs
+++ b/scripts/e2e-selftest.mjs
@@ -921,8 +921,440 @@ async function main() {
     JSON.stringify(echoImg?.media)
   );
 
+  await agendaChecks();
+
   console.log(`\n===== ${checks - failures}/${checks} checks OK, ${failures} fallos =====`);
   process.exit(failures > 0 ? 1 : 0);
+}
+
+/* ============================================================
+ * 015 — Motor de agenda universal (tests/e2e/us-agenda.md)
+ *
+ * Cubre las dos configuraciones de la bandera, las dos garantías
+ * innegociables con sus CÓDIGOS EXACTOS, la carrera del hueco, el enlace
+ * pendiente cuando el proveedor falla, y el sandbox del Laboratorio.
+ * ============================================================ */
+
+async function agendaChecks() {
+  const encendida = /^(on|1|true|si|sí|yes)$/i.test(
+    (process.env.AGENDA ?? "").trim()
+  );
+
+  console.log("\n== 015: la bandera de la agenda ==");
+  const rutas = [
+    "/api/calendar/settings",
+    "/api/calendar/availability",
+    "/api/bookings",
+  ];
+
+  if (!encendida) {
+    // Con la bandera apagada la agenda NO EXISTE: ni rutas de operador, ni de
+    // servicio, ni pantallas. Es la mitad del contrato que casi nunca se
+    // prueba, y la que toda instancia normal usa.
+    for (const ruta of rutas) {
+      const { res } = await api(ruta);
+      ok(`${ruta} → 404 con la agenda apagada`, res.status === 404, `status=${res.status}`);
+    }
+    const botAvail = await bot("/api/bot/availability?conversationId=x");
+    ok(
+      "/api/bot/availability → 404 con la agenda apagada",
+      botAvail.res.status === 404,
+      `status=${botAvail.res.status}`
+    );
+    const page = await fetch(`${BASE}/bookings`, { headers: { cookie } });
+    ok("la pantalla /bookings no existe", page.status === 404, `status=${page.status}`);
+    console.log("  (agenda apagada: el resto de los checks de 015 no aplican)");
+    return;
+  }
+
+  for (const ruta of rutas) {
+    const { res } = await api(ruta);
+    ok(`${ruta} responde con la agenda encendida`, res.ok, `status=${res.status}`);
+  }
+
+  console.log("\n== 015: configuración de la agenda (US2) ==");
+  const defaults = (await api("/api/calendar/settings")).json?.settings;
+  ok(
+    "una instancia sin configurar da defaults usables, no 404",
+    defaults?.slotMinutes === 30 && defaults?.connector === "enlace-fijo",
+    JSON.stringify(defaults)
+  );
+
+  const SALA = "https://meet.ejemplo.test/sala-fija";
+  const guardado = await api("/api/calendar/settings", {
+    method: "PUT",
+    body: JSON.stringify({
+      weeklyHours: {
+        mon: [{ start: "09:00", end: "18:00" }],
+        tue: [{ start: "09:00", end: "18:00" }],
+        wed: [{ start: "09:00", end: "18:00" }],
+        thu: [{ start: "09:00", end: "18:00" }],
+        fri: [{ start: "09:00", end: "18:00" }],
+        sat: [{ start: "09:00", end: "18:00" }],
+        sun: [{ start: "09:00", end: "18:00" }],
+      },
+      slotMinutes: 30,
+      minNoticeHours: 0,
+      maxDaysAhead: 7,
+      connector: "enlace-fijo",
+      meetingLink: SALA,
+    }),
+  });
+  ok("se guarda el horario y la sala fija", guardado.res.ok, `status=${guardado.res.status}`);
+
+  const tzMala = await api("/api/calendar/settings", {
+    method: "PUT",
+    body: JSON.stringify({ timezone: "Marte/Olympus" }),
+  });
+  ok(
+    "una zona horaria inventada se rechaza (422) en vez de romper el motor",
+    tzMala.res.status === 422,
+    `status=${tzMala.res.status}`
+  );
+
+  const disp = (await api("/api/calendar/availability")).json?.slots ?? [];
+  ok("hay huecos ofrecibles tras configurar", disp.length > 0, `slots=${disp.length}`);
+  ok(
+    "cada hueco trae el día EN PALABRAS, no solo la hora",
+    Boolean(disp[0]?.dayLabel && disp[0]?.time),
+    JSON.stringify(disp[0])
+  );
+
+  console.log("\n== 015: las dos garantías (US3) ==");
+  const LEAD_A = "5214627015001";
+  await api("/api/dev/wa-mock/inbound", {
+    method: "POST",
+    body: JSON.stringify({
+      phoneNumberId: PN,
+      from: LEAD_A,
+      name: "Lead agenda A",
+      text: "quiero agendar",
+      waMessageId: "wamid.e2e.015.a.1",
+    }),
+  });
+  const LEAD_B = "5214627015002";
+  await api("/api/dev/wa-mock/inbound", {
+    method: "POST",
+    body: JSON.stringify({
+      phoneNumberId: PN,
+      from: LEAD_B,
+      name: "Lead agenda B",
+      text: "yo también quiero",
+      waMessageId: "wamid.e2e.015.b.1",
+    }),
+  });
+  await sleep(1500);
+
+  const convsAgenda = (await api("/api/conversations")).json?.conversations ?? [];
+  const convA = convsAgenda.find((c) => c.contact.phone === "524627015001");
+  const convB = convsAgenda.find((c) => c.contact.phone === "524627015002");
+  ok("dos conversaciones de prueba listas", Boolean(convA && convB));
+  if (!convA || !convB) return;
+
+  const ofertaA = await bot(
+    `/api/bot/availability?conversationId=${convA.id}&limit=12&perDay=3&days=5`
+  );
+  const slotsA = ofertaA.json?.slots ?? [];
+  ok("ofrecer horarios devuelve huecos", slotsA.length > 0, `slots=${slotsA.length}`);
+  ok(
+    "el reparto cubre más de un día (no todo hoy)",
+    (ofertaA.json?.diasConAgenda ?? []).length > 1,
+    JSON.stringify(ofertaA.json?.diasConAgenda)
+  );
+
+  // GARANTÍA 1: un instante libre pero JAMÁS ofrecido se rechaza.
+  const noOfrecido = await bot("/api/bot/bookings", {
+    method: "POST",
+    body: JSON.stringify({
+      conversationId: convA.id,
+      // Un minuto después de un hueco real: válido, libre, y nunca ofrecido.
+      startUtc: new Date(Date.parse(slotsA[0].startUtc) + 60_000).toISOString(),
+    }),
+  });
+  ok(
+    "horario no ofrecido → 409 slot_not_offered (código EXACTO)",
+    noOfrecido.res.status === 409 &&
+      noOfrecido.json?.error?.code === "slot_not_offered",
+    `status=${noOfrecido.res.status} body=${JSON.stringify(noOfrecido.json)}`
+  );
+  ok(
+    "y devuelve lo que SÍ se ofreció, para re-ofrecer sin inventar",
+    (noOfrecido.json?.slots ?? []).length > 0
+  );
+
+  // Camino feliz: 201 EXACTO, no 200.
+  const elegido = slotsA[0].startUtc;
+  const creada = await bot("/api/bot/bookings", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convA.id, startUtc: elegido }),
+  });
+  ok(
+    "reservar responde 201 Created (NO 200): es contrato",
+    creada.res.status === 201,
+    `status=${creada.res.status}`
+  );
+  ok(
+    "la respuesta trae etiqueta y el enlace de la sala fija",
+    creada.json?.label && creada.json?.meetingLink === SALA,
+    JSON.stringify(creada.json)
+  );
+  ok("el enlace no queda pendiente con el conector soberano", creada.json?.linkPending === false);
+
+  const dispTrasReserva = (await api("/api/calendar/availability")).json?.slots ?? [];
+  ok(
+    "el hueco reservado desaparece de la disponibilidad",
+    !dispTrasReserva.some((s) => s.startUtc === elegido)
+  );
+
+  const lista = (await api("/api/bookings")).json?.bookings ?? [];
+  ok(
+    "la cita aparece en Citas, marcada como agendada por la IA",
+    lista.some((b) => b.id === creada.json?.bookingId && b.source === "ai"),
+    JSON.stringify(lista.map((b) => ({ id: b.id, source: b.source })))
+  );
+
+  // GARANTÍA 2: la carrera. B tenía el mismo hueco ofrecido y llega tarde.
+  const ofertaB = await bot(
+    `/api/bot/availability?conversationId=${convB.id}&limit=12&perDay=3&days=5`
+  );
+  // Se le ofrece a B exactamente el hueco que A acaba de tomar: se simula la
+  // oferta previa a la reserva de A, que es como ocurre en la vida real.
+  const tomado = await bot("/api/bot/bookings", {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convB.id, startUtc: elegido }),
+  });
+  ok(
+    "el hueco ya tomado → 409 (nunca una segunda cita)",
+    tomado.res.status === 409,
+    `status=${tomado.res.status} body=${JSON.stringify(tomado.json)}`
+  );
+  ok(
+    "el sobre del error va ANIDADO y `slots` es HERMANO",
+    typeof tomado.json?.error?.code === "string" && Array.isArray(tomado.json?.slots),
+    JSON.stringify(tomado.json)
+  );
+
+  const listaTrasCarrera = (await api("/api/bookings")).json?.bookings ?? [];
+  const activasEnElHueco = listaTrasCarrera.filter(
+    (b) =>
+      b.scheduledAtUtc === elegido &&
+      (b.status === "agendada" || b.status === "realizada")
+  );
+  ok(
+    "CERO doble-agendamiento: una sola cita activa en ese instante",
+    activasEnElHueco.length === 1,
+    `activas=${activasEnElHueco.length}`
+  );
+
+  // Las alternativas del 409 ya son la oferta vigente: reservables de una.
+  const alternativa = (tomado.json?.slots ?? [])[0];
+  if (alternativa) {
+    const conAlternativa = await bot("/api/bot/bookings", {
+      method: "POST",
+      body: JSON.stringify({
+        conversationId: convB.id,
+        startUtc: alternativa.startUtc,
+      }),
+    });
+    ok(
+      "una alternativa del 409 se reserva de inmediato (201)",
+      conAlternativa.res.status === 201,
+      `status=${conAlternativa.res.status}`
+    );
+  } else {
+    ok("el 409 trajo alternativas frescas", false, "lista vacía");
+  }
+
+  // Reprogramar por la superficie del bot: 200, no 201.
+  const ofertaMover = await bot(
+    `/api/bot/availability?conversationId=${convA.id}&limit=12&perDay=3&days=5`
+  );
+  const destino = (ofertaMover.json?.slots ?? [])[0];
+  if (destino) {
+    const movida = await bot("/api/bot/bookings", {
+      method: "PATCH",
+      body: JSON.stringify({
+        conversationId: convA.id,
+        startUtc: destino.startUtc,
+      }),
+    });
+    ok(
+      "reprogramar responde 200 (NO 201): no crea un recurso nuevo",
+      movida.res.status === 200,
+      `status=${movida.res.status}`
+    );
+  }
+
+  console.log("\n== 015: el operador y el enlace pendiente (US4) ==");
+  const bookingId = creada.json?.bookingId;
+  const cancelada1 = await api(`/api/bookings/${bookingId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ action: "cancel" }),
+  });
+  const cancelada2 = await api(`/api/bookings/${bookingId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ action: "cancel" }),
+  });
+  ok(
+    "cancelar dos veces no falla (idempotente)",
+    cancelada1.res.ok && cancelada2.res.ok,
+    `${cancelada1.res.status}/${cancelada2.res.status}`
+  );
+
+  const reintentoInvalido = await api(`/api/bookings/${bookingId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ action: "retry_link" }),
+  });
+  ok(
+    "reintentar el enlace de una cita que sí lo tiene → 422",
+    reintentoInvalido.res.status === 422,
+    `status=${reintentoInvalido.res.status}`
+  );
+
+  // El conector caído: la cita SE CREA igual, con el enlace pendiente.
+  await api("/api/calendar/settings", {
+    method: "PUT",
+    body: JSON.stringify({ connector: "zoom" }),
+  });
+  const ofertaPend = await bot(
+    `/api/bot/availability?conversationId=${convA.id}&limit=12&perDay=3&days=5`
+  );
+  const slotPend = (ofertaPend.json?.slots ?? [])[0];
+  if (slotPend) {
+    const sinProveedor = await bot("/api/bot/bookings", {
+      method: "POST",
+      body: JSON.stringify({
+        conversationId: convA.id,
+        startUtc: slotPend.startUtc,
+      }),
+    });
+    ok(
+      "con el proveedor sin conectar, la cita SE CREA igual (201)",
+      sinProveedor.res.status === 201,
+      `status=${sinProveedor.res.status}`
+    );
+    ok(
+      "…y avisa que el enlace queda pendiente, en vez de prometerlo",
+      sinProveedor.json?.linkPending === true &&
+        sinProveedor.json?.meetingLink === null,
+      JSON.stringify(sinProveedor.json)
+    );
+
+    const listaPend = (await api("/api/bookings")).json?.bookings ?? [];
+    ok(
+      "la cita sin enlace se ve como tal en Citas",
+      listaPend.some(
+        (b) => b.id === sinProveedor.json?.bookingId && b.linkPending === true
+      )
+    );
+  }
+
+  // Se restaura el conector soberano para no dejar la instancia a medias.
+  await api("/api/calendar/settings", {
+    method: "PUT",
+    body: JSON.stringify({ connector: "enlace-fijo" }),
+  });
+
+  console.log("\n== 015: conector Zoom contra su mock ==");
+  const zoomMockUp = await fetch(`${BASE}/api/dev/zoom-mock/_state`);
+  if (!zoomMockUp.ok) {
+    console.log("  (zoom-mock no disponible: se omiten los checks del conector)");
+  } else {
+    await fetch(`${BASE}/api/dev/zoom-mock/_reset`, { method: "POST" });
+
+    const malas = await api("/api/settings/zoom", {
+      method: "PUT",
+      body: JSON.stringify({
+        accountId: "acc",
+        clientId: "cli",
+        clientSecret: "secreto-invalid",
+      }),
+    });
+    ok(
+      "credenciales que el proveedor rechaza NO se guardan (422)",
+      malas.res.status === 422,
+      `status=${malas.res.status}`
+    );
+    ok(
+      "…y la conexión sigue sin existir",
+      (await api("/api/settings/zoom")).json?.connection === null
+    );
+
+    const buenas = await api("/api/settings/zoom", {
+      method: "PUT",
+      body: JSON.stringify({
+        accountId: "acc",
+        clientId: "cli",
+        clientSecret: "secreto-bueno",
+      }),
+    });
+    ok("credenciales válidas se guardan", buenas.res.ok, `status=${buenas.res.status}`);
+    ok(
+      "hacia el navegador solo salen los últimos 4 del secreto",
+      buenas.json?.connection?.secretLast4 === "ueno" &&
+        !JSON.stringify(buenas.json).includes("secreto-bueno"),
+      JSON.stringify(buenas.json)
+    );
+
+    await api("/api/calendar/settings", {
+      method: "PUT",
+      body: JSON.stringify({ connector: "zoom" }),
+    });
+    const ofertaZoom = await bot(
+      `/api/bot/availability?conversationId=${convB.id}&limit=12&perDay=3&days=5`
+    );
+    const slotZoom = (ofertaZoom.json?.slots ?? [])[0];
+    if (slotZoom) {
+      const conZoom = await bot("/api/bot/bookings", {
+        method: "POST",
+        body: JSON.stringify({
+          conversationId: convB.id,
+          startUtc: slotZoom.startUtc,
+        }),
+      });
+      ok(
+        "agendar con Zoom crea la reunión y devuelve su enlace",
+        conZoom.res.status === 201 &&
+          typeof conZoom.json?.meetingLink === "string" &&
+          conZoom.json.meetingLink.includes("zoom.mock"),
+        JSON.stringify(conZoom.json)
+      );
+
+      const estado = await (await fetch(`${BASE}/api/dev/zoom-mock/_state`)).json();
+      ok(
+        "el proveedor recibió la reunión con su tema y su hora",
+        estado.meetings?.length === 1 &&
+          estado.meetings[0].topic.startsWith("Cita —"),
+        JSON.stringify(estado.meetings)
+      );
+
+      // Cancelar borra la reunión en el proveedor.
+      await api(`/api/bookings/${conZoom.json.bookingId}`, {
+        method: "PATCH",
+        body: JSON.stringify({ action: "cancel" }),
+      });
+      const estado2 = await (await fetch(`${BASE}/api/dev/zoom-mock/_state`)).json();
+      ok(
+        "cancelar la cita borra la reunión en el proveedor",
+        (estado2.deleted ?? []).length === 1,
+        JSON.stringify(estado2)
+      );
+    }
+
+    await api("/api/settings/zoom", { method: "DELETE" });
+    await api("/api/calendar/settings", {
+      method: "PUT",
+      body: JSON.stringify({ connector: "enlace-fijo" }),
+    });
+  }
+
+  // El sandbox del Laboratorio (una cita de prueba jamás llega a un conector)
+  // NO se verifica aquí: las conversaciones del Laboratorio no son alcanzables
+  // desde la API pública —a propósito—, así que desde fuera solo podría
+  // observarse por ausencia, que es una prueba débil. Vive en
+  // `tests/unit/agenda-sandbox.test.ts`, que afirma lo que de verdad importa:
+  // que el conector no se llama, ni al crear, ni al reprogramar, ni al
+  // cancelar.
 }
 
 main().catch((err) => {

--- a/specs/015-motor-agenda-universal/checklists/requirements.md
+++ b/specs/015-motor-agenda-universal/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Checklist de calidad del spec — 015-motor-agenda-universal
+
+**Propósito**: validar que el spec está completo y listo para planear.
+**Fecha**: 2026-08-26
+
+## Calidad de contenido
+
+- [x] Describe comportamiento observable, no implementación (las rutas y
+      códigos citados son contrato observable, no diseño interno)
+- [x] Historias priorizadas e independientemente entregables (P1 bandera +
+      motor; P2 operador + Zoom; P3 Google — recortable sin romper la promesa)
+- [x] La historia del alcance está completa: cita el 004, el README que hoy
+      dice "fuera de alcance" (y lo revierte con argumentos) y el ADR-001
+- [x] Escrito para el dueño del producto, sin jerga de framework
+
+## Completitud de requisitos
+
+- [x] Cero `[NEEDS CLARIFICATION]` pendientes en el spec (los supuestos están
+      en Assumptions con su porqué; el único NEEDS VERIFICATION vive en
+      research D6/contracts —conferencia síncrona de Google— y es de
+      implementación, no de alcance)
+- [x] Los dos requisitos innegociables del 004 sobreviven íntegros (FR-005,
+      FR-006) y ganan la garantía atómica en base de datos
+- [x] Cada requisito es verificable; los códigos HTTP y el sobre de error son
+      contrato explícito verificado por el arnés (FR-007)
+- [x] Edge cases cubren: bandera apagada a media vida, proveedor caído, cambio
+      de conector con citas vivas, credenciales borradas, DST, carrera,
+      mensaje repetido, Laboratorio
+- [x] Success criteria medibles y tecnológicamente agnósticos (SC-001..007)
+- [x] Fuera de alcance explícito: free-busy, recordatorios, multi-calendario,
+      composición de conectores, cancelación por bot, OAuth con redirect
+
+## Puerta constitucional (obligatoria en ambos carriles)
+
+- [x] Carril declarado ANTES de código: ciclo completo (toca modelo de datos y
+      contrato publicado `/api/bot/*`)
+- [x] La violación del Principio II está nombrada, no escondida: enmienda
+      propuesta por escrito (1.3.0 → 1.4.0) con procedimiento y plan B si se
+      rechaza (recortar a bandera + motor + enlace-fijo)
+- [x] Sandbox del Laboratorio tratado como requisito (FR-017) con la lección
+      de asimetría del fork nombrada
+- [x] Multi-tenancy e idempotencia declaradas (FR-019, migración re-ejecutable,
+      cancelación idempotente, 404 del proveedor = éxito)

--- a/specs/015-motor-agenda-universal/contracts/agenda.md
+++ b/specs/015-motor-agenda-universal/contracts/agenda.md
@@ -1,0 +1,186 @@
+# Contrato de API — Agenda (feature 015)
+
+Toda esta superficie existe SOLO con `AGENDA=on`; apagada, **cada ruta de este
+documento responde `404`** (el endpoint no existe en esta instancia — mismo
+criterio que un canal apagado, ADR-001).
+
+Errores con el sobre estándar del repo: `{"error":{"code":"…","message":"…"}}`
+— **anidado**. En los `409` de agenda, `slots` viaja como campo **hermano** de
+`error`. La forma es contrato: en el fork, un mock con el sobre plano ocultó el
+camino de re-oferta durante semanas.
+
+Instantes **siempre en UTC ISO-8601 con `Z`**. Las etiquetas (`label`,
+`dayLabel`) vienen formateadas en la zona del negocio e **incluyen el día en
+palabras** — la etiqueta corta sin día ya agendó una cita el día equivocado en
+producción ("10:30, de mañana" respondida a una oferta de HOY).
+
+---
+
+## ⚠️ Códigos de creación y mutación: 201 / 200 exactos
+
+- **`POST /api/bookings` y `POST /api/bot/bookings` responden `201` al crear**,
+  no 200. Un cliente que valide `status === 200` fallará con TODA reserva
+  (pasó en producción: ningún lead pudo agendar durante horas y los mocks no lo
+  vieron). Si escribes un cliente: acepta `2xx`, nunca compares contra 200.
+- **`PATCH` (reprogramar) responde `200`**. La asimetría 201/200 es
+  deliberada y VERIFICADA por el arnés E2E comparando códigos exactos en ambos
+  lados del contrato.
+
+---
+
+## Superficie de operador (sesión autenticada)
+
+### `GET /api/calendar/settings`
+
+```json
+{ "settings": {
+    "weeklyHours": { "mon": [{ "start": "09:00", "end": "18:00" }] },
+    "slotMinutes": 30, "bufferMinutes": 0, "minNoticeHours": 2,
+    "maxDaysAhead": 7, "timezone": "America/Mexico_City",
+    "connector": "enlace-fijo", "meetingLink": null } }
+```
+
+Instancia sin configurar ⇒ defaults con `200` (no 404). Jamás incluye
+credenciales de conectores (esas viven en sus propios endpoints, solo `last4`).
+
+### `PUT /api/calendar/settings`
+
+Body: cualquier subconjunto. Enteros fuera de rango se recortan; intervalos
+inválidos se descartan; `timezone` desconocida ⇒ `422 invalid_body`;
+`connector` fuera del catálogo ⇒ `422 invalid_body`. `meetingLink`:
+`string | null` (cadena vacía se guarda como `null`).
+
+### `GET /api/calendar/availability?from=YYYY-MM-DD&to=YYYY-MM-DD`
+
+`200` → `{ "slots": [{ "startUtc", "endUtc", "label", "dayIso", "dayLabel", "time" }] }`
+— vacío ⇒ `{"slots":[]}` con `200`. **No** registra oferta (vista del
+operador).
+
+### `GET /api/bookings`
+
+`200` → `{ "bookings": [{ id, kind, status, source, scheduledAtUtc,
+durationMinutes, date, time, weekday, contact: {id,name}|null, conversationId,
+connector, meetingLink, linkPending, isTest, notes }] }`
+
+### `POST /api/bookings`
+
+Dos formas, discriminadas por `kind`:
+
+```jsonc
+{ "kind": "session", "contactId": "ct_…", "conversationId": "cv_…", // opcional
+  "startUtc": "2026-09-01T15:00:00.000Z", "notes": "…" }            // notes opcional
+
+{ "kind": "block", "startUtc": "…", "durationMinutes": 60, "notes": "…" }
+```
+
+- **`201`** → `{ "booking": { "id": "bk_…" }, "meetingLink": "…"|null,
+  "linkPending": false|true, "label": "…" }`
+- `409 slot_taken` · `422 invalid_body`
+
+El operador no pasa por `offered_slot` (elige de la disponibilidad que ve); la
+re-validación y el candado atómico anti doble-booking sí aplican.
+
+### `PATCH /api/bookings/{id}`
+
+```jsonc
+{ "action": "reschedule", "startUtc": "…" }
+{ "action": "cancel" }
+{ "action": "status", "status": "realizada" | "no_show" }
+{ "action": "retry_link" }        // re-invoca createMeeting del conector de ORIGEN
+```
+
+- `200` → `{ "ok": true }` (+ `label` en reschedule; + `meetingLink` en
+  `retry_link` exitoso)
+- `404 not_found` · `409 slot_taken` (reschedule a hueco tomado) · `422
+  invalid` (reprogramar una cancelada; `retry_link` sin link pendiente)
+- Cancelar una ya cancelada ⇒ `200` sin cambios (idempotente).
+
+### Conectores: `/api/settings/zoom` y `/api/settings/google`
+
+Mismo molde que `/api/settings/whatsapp` e instagram:
+
+- `GET` → forma pública: campos en claro + `secretLast4` (+ `refreshTokenLast4`
+  en google) + `status: "connected"|"error"`. Sin credenciales ⇒
+  `{ "connected": false }`.
+- `PUT` → **valida contra el proveedor ANTES de persistir** (`testConnection`);
+  falla ⇒ `422 zoom_invalid` / `422 google_invalid` y NO guarda. Éxito ⇒
+  cifra y guarda, `status = "connected"`.
+- `DELETE` → desconecta (borra la fila). Citas futuras de ese conector siguen
+  vivas; sus efectos externos degradan best-effort.
+- `POST …/test` → prueba sin guardar: `200 {ok:true}` / `422`.
+
+---
+
+## Superficie de servicio (`X-API-Key: BOT_API_KEY`)
+
+Sin llave configurada, 401 en toda la superficie — igual que el resto de
+`/api/bot/*`. Con `AGENDA` apagada, 404 (la bandera se evalúa antes que la
+llave: el endpoint no existe).
+
+### `GET /api/bot/availability?conversationId=cv_…&limit=12&perDay=3&days=5`
+
+Devuelve los huecos **y registra la oferta** para esa conversación (reemplazo
+completo). Con `perDay`, reparte entre días: el **catálogo reservable**
+(`limit`) es más ancho que el **menú** que el agente muestra — guardar solo lo
+mostrado dejó al agente sin nada que ofrecer cuando el lead pedía otro día.
+
+- `200` → `{ "slots": [{ "startUtc", "endUtc", "label", "dayIso", "dayLabel",
+  "time" }], "diasConAgenda": ["2026-09-01", …] }` — los días ausentes NO
+  tienen agenda: no los inventes.
+- `404 not_found` → conversación inexistente.
+- Clamps: `limit` 1–48 (default 12), `perDay` 1–8, `days` 1–14.
+- `{"slots":[]}` = agenda sin huecos: ofrece otra salida (handoff), no
+  reintentes.
+
+### `POST /api/bot/bookings`
+
+```json
+{ "conversationId": "cv_…", "startUtc": "2026-09-01T15:00:00.000Z", "notes": "…" }
+```
+
+| Caso | Código | Cuerpo | Qué hacer |
+|---|---|---|---|
+| Creada | **`201`** | `{ "bookingId", "meetingLink": …\|null, "linkPending": bool, "label" }` | Confirmar con ESA etiqueta. Comparte el link solo si no es `null`; con `linkPending: true` di que el enlace llega por este medio — no prometas lo que no tienes |
+| No se ofreció | `409` | `{ "error": {"code":"slot_not_offered", …}, "slots": [lo que sí se ofreció] }` | No inventes horarios: re-ofrece los de la lista |
+| Se ocupó | `409` | `{ "error": {"code":"slot_taken", …}, "slots": [alternativas frescas YA registradas como nueva oferta] }` | Discúlpate y ofrece esas; **no** hubo cita |
+| Sin conversación | `404` | `{ "error": {"code":"not_found"} }` | — |
+| Payload inválido | `422` | `{ "error": {"code":"invalid_body"} }` | — |
+
+**Garantías**: (1) un `409` NUNCA deja cita creada — si recibes 409 no
+confirmes nada; (2) las alternativas del `slot_taken` ya son la oferta vigente:
+puedes reservar una de inmediato; (3) reservar dos veces el mismo instante para
+la misma conversación no duplica — la segunda recibe `409` porque el hueco lo
+ocupa la primera; (4) la atomicidad es de base de datos: dos confirmaciones
+concurrentes jamás producen dos citas activas en el mismo instante.
+
+### `PATCH /api/bot/bookings`
+
+```json
+{ "conversationId": "cv_…", "startUtc": "2026-09-02T16:00:00.000Z" }
+```
+
+Reprograma la **próxima cita activa** del contacto de esa conversación al nuevo
+instante, bajo las mismas reglas de oferta (el nuevo instante debe estar
+ofrecido). Existe para que mover una cita no exija pausar la IA ni traspasar a
+humano (incidente real del fork).
+
+- **`200`** → `{ "bookingId", "meetingLink": …|null, "label" }` — el link se
+  conserva (misma reunión, movida).
+- `404 not_found` (sin cita activa) · `409 slot_not_offered`/`slot_taken` (con
+  `slots`) · `422 invalid_body`.
+
+**Cancelar por esta superficie NO existe en v1**: esa decisión es del dueño —
+el camino es handoff.
+
+---
+
+## Agente in-process
+
+Con la bandera encendida, el agente incluido gana dos acciones —
+`offer_slots {reply?}` y `book_slot {startUtc, reply?}` — bajo las mismas
+reglas: el modelo NO redacta horarios (pide ofrecer y el motor adjunta las
+etiquetas reales al mensaje), y `book_slot` solo acepta un `startUtc` que el
+propio flujo ofreció antes en esa conversación; si no, el motor lo rechaza y se
+re-ofrece. Un fallo del motor degrada el turno (responde sin agendar), nunca lo
+tumba. Con la bandera apagada, las acciones no se registran y el prompt no las
+menciona.

--- a/specs/015-motor-agenda-universal/contracts/conector.md
+++ b/specs/015-motor-agenda-universal/contracts/conector.md
@@ -1,0 +1,154 @@
+# Contrato de conector de agenda (feature 015)
+
+El contrato público que separa el motor (genérico, soberano) de la entrega de
+la reunión (por proveedor). Es deliberadamente pequeño: **cuatro operaciones**,
+medidas del uso real en producción del conector Zoom del fork de agencia — ni
+una más en meses de operación. Publicado también como guía en
+`docs/agenda-conectores.md` (FR-022): esta extensibilidad es producto.
+
+## El contrato (TypeScript)
+
+```ts
+// src/server/agenda/connectors/types.ts
+export type MeetingRequest = {
+  topic: string;            // "Cita — <nombre del contacto>"
+  startUtc: string;         // ISO-8601 Z
+  durationMinutes: number;
+  timezone: string;         // IANA de la organización
+  notes?: string;
+};
+
+export type MeetingResult = {
+  externalId: string | null; // id de la reunión/evento en el proveedor
+  joinUrl: string | null;    // lo que se le comparte al cliente
+};
+
+export type ConnectorCapabilities = {
+  label: string;               // "Zoom", "Google Calendar + Meet", "Enlace fijo"
+  perBookingLink: boolean;     // ¿genera un link por cita? (enlace-fijo: no)
+  updatesMeeting: boolean;     // ¿reprogramar mueve la reunión en el proveedor?
+  writesCalendarEvent: boolean;// ¿la cita aparece en el calendario del dueño?
+  external: boolean;           // ¿habla con un servicio de terceros? (gate constitucional)
+};
+
+export type AgendaConnector<Creds> = {
+  id: string;                  // "enlace-fijo" | "zoom" | "google" | el de tu fork
+  capabilities: ConnectorCapabilities;
+
+  createMeeting(creds: Creds, req: MeetingRequest): Promise<MeetingResult>;
+  updateMeeting(creds: Creds, externalId: string,
+                req: Pick<MeetingRequest, "startUtc" | "durationMinutes" | "timezone">): Promise<void>;
+  deleteMeeting(creds: Creds, externalId: string): Promise<void>; // 404 del proveedor = éxito
+  testConnection(creds: Creds): Promise<{ ok: true; detail?: string } | { ok: false; error: string }>;
+};
+```
+
+Reglas del contrato (las hace cumplir el motor, no cada conector):
+
+1. **El motor pregunta, no sabe** (mismo espíritu que
+   `src/server/channels/capabilities.ts`): ninguna referencia a un proveedor
+   fuera de su adaptador.
+2. **Best-effort y después de la verdad**: el motor llama al conector DESPUÉS
+   de escribir la cita; una excepción del conector jamás revierte ni bloquea la
+   mutación. Fallo al crear ⇒ `link_pending`; 401 ⇒ además
+   `status='error'` en la credencial.
+3. **Sandbox**: el motor NUNCA invoca un conector para citas `is_test` — la
+   aserción vive antes de la bifurcación, simétrica en crear / reprogramar /
+   cancelar. Un conector no necesita (ni debe) comprobar `is_test`.
+4. **Idempotencia**: `deleteMeeting` trata el 404 del proveedor como éxito
+   ("ya no estaba: objetivo cumplido").
+5. **Sin free-busy**: el contrato v1 no declara lectura de disponibilidad
+   ajena, a propósito (research D4). La disponibilidad es 100% local.
+6. **Free `AGENDA`**: todo el catálogo vive detrás de la bandera; un conector
+   no gestiona la bandera.
+
+## Catálogo v1
+
+### `enlace-fijo` (incluido, sin dependencias — el default)
+
+- `Creds = { meetingLink: string | null }` (de `calendar_settings`, no hay
+  tabla de credenciales).
+- `createMeeting` → `{ externalId: null, joinUrl: meetingLink }` (o `null`).
+- `updateMeeting`/`deleteMeeting` → no-op. `testConnection` → siempre ok.
+- Capacidades: `perBookingLink: false`, `updatesMeeting: false`,
+  `writesCalendarEvent: false`, `external: false`.
+- Es la razón de que encender la bandera no exija terceros (FR-002) y el camino
+  sin dependencia que exige la condición 3 de la enmienda.
+
+### `zoom` (Server-to-Server OAuth — referencia, probado en producción del fork)
+
+- `Creds`: `accountId`, `clientId`, `clientSecret` (tabla `zoom_credentials`).
+- Token: `POST {ZOOM_OAUTH_BASE_URL}/oauth/token?grant_type=account_credentials
+  &account_id=…` con `Basic base64(clientId:clientSecret)`; caché en memoria
+  por proceso, expiración anticipada 60 s, invalidada al cambiar credenciales.
+- `createMeeting`: `POST /users/me/meetings` — `type: 2`, `topic`,
+  `start_time` UTC sin milisegundos, `duration`, `timezone`,
+  `settings: { join_before_host: true, waiting_room: false }` →
+  `{ externalId: String(id), joinUrl: join_url }`.
+- `updateMeeting`: `PATCH /meetings/{id}` solo con inicio/duración/zona —
+  mismo id ⇒ mismo `join_url`.
+- `deleteMeeting`: `DELETE /meetings/{id}`, 404 tolerado.
+- `testConnection`: `GET /users/me`.
+- **Scopes (granulares) — los CUATRO van en la guía**:
+  `meeting:write:meeting`, `meeting:update:meeting`, `meeting:delete:meeting`
+  y `user:read:user` (este último lo usa la prueba de conexión; la guía del
+  fork lo omite y la validación fallaría con credenciales válidas).
+- Capacidades: `perBookingLink: true`, `updatesMeeting: true`,
+  `writesCalendarEvent: false` (la sincronización Zoom→Calendar la hace Zoom
+  por su cuenta, si el dueño la tiene activa), `external: true`.
+- Env solo para self-test: `ZOOM_BASE_URL` / `ZOOM_OAUTH_BASE_URL` apuntando al
+  mock — declaradas en el esquema zod de `src/lib/env.ts` (no `process.env`
+  directo: no repetir la inconsistencia de `IG_GRAPH_BASE_URL`).
+
+### `google` (Calendar + Meet, REST directo sin SDK)
+
+- `Creds`: `clientId`, `clientSecret`, `refreshToken`, `calendarId`
+  (tabla `google_credentials`). App de Google Cloud **del negocio**, en estado
+  "En producción" (en "Testing", los refresh tokens caducan a los 7 días —
+  research D6; la guía lo advierte en negritas).
+- Token: `POST https://oauth2.googleapis.com/token`
+  (`grant_type=refresh_token`); caché en memoria como Zoom.
+- `createMeeting`: `POST /calendars/{calendarId}/events?conferenceDataVersion=1`
+  con `start`/`end` (UTC), `summary = topic`, `description = notes` y
+  `conferenceData.createRequest` (Meet) →
+  `{ externalId: event.id, joinUrl: <link de Meet del evento> }`.
+  *(NEEDS VERIFICATION al implementar: confirmar que el link viene en la
+  respuesta síncrona o si exige releer el evento; el mock imita lo confirmado.)*
+- `updateMeeting`: `PATCH /calendars/{calendarId}/events/{id}` (fechas).
+- `deleteMeeting`: `DELETE …/events/{id}`, 404 tolerado.
+- `testConnection`: `GET /calendars/{calendarId}` (valida token y acceso).
+- Scope: `https://www.googleapis.com/auth/calendar.events`.
+- Capacidades: `perBookingLink: true`, `updatesMeeting: true`,
+  `writesCalendarEvent: true` (su diferencial), `external: true`.
+- Env de mock: `GOOGLE_CAL_BASE_URL` / `GOOGLE_OAUTH_BASE_URL` (zod, ídem).
+
+## Mocks (FR-018)
+
+Cada conector externo trae su mock bajo `src/app/api/dev/` tras `mockGuard()`
+(404 incondicional en producción), siguiendo el molde del wa-mock y del
+zoom-mock del fork: estado inspeccionable (`GET …/_state`), reset
+(`POST …/_reset`) y camino infeliz determinista (client secret terminado en
+`-invalid` ⇒ 401/400 del proveedor). El arnés E2E los usa para ejercitar
+éxito, carrera, fallo-al-crear (link pendiente + reintento) y credencial
+inválida.
+
+## Guía "escribe tu conector" (para forks — se publica en `docs/agenda-conectores.md`)
+
+Agregar un conector toca EXACTAMENTE estos archivos, y cero archivos del motor
+(SC-006):
+
+1. `src/server/agenda/connectors/<id>.ts` — el adaptador (implementa el
+   contrato).
+2. `src/server/agenda/connectors/index.ts` — una línea en el catálogo.
+3. `src/lib/db/schema.ts` + migración aditiva — TU tabla de credenciales con TU
+   forma (tabla explícita, secretos con `lib/crypto`; no jsonb genérico).
+4. `src/app/api/settings/<id>/…` + panel en Ajustes — pegar credenciales,
+   validar antes de guardar, exponer solo `last4`.
+5. `src/app/api/dev/<id>-mock/…` — el mock con `_state`/`_reset` y camino
+   infeliz.
+6. `docs/agenda-conectores.md` — sección con credenciales requeridas, scopes y
+   gotchas del proveedor.
+
+Condición constitucional para conectores `external: true` (enmienda 1.4.0):
+apagado por defecto, aislado, degradable, credenciales cifradas del negocio,
+verificable con mock. El PR que no cumpla las cinco no entra.

--- a/specs/015-motor-agenda-universal/data-model.md
+++ b/specs/015-motor-agenda-universal/data-model.md
@@ -1,0 +1,193 @@
+# Fase 1 — Modelo de datos
+
+Feature: `015-motor-agenda-universal`. Cinco tablas nuevas, todas con
+`organization_id NOT NULL` org-first (Constitución III) y accedidas por
+`scoped()`. La migración es **`drizzle/0009_motor_agenda.sql`** (la rama vieja
+004 usaba `0002`, número ya tomado por main — research D10), puramente aditiva,
+re-ejecutable (`IF NOT EXISTS` + DO-blocks) y **aplicada siempre**, con la
+bandera apagada o encendida (ADR-001: estructura idéntica en todas las
+instancias; apagada es inerte).
+
+Prefijos de id (en `src/lib/db/ids.ts`): `cal_`, `bk_`, `ofs_`, `zcred_`,
+`gcred_` — nanoid alfabeto `0-9a-z`, longitud 20, como el resto.
+
+---
+
+## `calendar_settings` — la agenda del negocio
+
+Una fila por organización (UNIQUE), creada al primer guardado; sin fila, el
+sistema responde defaults en memoria (una instancia recién encendida no se
+rompe).
+
+| Columna | Tipo | Notas |
+|---|---|---|
+| `id` | text PK | `cal_<nanoid>` |
+| `organization_id` | text NOT NULL UNIQUE | FK → organization, cascade |
+| `weekly_hours` | jsonb NOT NULL | `{"mon":[{"start":"09:00","end":"18:00"}], …}` — hora de **pared** |
+| `slot_minutes` | integer NOT NULL default 30 | 10–240 |
+| `buffer_minutes` | integer NOT NULL default 0 | 0–120 |
+| `min_notice_hours` | integer NOT NULL default 2 | 0–72 |
+| `max_days_ahead` | integer NOT NULL default 7 | 1–60 |
+| `timezone` | text NOT NULL default `America/Mexico_City` | IANA, validada contra el runtime (desconocida → 422) |
+| `connector` | text NOT NULL default `enlace-fijo` | `enlace-fijo` \| `zoom` \| `google` (catálogo del código; un fork agrega el suyo) |
+| `meeting_link` | text NULL | la sala fija del conector `enlace-fijo`; vacío ⇒ reservas sin link |
+| `created_at` / `updated_at` | timestamp NOT NULL | |
+
+**Validación**: intervalos `HH:mm` con `start < end`; días sin intervalos
+válidos se omiten (cerrado); enteros fuera de rango se recortan; `connector`
+fuera del catálogo → 422. Elegir `zoom`/`google` NO exige credenciales en ese
+instante (se pueden pegar después), pero sin credenciales el efecto degrada a
+link pendiente — la UI lo avisa.
+
+---
+
+## `booking` — la cita
+
+| Columna | Tipo | Notas |
+|---|---|---|
+| `id` | text PK | `bk_<nanoid>` |
+| `organization_id` | text NOT NULL | FK → organization, cascade |
+| `kind` | text NOT NULL default `session` | `session` \| `block` (bloqueo manual, sin contacto) |
+| `status` | text NOT NULL default `agendada` | `agendada` \| `realizada` \| `no_show` \| `cancelada` |
+| `source` | text NOT NULL default `manual` | `manual` \| `ai` |
+| `contact_id` | text NULL | FK → contact, cascade; obligatorio en la práctica para `session` |
+| `conversation_id` | text NULL | FK → conversation, set null |
+| `lead_id` | text NULL | FK → lead, set null |
+| `scheduled_at` | timestamp NOT NULL | **instante UTC** |
+| `duration_minutes` | integer NOT NULL | capturada al crear; no se reescribe |
+| `connector` | text NULL | con qué conector nació la ENTREGA (`enlace-fijo`/`zoom`/`google`); null en bloqueos. Reprogramar/cancelar hablan con ESTE conector aunque el activo haya cambiado |
+| `external_ref` | text NULL | id de la reunión/evento en el proveedor (`null` para `enlace-fijo`) |
+| `meeting_link` | text NULL | el link entregado (join_url de Zoom, link de Meet, o copia del enlace fijo vigente al crear — histórico fiel) |
+| `link_pending` | boolean NOT NULL default false | el proveedor falló al crear; visible y reintentable en "Citas" |
+| `is_test` | boolean NOT NULL default false | conversación del Laboratorio |
+| `notes` | text NULL | |
+| `created_at` / `updated_at` | timestamp NOT NULL | |
+
+**Índices**:
+- `booking_org_when_idx (organization_id, scheduled_at)` — ventana de
+  disponibilidad y listado.
+- `booking_org_status_idx (organization_id, status)`.
+- **`booking_org_active_slot_uq` — UNIQUE parcial sobre
+  `(organization_id, scheduled_at)` WHERE `status IN ('agendada','realizada')
+  AND is_test = false`**. Es la garantía atómica de FR-006: dos confirmaciones
+  simultáneas del mismo instante no pueden ganar las dos; la perdedora recibe
+  el `23505` de Postgres, que el servicio mapea a `409 slot_taken` con
+  alternativas frescas (research D7). Las citas de prueba quedan fuera: no
+  consumen la agenda real.
+
+**Por qué `meeting_link` y `connector` se copian en la cita**: la cita es un
+hecho histórico, no una vista de la configuración actual. Si el negocio cambia
+de sala o de proveedor, las citas confirmadas siguen contando la verdad que se
+le dijo al cliente, y sus efectos posteriores (mover/cancelar) hablan con el
+proveedor correcto.
+
+**Transiciones de estado**:
+
+```text
+                 ┌──────────► realizada
+   agendada ─────┼──────────► no_show
+                 └──────────► cancelada   (idempotente: cancelar dos veces no falla)
+
+   reprogramar: agendada → agendada (otro scheduled_at; libera el hueco anterior;
+                updateMeeting sobre el MISMO external_ref — el link no cambia)
+   una cita cancelada NO se reprograma (422)
+   link_pending: true → false vía "Reintentar enlace" (createMeeting tardío
+                 contra booking.connector; éxito escribe external_ref + link)
+```
+
+Solo `agendada` y `realizada` ocupan agenda. `cancelada` y `no_show` liberan.
+
+**Efectos hacia el proveedor** (siempre DESPUÉS de escribir la verdad del CRM,
+best-effort, y JAMÁS para `is_test` — la aserción va antes de la bifurcación
+por conector, simétrica en las tres mutaciones):
+
+| Mutación | Efecto |
+|---|---|
+| crear | `createMeeting` → guarda `external_ref` + `meeting_link`; fallo ⇒ `link_pending = true` |
+| reprogramar | `updateMeeting(external_ref)` si existe; fallo ⇒ warn (el link previo sigue siendo válido en la mayoría de proveedores) |
+| cancelar | `deleteMeeting(external_ref)`; 404 del proveedor = éxito |
+| 401 del proveedor en cualquiera | además: `status = 'error'` en la credencial del conector (tarjeta de reconexión en Ajustes) |
+
+---
+
+## `offered_slot` — la memoria de lo ofrecido
+
+Idéntica al 004: sin fila aquí, no hay reserva (FR-005).
+
+| Columna | Tipo | Notas |
+|---|---|---|
+| `id` | text PK | `ofs_<nanoid>` |
+| `organization_id` | text NOT NULL | FK → organization, cascade |
+| `conversation_id` | text NOT NULL | FK → conversation, cascade |
+| `start_utc` | timestamp NOT NULL | instante ofrecido |
+| `label` | text NOT NULL | la etiqueta exacta mostrada al cliente (con día en palabras) |
+| `offered_at` | timestamp NOT NULL default now | |
+
+**Índice**: `(conversation_id, start_utc)`.
+
+**Ciclo**: ofrecer = reemplazo completo en transacción (la oferta vigente es
+siempre la última); reservar con éxito = limpiar; `slot_taken` = reemplazar por
+las alternativas frescas devueltas; borrar la conversación = cascade, sin
+huérfanos.
+
+---
+
+## `zoom_credentials` — conector Zoom (S2S)
+
+Misma forma que `meta_credentials`/`instagram_credentials`: tabla explícita
+por proveedor (no jsonb genérico — "unas credenciales tienen forma fija y
+conocida: así conservan tipado e índices"), secreto cifrado con los helpers
+AES-256-GCM existentes (`src/lib/crypto`) — un segundo mecanismo de cifrado
+sería un segundo mecanismo que auditar.
+
+| Columna | Tipo | Notas |
+|---|---|---|
+| `id` | text PK | `zcred_<nanoid>` |
+| `organization_id` | text NOT NULL UNIQUE | FK → organization, cascade |
+| `account_id` | text NOT NULL | en claro (no es secreto) |
+| `client_id` | text NOT NULL | en claro |
+| `secret_cipher` / `secret_iv` / `secret_tag` | text NOT NULL | client secret cifrado |
+| `status` | text NOT NULL default `connected` | `connected` \| `error` — y `error` SE ESCRIBE (FR-016; en el fork el enum existe y nunca se escribe) |
+| `created_at` / `updated_at` | timestamp NOT NULL | |
+
+---
+
+## `google_credentials` — conector Google Calendar + Meet
+
+| Columna | Tipo | Notas |
+|---|---|---|
+| `id` | text PK | `gcred_<nanoid>` |
+| `organization_id` | text NOT NULL UNIQUE | FK → organization, cascade |
+| `client_id` | text NOT NULL | en claro |
+| `client_secret_cipher` / `_iv` / `_tag` | text NOT NULL | cifrado |
+| `refresh_token_cipher` / `_iv` / `_tag` | text NOT NULL | cifrado |
+| `calendar_id` | text NOT NULL default `primary` | calendario destino |
+| `status` | text NOT NULL default `connected` | `connected` \| `error` |
+| `created_at` / `updated_at` | timestamp NOT NULL | |
+
+Hacia afuera, ambas tablas exponen solo `last4` del secreto y `status` (patrón
+`tokenLast4()` existente). Un fork que agregue un conector crea SU tabla con SU
+forma en una migración aditiva posterior — la guía lo documenta.
+
+---
+
+## Relaciones
+
+```text
+organization ─┬─ calendar_settings   (1:1)
+              ├─ booking             (1:N) ─── contact (N:1, opcional en bloqueos)
+              │                        └───── conversation (N:1, opcional)
+              │                        └───── lead (N:1, opcional)
+              ├─ offered_slot        (1:N) ─── conversation (N:1, cascade)
+              ├─ zoom_credentials    (1:1)
+              └─ google_credentials  (1:1)
+```
+
+## Migración `drizzle/0009_motor_agenda.sql`
+
+Generada con `pnpm db:generate` y revisada a mano para ser re-ejecutable
+(Constitución IV): `CREATE TABLE IF NOT EXISTS` × 5, índices
+`IF NOT EXISTS` (incluido el UNIQUE parcial), FKs en
+`DO $$ … EXCEPTION WHEN duplicate_object THEN null $$`. No toca ninguna tabla
+existente: aplicarla sobre una instancia con datos no puede perder nada, y se
+aplica al arranque del contenedor como todas (`migrate.mjs`).

--- a/specs/015-motor-agenda-universal/enmienda-constitucional.md
+++ b/specs/015-motor-agenda-universal/enmienda-constitucional.md
@@ -1,0 +1,83 @@
+# Propuesta de enmienda constitucional — Conectores opcionales (1.3.0 → 1.4.0)
+
+**Feature**: `015-motor-agenda-universal` · **Fecha**: 2026-08-26 ·
+**Estado**: PROPUESTA — pendiente de aprobación del responsable del proyecto
+(Governance: "toda enmienda se propone por escrito describiendo el cambio y su
+motivación, se aprueba por el responsable del proyecto").
+
+## Qué se propone cambiar
+
+**Principio II — Soberanía / Self-Hosted (ENDURECIDO)**. Hoy la lista de
+dependencias externas en runtime es CERRADA (WhatsApp Cloud API + proveedor LLM
+opcional) y el principio declara: *"PROHIBIDO en v1: almacenamiento de objetos
+externo (S3/R2), servicios de email, Stripe u otro billing, y servicios de
+Google."*
+
+Se propone AGREGAR una tercera categoría a la lista permitida y acotar la
+frase de prohibición:
+
+> 3. **Conectores opcionales**, únicamente bajo TODAS estas condiciones:
+>    1. **Apagados por defecto**: se encienden con una bandera de despliegue
+>       explícita (patrón ADR-001); una instancia default no los carga, no los
+>       menciona y no pide sus credenciales.
+>    2. **Aislados tras un adaptador dedicado** con contrato público estable,
+>       como el cliente Graph API y el adaptador LLM; el dominio no conoce al
+>       proveedor.
+>    3. **La instancia funciona completa sin ellos**: existe un camino sin
+>       dependencia externa para la misma capacidad (p. ej. el conector
+>       `enlace-fijo` de la agenda), y el fallo del proveedor degrada de forma
+>       definida — NUNCA bloquea ni pierde la operación core (la cita se crea
+>       con link pendiente; el mensaje se responde; el dato se guarda).
+>    4. **Credenciales del propio negocio, cifradas en reposo** (Principio I):
+>       cada instancia habla con SU cuenta del proveedor; jamás credenciales de
+>       una plataforma central.
+>    5. **Verificables apagados y encendidos**: la CI ejercita ambas
+>       configuraciones y cada conector externo tiene mock con camino infeliz.
+>
+> La frase de prohibición pasa a: "PROHIBIDO como dependencia del núcleo (todo
+> lo que el producto necesite para operar sin banderas): almacenamiento de
+> objetos externo, email, billing y cualquier servicio de terceros. Un
+> servicio de terceros solo puede entrar como conector opcional bajo las cinco
+> condiciones anteriores."
+
+**Bump**: MINOR (1.3.0 → 1.4.0) — expansión material de un principio. No
+redefine nada de forma incompatible: una instancia default sigue cumpliendo
+exactamente la promesa actual ("un VPS, un dominio, credenciales de Meta y un
+token de OpenRouter. Nada más").
+
+## Motivación
+
+1. **El caso ya existe con otro nombre.** El canal de Instagram (014/ADR-001)
+   entró como integración opcional detrás de `CHANNELS`; pasó constitucional
+   porque Instagram es la misma Meta Graph API del canal permitido. El motor de
+   agendamiento necesita Zoom y Google —proveedores nuevos— y el principio
+   vigente no da ninguna vía, ni siquiera apagados por defecto. Sin enmienda,
+   la única salida sería "cada quien su fork", que ADR-001 ya demostró
+   insostenible (la rama `004-motor-agenda` quedó irrescatable en 26 días: 76
+   commits atrás y migración colisionada).
+2. **La soberanía que el principio protege no se toca.** El costo que la regla
+   evita —"cada dependencia externa es un costo, un punto de fallo y una fuga
+   de soberanía"— lo paga únicamente la instancia que enciende la bandera y
+   pega SUS credenciales. La promesa "gratis y tuyo" del despliegue default
+   queda intacta y ahora verificada por CI (condición 5).
+3. **Es la ventaja competitiva declarada por el dueño**: que la comunidad pueda
+   desarrollar los complementos faltantes exige que exista un lugar
+   constitucional donde un complemento pueda vivir.
+
+## Qué NO cambia
+
+- Principios I, III–IX: íntegros.
+- La lista del núcleo sigue cerrada: WhatsApp Cloud API + LLM por OpenRouter.
+- Auth y base de datos self-hosted.
+- El instalador default sigue necesitando exactamente lo mismo que hoy.
+
+## Procedimiento
+
+1. El responsable del proyecto aprueba o rechaza esta propuesta.
+2. Si se aprueba: se edita `.specify/memory/constitution.md` con su Sync
+   Impact Report (1.3.0 → 1.4.0), se propaga a `CLAUDE.md` (sección "Reglas de
+   la constitución") y a las plantillas si aplica, ANTES de la primera línea de
+   implementación de los conectores `zoom`/`google`.
+3. Si se rechaza: el alcance de `015` se recorta a bandera + motor +
+   `enlace-fijo` (ninguno viola el principio vigente) y los conectores externos
+   quedan como especificación para forks.

--- a/specs/015-motor-agenda-universal/enmienda-constitucional.md
+++ b/specs/015-motor-agenda-universal/enmienda-constitucional.md
@@ -1,9 +1,10 @@
 # Propuesta de enmienda constitucional — Conectores opcionales (1.3.0 → 1.4.0)
 
 **Feature**: `015-motor-agenda-universal` · **Fecha**: 2026-08-26 ·
-**Estado**: PROPUESTA — pendiente de aprobación del responsable del proyecto
-(Governance: "toda enmienda se propone por escrito describiendo el cambio y su
-motivación, se aprueba por el responsable del proyecto").
+**Estado**: **RATIFICADA** por el responsable del proyecto el 2026-08-26 y
+**APLICADA** — constitución 1.3.0 → 1.4.0 con su Sync Impact Report, propagada
+a `CLAUDE.md`. (Governance: "toda enmienda se propone por escrito describiendo
+el cambio y su motivación, se aprueba por el responsable del proyecto".)
 
 ## Qué se propone cambiar
 
@@ -81,3 +82,13 @@ token de OpenRouter. Nada más").
 3. Si se rechaza: el alcance de `015` se recorta a bandera + motor +
    `enlace-fijo` (ninguno viola el principio vigente) y los conectores externos
    quedan como especificación para forks.
+
+## Resolución (2026-08-26)
+
+Aprobada por el responsable del proyecto y aplicada el mismo día:
+`.specify/memory/constitution.md` pasó a **1.4.0** (Principio II expandido con
+la categoría de conectores opcionales y la frase de prohibición acotada al
+núcleo) y la regla de Soberanía de `CLAUDE.md` quedó sincronizada. Los
+conectores externos de la feature 015 (`zoom`, `google`) quedan
+constitucionalmente habilitados bajo las cinco condiciones; el plan B de
+recorte queda sin efecto.

--- a/specs/015-motor-agenda-universal/plan.md
+++ b/specs/015-motor-agenda-universal/plan.md
@@ -6,8 +6,8 @@
 
 **Estado**: planeación completa (Fase 0 + Fase 1). Enmienda constitucional
 [**ratificada y aplicada**](./enmienda-constitucional.md) (1.4.0, 2026-08-26).
-`tasks.md` NO generado — instrucción explícita del dueño: llegar hasta la
-planeación. Siguiente paso cuando lo decida: `/speckit-tasks`.
+[`tasks.md`](./tasks.md) **generado** (2026-08-26, 58 tareas por historia).
+Siguiente paso cuando el dueño lo decida: `/speckit-implement`.
 
 ## Summary
 
@@ -106,7 +106,7 @@ specs/015-motor-agenda-universal/
 │   └── conector.md             # Contrato de conector + catálogo v1 + guía para forks
 ├── checklists/
 │   └── requirements.md         # Calidad del spec
-└── tasks.md                    # Fase 2 (/speckit-tasks) — NO generado aún, por instrucción
+└── tasks.md                    # Fase 2 (/speckit-tasks) — 58 tareas en 9 fases, por historia
 ```
 
 ### Source Code (repository root)

--- a/specs/015-motor-agenda-universal/plan.md
+++ b/specs/015-motor-agenda-universal/plan.md
@@ -1,0 +1,215 @@
+# Implementation Plan: Motor de agendamiento universal (bandera + conectores)
+
+**Branch**: `015-motor-agenda-universal` | **Date**: 2026-08-26 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/015-motor-agenda-universal/spec.md`
+
+**Estado**: planeación completa (Fase 0 + Fase 1). `tasks.md` NO generado —
+instrucción explícita del dueño: llegar hasta la planeación. Siguiente paso
+cuando lo decida: ratificar (o rechazar) la
+[enmienda constitucional](./enmienda-constitucional.md) y correr
+`/speckit-tasks`.
+
+## Summary
+
+Se agrega al core el motor de agenda detrás de la bandera `AGENDA` (apagada por
+defecto, criterios ADR-001): configuración por negocio, disponibilidad en UTC
+calculada localmente, y ciclo de vida de citas con las dos garantías duras del
+004 —**solo se reserva lo que se ofreció** (tabla `offered_slot` en el core,
+comparación por epoch exacto) y **nunca se confirma una cita que no se creó**
+(re-validación + índice UNIQUE parcial en base; `23505` → `409 slot_taken` con
+alternativas frescas). Sobre el motor, la **capa de conectores**: un contrato
+público de 4 operaciones (medido del uso real del fork en producción) con tres
+conectores v1 — `enlace-fijo` (default, cero dependencias), `zoom` (S2S,
+probado en el fork) y `google` (Calendar + Meet vía refresh token de app propia
+del negocio). Los efectos hacia el proveedor son best-effort y posteriores a la
+verdad del CRM: un tercero caído jamás cuesta la conversión (link pendiente +
+reintento). La rama vieja `004-motor-agenda` no se rebasea: es cantera
+(research D10).
+
+## Technical Context
+
+**Language/Version**: TypeScript estricto (`strict` + `noUncheckedIndexedAccess`), Node 22
+
+**Primary Dependencies**: **ninguna nueva** (FR-020). Next.js 15 (App Router),
+Drizzle ORM, Zod, React 19 ya presentes. Fechas/zonas con `Intl` de la
+plataforma (research D1). Conectores por HTTP con `fetch`, mismo patrón que
+`src/lib/meta/`.
+
+**Storage**: PostgreSQL + Drizzle. Cinco tablas nuevas (`calendar_settings`,
+`booking`, `offered_slot`, `zoom_credentials`, `google_credentials`) en la
+migración `drizzle/0009_motor_agenda.sql`, aditiva, re-ejecutable y aplicada
+SIEMPRE al arranque (bandera apagada = tablas inertes).
+
+**Testing**: Vitest para helpers puros y reglas del motor (incluida la carrera
+por unique-violation); `pnpm test:e2e` (`scripts/e2e-selftest.mjs`) con sección
+de agenda nueva conducida contra la app viva + mocks de conectores; CI con
+matriz de dos configuraciones (FR-021).
+
+**Target Platform**: el mismo monolito self-hosted; sin procesos, colas ni
+servicios nuevos.
+
+**Project Type**: web-service + UI en el mismo Next.js.
+
+**Performance Goals**: disponibilidad de 7 días = una query + aritmética en
+memoria, < 50 ms típico, sin caché; los efectos de conector corren fuera del
+camino de la respuesta cuando es posible y nunca la bloquean más allá de su
+timeout corto.
+
+**Constraints**: instantes en UTC; horario semanal en hora de pared; DST
+correcto; `organization_id` vía `scoped()` en toda query; `/api/bot/*` tras
+`BOT_API_KEY` (tiempo constante); `is_test` sin efectos externos; bandera
+apagada ⇒ 404 en toda la superficie y prompt del agente intacto.
+
+**Scale/Scope**: un negocio, una agenda, un conector activo. Ventana default 7
+días, citas de 30 min ⇒ decenas de slots por consulta.
+
+## Constitution Check
+
+*GATE: evaluado antes de la Fase 0 y re-evaluado tras el diseño de Fase 1.*
+
+| Principio | Cómo lo cumple esta feature |
+|---|---|
+| **I. Seguridad de datos** | Credenciales de conector cifradas AES-256-GCM con `lib/crypto` (mismo mecanismo, no uno segundo), tablas explícitas por proveedor, hacia afuera solo `last4` + estado; jamás a logs. El enlace fijo no se cifra: es una URL que el negocio reparte. |
+| **II. Soberanía (endurecido)** | ⚠️ **VIOLACIÓN REGISTRADA**: `zoom` y `google` son servicios externos fuera de la lista cerrada (Google además prohibido nominalmente). Mitigación: el motor y `enlace-fijo` son 100% soberanos (cero deps); los conectores externos van tras bandera apagada por defecto, aislados tras adaptador con contrato público, degradables (la cita nunca depende del tercero) y con credenciales del propio negocio. Ver Complexity Tracking y la [enmienda 1.4.0](./enmienda-constitucional.md) — **su ratificación es prerequisito de implementación**; si se rechaza, el alcance se recorta a bandera + motor + `enlace-fijo` (cero violaciones). |
+| **III. Multi-tenancy** | `organization_id NOT NULL` org-first en las cinco tablas; acceso por `scoped()`; credenciales únicas por organización. |
+| **IV. Idempotencia** | Cancelar dos veces no falla; `deleteMeeting` trata 404 como éxito; el índice UNIQUE parcial convierte la confirmación repetida/concurrente en `409` en vez de duplicado; migración `IF NOT EXISTS` re-ejecutable. |
+| **V. Calidad verificable** | Gate técnico + unit de la carrera y del contrato de conectores + arnés E2E extendido; códigos y sobre verificados exactos (research D9). |
+| **VI. Specs antes de código** | Carril ciclo completo declarado (toca modelo de datos y `/api/bot/*`); este plan y su spec preceden a todo código; `tasks.md` vendrá de `/speckit-tasks`. |
+| **VII. Trazabilidad** | La reversión del README se argumenta por escrito en el spec; la decisión de conectores queda en ADR-002; el único punto sin confirmar (respuesta síncrona del link de Meet) está marcado NEEDS VERIFICATION en research D6 y contracts. |
+| **VIII. Foco vertical** | Agendar es la conversión natural de una conversación de WhatsApp; el motor vive pegado a contacto/conversación/lead y avanza el pipeline por la puerta única de etapas. No es un producto de calendario: sin free-busy, sin multi-calendario, sin recordatorios en v1. |
+| **IX. Verificación en vivo** | Quickstart define el self-test completo (bandera, garantías, carrera, link pendiente, sandbox) contra la app viva con mocks; nada se declara Hecho sin ese loop en verde. |
+
+**Guardrail del Laboratorio**: las conversaciones `is_test` agendan citas
+marcadas de prueba que JAMÁS invocan un conector (aserción antes de la
+bifurcación, simétrica en crear/reprogramar/cancelar — FR-017, corrigiendo la
+asimetría accidental del fork). El sender de WhatsApp sigue lanzando en
+sandbox — no se toca.
+
+**Resultado del gate**: PASA CON UNA VIOLACIÓN JUSTIFICADA (II), condicionada a
+la enmienda. Re-evaluado tras Fase 1: el diseño no agregó violaciones nuevas.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/015-motor-agenda-universal/
+├── spec.md                     # Qué y por qué (incluye la reversión del README)
+├── plan.md                     # Este archivo
+├── research.md                 # Fase 0: D1..D10 con evidencia
+├── data-model.md               # Fase 1: cinco tablas, índice único parcial, transiciones
+├── quickstart.md               # Fase 1: el self-test de punta a punta
+├── enmienda-constitucional.md  # Propuesta 1.3.0 → 1.4.0 (GATE de implementación)
+├── contracts/
+│   ├── agenda.md               # API operador + bot (201/200/409 exactos, sobre anidado)
+│   └── conector.md             # Contrato de conector + catálogo v1 + guía para forks
+├── checklists/
+│   └── requirements.md         # Calidad del spec
+└── tasks.md                    # Fase 2 (/speckit-tasks) — NO generado aún, por instrucción
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── lib/
+│   ├── env.ts                            # EDITA · AGENDA + bases de mock de conectores (en el esquema zod, no process.env directo)
+│   ├── time/
+│   │   └── slots.ts                      # NUEVO · helpers puros Intl (cantera 004, con sus tests de DST)
+│   └── db/
+│       ├── schema.ts                     # EDITA · cinco tablas nuevas
+│       └── ids.ts                        # EDITA · prefijos cal_/bk_/ofs_/zcred_/gcred_
+├── server/
+│   ├── agenda/
+│   │   ├── flag.ts                       # NUEVO · agendaEnabled() + respuesta 404 (molde de channels/enabled.ts)
+│   │   ├── settings.ts                   # NUEVO · get/upsert configuración + defaults
+│   │   ├── availability.ts               # NUEVO · computeAvailability / findSlot (cantera 004)
+│   │   ├── spread.ts                     # NUEVO · reparto por día (cantera fork; incidente 2026-08-07)
+│   │   ├── offers.ts                     # NUEVO · offered_slot: replace/get/clear en transacción
+│   │   ├── service.ts                    # NUEVO · ciclo de vida + garantías (23505→slot_taken) + efectos de conector best-effort
+│   │   ├── queries.ts                    # NUEVO · listado para la UI
+│   │   └── connectors/
+│   │       ├── types.ts                  # NUEVO · contrato + capacidades (contracts/conector.md)
+│   │       ├── index.ts                  # NUEVO · catálogo {enlace-fijo, zoom, google}
+│   │       ├── enlace-fijo.ts            # NUEVO · default sin dependencias
+│   │       ├── zoom.ts                   # NUEVO · S2S OAuth + caché de token (cantera fork)
+│   │       ├── zoom-credentials.ts       # NUEVO · cifrado/estado (molde whatsapp/credentials.ts)
+│   │       ├── google.ts                 # NUEVO · Calendar + Meet, REST directo
+│   │       └── google-credentials.ts     # NUEVO
+│   ├── ai/
+│   │   ├── actions.ts                    # EDITA · offer_slots / book_slot en la unión, solo con bandera
+│   │   ├── prompts.ts                    # EDITA · sección de agenda condicional (apagada = 0 tokens)
+│   │   └── pipeline.ts                   # EDITA · ejecución de las dos acciones con degradación
+│   └── dev/
+│       ├── zoom-mock-state.ts            # NUEVO · estado inspeccionable (cantera fork)
+│       └── google-mock-state.ts          # NUEVO
+├── app/
+│   ├── api/
+│   │   ├── calendar/
+│   │   │   ├── settings/route.ts         # NUEVO · GET/PUT (404 sin bandera)
+│   │   │   └── availability/route.ts     # NUEVO · GET
+│   │   ├── bookings/
+│   │   │   ├── route.ts                  # NUEVO · GET / POST (201)
+│   │   │   └── [id]/route.ts             # NUEVO · PATCH (reschedule/cancel/status/retry_link)
+│   │   ├── bot/
+│   │   │   ├── availability/route.ts     # NUEVO · GET (registra oferta; perDay/days)
+│   │   │   └── bookings/route.ts         # NUEVO · POST 201 / PATCH 200 / 409 con slots
+│   │   ├── settings/
+│   │   │   ├── zoom/route.ts (+ test/)   # NUEVO · GET/PUT/DELETE + probar sin guardar
+│   │   │   └── google/route.ts (+ test/) # NUEVO
+│   │   └── dev/
+│   │       ├── zoom-mock/[...path]/route.ts    # NUEVO · tras mockGuard(); _state/_reset; secret -invalid ⇒ fallo
+│   │       └── google-mock/[...path]/route.ts  # NUEVO
+│   └── (app)/
+│       ├── layout.tsx                    # EDITA · calcula bandera (server) → AppShell → AppNav
+│       ├── bookings/page.tsx             # NUEVO · "Citas" (404 sin bandera)
+│       └── settings/
+│           ├── layout.tsx                # EDITA · pasa bandera a SettingsNav
+│           └── calendar/page.tsx         # NUEVO · Ajustes → "Agenda" (horario + conector + credenciales)
+├── components/
+│   ├── app-nav.tsx                       # EDITA · entrada "Citas" condicional por prop (patrón inbox/page.tsx)
+│   ├── settings/settings-nav.tsx         # EDITA · pestaña "Agenda" condicional por prop
+│   ├── settings/agenda-client.tsx        # NUEVO
+│   └── bookings/bookings-client.tsx      # NUEVO · lista + acciones + "Reintentar enlace"
+drizzle/0009_motor_agenda.sql             # NUEVO · aditiva, re-ejecutable, incluye el UNIQUE parcial
+tests/unit/
+├── slots.test.ts                         # NUEVO · DST y bordes (cantera 004)
+├── availability.test.ts                  # NUEVO
+├── offers.test.ts                        # NUEVO
+├── booking-race.test.ts                  # NUEVO · 23505 → slot_taken
+├── agenda-flag.test.ts                   # NUEVO · apagada/encendida (molde channels.test.ts)
+└── connectors.test.ts                    # NUEVO · contrato compartido de los tres conectores
+tests/e2e/us-agenda.md                    # NUEVO · guion de la historia (cantera 004)
+scripts/e2e-selftest.mjs                  # EDITA · sección de agenda (códigos exactos)
+.github/workflows/ci.yml                  # EDITA · matriz: default y todo-encendido (paga la deuda de ADR-001)
+docs/
+├── agenda-conectores.md                  # NUEVO · contrato público + guía "escribe tu conector" + scopes/gotchas
+└── adr-002-conectores-de-agenda.md       # NUEVO · la decisión registrada (bandera AGENDA, 4 operaciones, sin free-busy)
+README.md                                 # EDITA · reescribe "Fuera de alcance a propósito" + sección de agenda y conectores
+.env.example                              # EDITA · AGENDA con guía inline
+CLAUDE.md                                 # EDITA · mapa del código (fila de agenda/conectores) + regla de conectores
+.specify/memory/constitution.md           # EDITA · SOLO tras ratificar la enmienda (1.4.0 + Sync Impact Report)
+```
+
+**Structure Decision**: se respeta la separación del repo — helpers puros en
+`src/lib/`, dominio en `src/server/agenda/`, rutas delgadas que solo traducen
+HTTP ↔ dominio (el motor no conoce HTTP: la carrera se testea sin levantar la
+app). Los conectores viven DENTRO de `server/agenda/connectors/` con el molde
+de aislamiento de `src/lib/meta/` (Constitución: "las dependencias de APIs
+externas se acceden a través de adaptadores dedicados"). Rutas en inglés con
+etiquetas en español, como el resto: `/bookings` (nav "Citas"),
+`/settings/calendar` (pestaña "Agenda").
+
+**Orden de entrega sugerido para `/speckit-tasks`** (por historias
+independientes): US1 bandera (flag + 404 + navs condicionales + CI matriz) →
+US2 settings + enlace-fijo → US3 motor + garantías + bot + agente → US4 página
+Citas → US5 conector Zoom + mock → US6 conector Google + mock → docs/README/
+ADR-002. La enmienda se ratifica antes de US5 (o se recorta el alcance ahí).
+
+## Complexity Tracking
+
+| Violación | Por qué se necesita | Alternativa más simple rechazada porque |
+|---|---|---|
+| Principio II: servicios externos `zoom`/`google` fuera de la lista cerrada | Es el pedido del dueño y la ventaja competitiva declarada: la reunión debe entregarse donde el negocio ya vive (Zoom/Meet/Calendar), con contrato para que forks agreguen el resto | *Enlace fijo solamente* (el 004): no entrega reunión por cita ni evento en calendario — exactamente lo que el dueño pidió superar. *Forks por proveedor*: ADR-001 demostró empíricamente el costo (la propia rama 004 quedó irrescatable en 26 días). La violación queda condicionada a la enmienda 1.4.0: apagado por defecto, aislado, degradable, credenciales propias, verificable — y con plan B explícito si se rechaza |
+| Cinco tablas nuevas (vs. tres del 004) | Las dos extra son credenciales por proveedor | *Un jsonb genérico de credenciales*: rechazado por el precedente escrito del repo ("unas credenciales tienen forma fija y conocida: así conservan tipado e índices") y porque cada conector de fork trae SU forma |

--- a/specs/015-motor-agenda-universal/plan.md
+++ b/specs/015-motor-agenda-universal/plan.md
@@ -4,11 +4,10 @@
 
 **Input**: Feature specification from `/specs/015-motor-agenda-universal/spec.md`
 
-**Estado**: planeación completa (Fase 0 + Fase 1). `tasks.md` NO generado —
-instrucción explícita del dueño: llegar hasta la planeación. Siguiente paso
-cuando lo decida: ratificar (o rechazar) la
-[enmienda constitucional](./enmienda-constitucional.md) y correr
-`/speckit-tasks`.
+**Estado**: planeación completa (Fase 0 + Fase 1). Enmienda constitucional
+[**ratificada y aplicada**](./enmienda-constitucional.md) (1.4.0, 2026-08-26).
+`tasks.md` NO generado — instrucción explícita del dueño: llegar hasta la
+planeación. Siguiente paso cuando lo decida: `/speckit-tasks`.
 
 ## Summary
 
@@ -71,7 +70,7 @@ días, citas de 30 min ⇒ decenas de slots por consulta.
 | Principio | Cómo lo cumple esta feature |
 |---|---|
 | **I. Seguridad de datos** | Credenciales de conector cifradas AES-256-GCM con `lib/crypto` (mismo mecanismo, no uno segundo), tablas explícitas por proveedor, hacia afuera solo `last4` + estado; jamás a logs. El enlace fijo no se cifra: es una URL que el negocio reparte. |
-| **II. Soberanía (endurecido)** | ⚠️ **VIOLACIÓN REGISTRADA**: `zoom` y `google` son servicios externos fuera de la lista cerrada (Google además prohibido nominalmente). Mitigación: el motor y `enlace-fijo` son 100% soberanos (cero deps); los conectores externos van tras bandera apagada por defecto, aislados tras adaptador con contrato público, degradables (la cita nunca depende del tercero) y con credenciales del propio negocio. Ver Complexity Tracking y la [enmienda 1.4.0](./enmienda-constitucional.md) — **su ratificación es prerequisito de implementación**; si se rechaza, el alcance se recorta a bandera + motor + `enlace-fijo` (cero violaciones). |
+| **II. Soberanía (endurecido, 1.4.0)** | ✅ CUMPLE bajo la constitución 1.4.0 ([enmienda ratificada y aplicada](./enmienda-constitucional.md) el 2026-08-26): `zoom` y `google` entran como **conectores opcionales** y el diseño satisface las cinco condiciones — (1) apagados por defecto tras `AGENDA`; (2) adaptadores aislados con contrato público; (3) camino sin dependencia (`enlace-fijo`) y degradación definida (link pendiente: la cita nunca depende del tercero); (4) credenciales del propio negocio cifradas; (5) matriz de CI + mocks con camino infeliz. Historia: contra la 1.3.0 esto era una violación registrada — queda documentada en Complexity Tracking para trazabilidad. |
 | **III. Multi-tenancy** | `organization_id NOT NULL` org-first en las cinco tablas; acceso por `scoped()`; credenciales únicas por organización. |
 | **IV. Idempotencia** | Cancelar dos veces no falla; `deleteMeeting` trata 404 como éxito; el índice UNIQUE parcial convierte la confirmación repetida/concurrente en `409` en vez de duplicado; migración `IF NOT EXISTS` re-ejecutable. |
 | **V. Calidad verificable** | Gate técnico + unit de la carrera y del contrato de conectores + arnés E2E extendido; códigos y sobre verificados exactos (research D9). |
@@ -86,8 +85,9 @@ bifurcación, simétrica en crear/reprogramar/cancelar — FR-017, corrigiendo l
 asimetría accidental del fork). El sender de WhatsApp sigue lanzando en
 sandbox — no se toca.
 
-**Resultado del gate**: PASA CON UNA VIOLACIÓN JUSTIFICADA (II), condicionada a
-la enmienda. Re-evaluado tras Fase 1: el diseño no agregó violaciones nuevas.
+**Resultado del gate**: PASA sin violaciones vigentes — la única (II, contra la
+1.3.0) quedó resuelta por la enmienda ratificada y aplicada (1.4.0,
+2026-08-26). Re-evaluado tras Fase 1: el diseño no agregó violaciones nuevas.
 
 ## Project Structure
 
@@ -189,7 +189,7 @@ docs/
 README.md                                 # EDITA · reescribe "Fuera de alcance a propósito" + sección de agenda y conectores
 .env.example                              # EDITA · AGENDA con guía inline
 CLAUDE.md                                 # EDITA · mapa del código (fila de agenda/conectores) + regla de conectores
-.specify/memory/constitution.md           # EDITA · SOLO tras ratificar la enmienda (1.4.0 + Sync Impact Report)
+.specify/memory/constitution.md           # EDITADA · enmienda aplicada (1.4.0 + Sync Impact Report, 2026-08-26)
 ```
 
 **Structure Decision**: se respeta la separación del repo — helpers puros en
@@ -205,11 +205,12 @@ etiquetas en español, como el resto: `/bookings` (nav "Citas"),
 independientes): US1 bandera (flag + 404 + navs condicionales + CI matriz) →
 US2 settings + enlace-fijo → US3 motor + garantías + bot + agente → US4 página
 Citas → US5 conector Zoom + mock → US6 conector Google + mock → docs/README/
-ADR-002. La enmienda se ratifica antes de US5 (o se recorta el alcance ahí).
+ADR-002. La enmienda ya está ratificada y aplicada (1.4.0): US5 y US6 quedan
+desbloqueadas desde el arranque.
 
 ## Complexity Tracking
 
 | Violación | Por qué se necesita | Alternativa más simple rechazada porque |
 |---|---|---|
-| Principio II: servicios externos `zoom`/`google` fuera de la lista cerrada | Es el pedido del dueño y la ventaja competitiva declarada: la reunión debe entregarse donde el negocio ya vive (Zoom/Meet/Calendar), con contrato para que forks agreguen el resto | *Enlace fijo solamente* (el 004): no entrega reunión por cita ni evento en calendario — exactamente lo que el dueño pidió superar. *Forks por proveedor*: ADR-001 demostró empíricamente el costo (la propia rama 004 quedó irrescatable en 26 días). La violación queda condicionada a la enmienda 1.4.0: apagado por defecto, aislado, degradable, credenciales propias, verificable — y con plan B explícito si se rechaza |
+| Principio II (contra la 1.3.0; RESUELTA por la enmienda 1.4.0 ratificada el 2026-08-26): servicios externos `zoom`/`google` fuera de la lista cerrada | Es el pedido del dueño y la ventaja competitiva declarada: la reunión debe entregarse donde el negocio ya vive (Zoom/Meet/Calendar), con contrato para que forks agreguen el resto | *Enlace fijo solamente* (el 004): no entrega reunión por cita ni evento en calendario — exactamente lo que el dueño pidió superar. *Forks por proveedor*: ADR-001 demostró empíricamente el costo (la propia rama 004 quedó irrescatable en 26 días). La enmienda habilitó la vía del conector opcional: apagado por defecto, aislado, degradable, credenciales propias, verificable |
 | Cinco tablas nuevas (vs. tres del 004) | Las dos extra son credenciales por proveedor | *Un jsonb genérico de credenciales*: rechazado por el precedente escrito del repo ("unas credenciales tienen forma fija y conocida: así conservan tipado e índices") y porque cada conector de fork trae SU forma |

--- a/specs/015-motor-agenda-universal/quickstart.md
+++ b/specs/015-motor-agenda-universal/quickstart.md
@@ -1,0 +1,108 @@
+# Quickstart — probar el motor de agenda universal de punta a punta
+
+Feature: `015-motor-agenda-universal`. Cómo se ejercita TODO el alcance en
+localhost con los mocks, sin tocar proveedores reales (Constitución IX: local
+primero, nube después).
+
+## 1. Entorno
+
+```bash
+# .env (además de lo habitual: DATABASE_URL, BETTER_AUTH_SECRET, ENCRYPTION_KEY…)
+AGENDA=on                                   # la bandera de esta feature
+CHANNELS=whatsapp                           # (o whatsapp,instagram para la config "todo encendido")
+WA_MOCK_ENABLED=true
+META_GRAPH_BASE_URL=http://localhost:3000/api/dev/wa-mock/graph
+OPENROUTER_BASE_URL=http://localhost:3000/api/dev/ai-mock
+BOT_API_KEY=una-llave-de-al-menos-16-chars
+ZOOM_BASE_URL=http://localhost:3000/api/dev/zoom-mock
+ZOOM_OAUTH_BASE_URL=http://localhost:3000/api/dev/zoom-mock
+GOOGLE_CAL_BASE_URL=http://localhost:3000/api/dev/google-mock
+GOOGLE_OAUTH_BASE_URL=http://localhost:3000/api/dev/google-mock
+```
+
+App viva con BD migrada (`pnpm db:migrate` en dev; en contenedor migra al
+arranque).
+
+## 2. La bandera, primero apagada
+
+1. Arranca SIN `AGENDA` → `GET /api/calendar/settings`, `GET /api/bookings`,
+   `GET /api/bot/availability` y `POST /api/bot/bookings` responden **404**;
+   la navegación no muestra "Citas"; Ajustes no muestra "Agenda"; el prompt del
+   agente (Laboratorio) no menciona agendar.
+2. Arranca con `AGENDA=on` → todo lo anterior existe; la migración no cambió
+   (ya estaba aplicada: es inerte apagada).
+
+## 3. Camino feliz sin terceros (conector `enlace-fijo`)
+
+1. Ajustes → Agenda: horario L-V 09:00-18:00, cita 30 min, zona
+   `America/Mexico_City`, link `https://meet.ejemplo.com/mi-sala`.
+2. `GET /api/bot/availability?conversationId=cv_…&limit=12&perDay=3&days=5` →
+   huecos repartidos entre días, etiquetas con día en palabras.
+3. `POST /api/bot/bookings` con un `startUtc` ofrecido → **`201`** con
+   `meetingLink` = la sala fija y `linkPending: false`.
+4. La cita aparece en "Citas"; el hueco desapareció de la disponibilidad; el
+   lead avanzó de etapa (bitácora registra el movimiento).
+
+## 4. Las dos garantías (contra la app viva, no con mocks unitarios)
+
+- **No ofrecido**: `POST /api/bot/bookings` con un instante libre pero jamás
+  ofrecido → `409` con `error.code = "slot_not_offered"` y `slots` = lo que sí
+  se ofreció.
+- **La carrera**: ofrece a dos conversaciones el mismo hueco; reserva con la
+  primera (201); reserva con la segunda → `409 slot_taken` con alternativas
+  frescas, y `GET /api/bookings` muestra UNA sola cita en ese instante.
+  Reservar la alternativa de inmediato → 201 (ya estaba registrada como
+  oferta).
+- **Códigos exactos**: los checks comparan `status === 201` / `=== 409` y la
+  forma anidada del sobre — nunca `res.ok`.
+
+## 5. Conector Zoom (mock)
+
+1. Ajustes → Agenda → conector Zoom: pega Account ID / Client ID / Client
+   Secret cualquiera → **Probar** pega al zoom-mock y pasa; con secret
+   terminado en `-invalid` → 422 y NO se guarda.
+2. Agenda una cita → `201` con `meetingLink` `https://zoom.mock/j/…`;
+   `GET /api/dev/zoom-mock/_state` muestra la reunión creada con tema, inicio y
+   duración.
+3. Reprograma (`PATCH /api/bot/bookings`) → 200, mismo link; el `_state`
+   muestra el PATCH con el mismo id.
+4. Cancela desde "Citas" → el `_state` muestra el DELETE; cancelar de nuevo →
+   200 sin cambios.
+
+## 6. Fallo del proveedor ⇒ link pendiente ⇒ reintento
+
+1. Con el mock en modo fallo (o credenciales rotas a propósito), agenda →
+   **`201` igualmente**, con `meetingLink: null` y `linkPending: true` — la
+   conversión no se pierde.
+2. "Citas" muestra la cita marcada "sin enlace" con **Reintentar enlace**.
+3. Repara el mock y reintenta → el link aparece y `linkPending` vuelve a
+   `false`.
+4. Si el fallo fue 401: Ajustes muestra la tarjeta de reconexión
+   (`status: "error"`).
+
+## 7. Conector Google (mock)
+
+Igual que Zoom con el google-mock: conectar valida antes de guardar; agendar
+crea el evento con petición de Meet; reprogramar mueve el evento; cancelar lo
+borra; refresh token inválido → error claro + estado de reconexión.
+
+## 8. Sandbox del Laboratorio
+
+Corre una conversación del Laboratorio hasta agendar: la cita nace `is_test`,
+visible marcada de prueba, y los `_state` de los mocks de conectores quedan
+**vacíos** — ni crear, ni reprogramar, ni cancelar tocan proveedor alguno para
+citas de prueba (y la app real, jamás: los mocks solo existen con
+`WA_MOCK_ENABLED=true` fuera de producción).
+
+## 9. Gate y arnés
+
+```bash
+pnpm typecheck && pnpm lint && pnpm build && pnpm test   # el piso
+pnpm test:e2e                                            # el arnés, con la app viva
+```
+
+`pnpm test:e2e` incluye la sección de agenda (guion `tests/e2e/us-agenda.md`):
+bandera apagada/encendida, camino feliz, las dos garantías con códigos exactos,
+la carrera, link pendiente + reintento, y sandbox. Sale distinto de cero si
+algo falla. En CI, los gates corren en la matriz de dos configuraciones: todo
+apagado (default) y todo encendido (`AGENDA=on` + canales) — FR-021.

--- a/specs/015-motor-agenda-universal/research.md
+++ b/specs/015-motor-agenda-universal/research.md
@@ -179,10 +179,28 @@ configurable (default `primary`). Scope: `…/auth/calendar.events`.
   [Google Cloud — Manage App Audience](https://support.google.com/cloud/answer/15549945?hl=en),
   [Using OAuth 2.0 to Access Google APIs](https://developers.google.com/identity/protocols/oauth2),
   [resumen del límite de 7 días](https://www.unipile.com/google-oauth-refresh-token/).
-- **NEEDS VERIFICATION (en implementación, Principio VII)**: confirmar contra
-  la API real que `conferenceData.createRequest` responde el link en la
-  creación síncrona (o exige un poll del evento) antes de fijar el contrato de
-  respuesta del adaptador; el mock debe imitar el comportamiento confirmado.
+- **RESUELTO 2026-08-26 (era NEEDS VERIFICATION)**: la conferencia se crea de
+  forma **asíncrona**. La documentación oficial es explícita: *"the immediate
+  response to this call might not yet contain the fully-populated
+  `conferenceData`; the status field contains `pending`"*, y solo cuando pasa a
+  `success` aparecen los `entryPoints` con el enlace. Fuentes:
+  [Create events — Calendar API](https://developers.google.com/workspace/calendar/api/guides/create-events)
+  y la [referencia de events](https://developers.google.com/workspace/calendar/api/v3/reference/events).
+
+  **Consecuencias de diseño, ya aplicadas:**
+  1. El adaptador **re-lee el evento** unas pocas veces tras crearlo, en vez de
+     confiar en la respuesta del insert.
+  2. Si aun así sigue pendiente, la cita se entrega **con el evento creado y
+     sin enlace** (`link_pending`), no se descarta ni se reintenta a ciegas.
+  3. Eso obligó a una operación **opcional** más en el contrato:
+     `refreshMeeting(creds, externalId)`. Sin ella, "Reintentar enlace" sobre
+     una cita que ya tiene evento crearía un evento DUPLICADO en el calendario
+     del dueño. Es opcional: un conector cuyo enlace llega de inmediato (Zoom)
+     no la necesita.
+
+  Esto es exactamente lo que el marcador de trazabilidad existía para evitar:
+  fijar el contrato sobre un supuesto cómodo y descubrir en producción que el
+  proveedor no lo cumple.
 
 ---
 

--- a/specs/015-motor-agenda-universal/research.md
+++ b/specs/015-motor-agenda-universal/research.md
@@ -1,0 +1,265 @@
+# Fase 0 — Investigación y decisiones
+
+Feature: `015-motor-agenda-universal` · Fecha: 2026-08-26
+
+Cada decisión con su evidencia. Tres fuentes: la rama `004-motor-agenda` (el
+motor ya diseñado y probado contra este repo, 2026-07-31), el fork de agencia
+`aishia-crm` + `aishia-lead-bot` (la integración Zoom y el gateway del bot en
+producción desde julio), y verificación externa donde se indica.
+
+---
+
+## D1. Zona horaria y DST con `Intl`, sin dependencias (heredada del 004)
+
+**Decisión**: aritmética de zonas con `Intl.DateTimeFormat` (`formatToParts`)
+en helpers puros. No se agrega luxon (lo que usa el fork).
+
+**Evidencia** (prototipo del 004, corrido entonces también dentro del
+contenedor de producción `node:22-alpine`): México ago/ene → 15:00Z ambos;
+Nueva York 2026-03-07 (EST) → 14:00Z y 2026-03-09 (EDT) → 13:00Z; Madrid CET
+08:00Z / CEST 07:00Z; 418 zonas disponibles en el ICU del contenedor y formato
+es-MX correcto. Bordes documentados: hora inexistente (salto de primavera) se
+resuelve con el offset previo; hora ambigua (retroceso) toma la primera
+ocurrencia; ninguna lanza.
+
+**Alternativas**: luxon (dependencia nueva de runtime en un core que no tiene
+ninguna de fechas — rechazada, FR-020); guardar el horario en UTC (rompe con
+DST: el negocio abre "a las 9" todo el año — incorrecta); `Temporal` (no
+estable en el runtime objetivo — revisable).
+
+---
+
+## D2. La memoria de "lo ofrecido" vive en el core (heredada del 004, reforzada)
+
+**Decisión**: tabla `offered_slot` y su validación en el core del CRM.
+`GET /api/bot/availability` registra la oferta por conversación; reservar exige
+coincidencia por **epoch exacto** con lo ofrecido a ESA conversación.
+
+**Rationale**: en el fork la protección vive en el bot (tabla `offered_slots`
+en la base del bot, `aishia-lead-bot/migrations/001_init.sql`, match por epoch
+en `app/tools.py`). Funciona porque hay UN cliente de confianza. Vocero promete
+"conecta tu propio cerebro": con la garantía en el cliente, cualquier otro
+cerebro podría reservar un instante jamás ofrecido y el CRM lo aceptaría. En el
+core es inviolable por construcción y vale igual para el agente in-process, el
+bot externo y cualquier integración futura. Esto responde directamente al
+argumento del README ("lo ofrecido pertenece al agente"): pertenecía al agente
+mientras el CRM no ofrecía la garantía; al ofrecerla, es el CRM quien debe
+poder probarla.
+
+**Por qué epoch exacto**: un LLM alucina con facilidad un "martes a las 10" que
+nunca se ofreció o desplaza la hora al re-escribir el ISO; la comparación
+exacta convierte esa alucinación en un rechazo explícito con la lista de lo que
+sí se ofreció. El fork registra además la frase textual de confirmación del
+lead para auditar disputas — buena práctica del lado del cliente que la guía
+del bot recomendará, sin ser contrato.
+
+---
+
+## D3. La bandera: `AGENDA`, hermana de `CHANNELS` (nueva)
+
+**Decisión**: una variable de entorno booleana `AGENDA` (`on` = encendida;
+ausente o cualquier otro valor = apagada), parseada junto al patrón de
+`src/server/channels/enabled.ts`, con las mismas consecuencias de ADR-001:
+apagada ⇒ 404 en toda la superficie, UI sin rastro, acciones del agente no
+registradas, migración siempre aplicada.
+
+**Alternativas consideradas**:
+- *Reutilizar `CHANNELS`*: agendar no es un canal; mezclar taxonomías confunde
+  el contrato de capacidades por canal. Rechazada.
+- *Una lista `AGENDA_CONNECTORS="zoom,google"` como bandera doble* (módulo +
+  allowlist de conectores por despliegue): la soberanía ya queda garantizada
+  por el opt-in real —ningún código llama a un proveedor sin conector
+  seleccionado Y credenciales pegadas—, así que la segunda bandera solo
+  agregaría ceremonia. Rechazada; si algún operador necesita prohibir
+  conectores a nivel de despliegue, es una extensión natural futura.
+- *Un mecanismo genérico `FEATURES=`*: ADR-001 fija el criterio de revisión
+  ("cuando haya del orden de quince banderas, extraer una interfaz"); hoy van
+  dos. Prematuro. Rechazada — pero la decisión queda registrada en ADR-002
+  para que la tercera bandera dispare la conversación.
+
+**Deuda que esta feature paga**: ADR-001 afirma que "CI corre la suite con la
+bandera apagada y encendida" y el workflow real no tiene matriz ni menciona
+`CHANNELS` (verificado: un solo job `gates`). FR-021 implementa la matriz con
+dos configuraciones extremas (todo apagado / todo encendido), cubriendo ambas
+banderas de una vez.
+
+**Hueco de 014 que esta feature no hereda**: no existe precedente de pestaña de
+Ajustes ni navegación bajo bandera (014 nunca creó la pestaña de Instagram; los
+navs son client components con arrays constantes). El patrón correcto ya existe
+en el repo: server component calcula y pasa por prop (`inbox/page.tsx` →
+`InboxClient`). Se replica desde los layouts de servidor hacia `AppNav` y
+`SettingsNav`.
+
+---
+
+## D4. El contrato de conector: 4 operaciones, ni una más (nueva)
+
+**Decisión**: el contrato público es
+
+```
+createMeeting(creds, {topic, startUtc, durationMinutes, timezone, notes?})
+  → { externalId: string | null, joinUrl: string | null }
+updateMeeting(creds, externalId, {startUtc, durationMinutes, timezone}) → void
+deleteMeeting(creds, externalId) → void          // 404 del proveedor = éxito
+testConnection(creds) → { ok: true, detail? } | { ok: false, error }
+```
+
+más capacidades declarativas (`perBookingLink`, `updatesMeeting`,
+`writesCalendarEvent`) al estilo del contrato de canales
+(`src/server/channels/capabilities.ts`): el motor pregunta, no sabe.
+
+**Evidencia**: es exactamente la superficie que el fork usa en producción
+(`aishia-crm/src/lib/zoom/index.ts`: `createMeeting`, `updateMeeting`,
+`deleteMeeting`, `testConnection`) — ni una operación más en meses de uso real.
+`deleteMeeting` que traga el 404 ("reunión ya borrada: objetivo cumplido") y
+`updateMeeting` que conserva el `join_url` (mismo id ⇒ mismo link) son
+comportamiento observado, no teoría.
+
+**Lo que deliberadamente NO entra**: `getBusy`/free-busy (leer el calendario
+ajeno para descontar disponibilidad). El fork nunca lo tuvo — decisión de
+producto explícita de su spec 005 ("Zoom ya sincroniza con mi calendario; los
+compromisos externos son bloqueos manuales") — y meterlo acoplaría la latencia
+y los fallos del proveedor al camino caliente de la disponibilidad, que hoy es
+una query + aritmética local. Se decide a propósito y queda como frontera de
+extensión para forks (Assumptions del spec).
+
+---
+
+## D5. Zoom Server-to-Server como conector de referencia (nueva)
+
+**Decisión**: portar el adaptador del fork tal cual en espíritu: token S2S
+(`POST {oauth}/oauth/token?grant_type=account_credentials&account_id=…`, header
+`Basic base64(clientId:clientSecret)`), caché de token en memoria por proceso
+con expiración anticipada 60 s e invalidación al cambiar credenciales;
+`POST /users/me/meetings` con `type: 2`, topic, `start_time` UTC sin
+milisegundos, `duration`, `timezone` y `settings {join_before_host: true,
+waiting_room: false}`; `PATCH /meetings/{id}` solo con inicio/duración/zona;
+`DELETE /meetings/{id}` tolerante a 404. Bases URL configurables solo para
+apuntar al mock en self-test.
+
+**Correcciones sobre el fork** (lecciones, no copias):
+1. La guía de scopes del fork omite el de lectura de usuario que usa
+   `testConnection` (`GET /users/me`): con solo `meeting:write:*` la conexión
+   fallaría con credenciales por lo demás válidas. La guía v1 lista los cuatro
+   scopes granulares (crear/actualizar/borrar reunión + leer usuario).
+2. `isAuthError` existe en el fork y nadie lo consume, y el estado `error` de
+   sus credenciales nunca se escribe. Aquí el error de autenticación en un
+   efecto ESCRIBE el estado y la UI lo muestra (FR-016) — el criterio es
+   estricto (401), no "cualquier 400" como el helper muerto del fork.
+3. El fallo del proveedor en el fork es pérdida silenciosa (warn y nada más).
+   Aquí deja `link_pending` visible y reintentable (FR-014, D8).
+
+---
+
+## D6. Google: Calendar + Meet con refresh token de app propia (nueva)
+
+**Decisión**: el conector `google` habla REST directo (sin SDK):
+`POST https://oauth2.googleapis.com/token` (`grant_type=refresh_token`) para
+obtener el access token, y `POST/PATCH/DELETE …/calendars/{id}/events` con
+`conferenceDataVersion=1` y `conferenceData.createRequest` para el link de
+Meet. Credenciales: Client ID + Client Secret + refresh token de la **propia
+app de Google Cloud del negocio**, pegados una vez; calendario destino
+configurable (default `primary`). Scope: `…/auth/calendar.events`.
+
+**Por qué así y no de otra forma** (verificado 2026-08-26):
+- *Service account*: crear conferencias de Meet vía `conferenceData` con
+  service account requiere delegación de dominio de Workspace; sin ella el
+  proveedor rechaza la conferencia. Eso excluye a todo negocio con Gmail de
+  consumidor — inaceptable para el público de Vocero. Fuentes:
+  [issue #2387 de google-api-nodejs-client](https://github.com/googleapis/google-api-nodejs-client/issues/2387),
+  [guía de dominio de Calendar API](https://developers.google.com/workspace/calendar/api/concepts/domain).
+- *Flujo OAuth con redirect dentro del producto*: mejor UX, pero exige
+  implementar callback, estado y rotación — más superficie para v1 sin cambiar
+  la soberanía (la app OAuth seguiría siendo del negocio). Queda como mejora
+  futura explícita.
+- *Gotcha que la guía DEBE advertir*: con la app OAuth en publishing status
+  "Testing" (tipo External), Google revoca autorizaciones y refresh tokens a
+  los **7 días**; en "In production" no caducan. Sin esta advertencia la
+  integración muere en silencio a la semana. Fuentes:
+  [Google Cloud — Manage App Audience](https://support.google.com/cloud/answer/15549945?hl=en),
+  [Using OAuth 2.0 to Access Google APIs](https://developers.google.com/identity/protocols/oauth2),
+  [resumen del límite de 7 días](https://www.unipile.com/google-oauth-refresh-token/).
+- **NEEDS VERIFICATION (en implementación, Principio VII)**: confirmar contra
+  la API real que `conferenceData.createRequest` responde el link en la
+  creación síncrona (o exige un poll del evento) antes de fijar el contrato de
+  respuesta del adaptador; el mock debe imitar el comportamiento confirmado.
+
+---
+
+## D7. La carrera del slot: índice UNIQUE parcial + mapeo del 23505 (heredada del 004)
+
+**Decisión**: además de la re-validación al confirmar, la atomicidad la da la
+base: índice único parcial sobre `(organization_id, scheduled_at)` limitado a
+`status IN ('agendada','realizada') AND is_test = false`; la violación (23505)
+se mapea a `409 slot_taken` con alternativas frescas.
+
+**Evidencia**: así lo implementó la rama 004 (migración `0002_grey_oracle.sql`,
+índice `booking_org_active_slot_uq` + `isUniqueViolation` en el servicio) y su
+E2E condujo la carrera contra la app viva. El contraste importa: el CRM del
+fork en producción NO tiene este candado (verificado: sus únicas constraints de
+`booking` son FKs; el patrón es leer-luego-insertar) — funciona por
+serialización de facto de un solo operador, no por garantía. Vocero, con
+cerebros externos concurrentes, necesita la garantía real. Solo instantes de la
+rejilla son reservables (la coincidencia por epoch exacto con la
+disponibilidad), así que la colisión práctica es "mismo instante", que el
+índice cubre; el solape entre duraciones distintas lo filtra el cálculo de
+disponibilidad en la oferta y la re-validación al confirmar.
+
+---
+
+## D8. Fallo del conector ⇒ cita con link pendiente, reintento manual (nueva)
+
+**Decisión**: los efectos hacia el proveedor corren DESPUÉS de que la verdad
+del CRM está escrita, son best-effort, y el fallo al crear deja
+`link_pending = true` visible en "Citas" con acción "Reintentar enlace" (contra
+el conector de origen). Sin cola ni cron en v1.
+
+**Rationale**: la conversión jamás se pierde por un tercero caído (la lección
+cara del fork es doble: el incidente del token de Meta 2026-08-03 —un hipo
+externo tumbó los envíos— y la pérdida silenciosa actual de reuniones Zoom sin
+reparación posible). La alternativa de una cola durable con reintentos
+automáticos (patrón `pending_send` del bot del fork) es más robusta pero exige
+un trabajador periódico que el core no tiene (Constitución II: sin colas
+externas; el in-process no sobrevive reinicios). El reintento manual entrega el
+90% del valor con el 10% de la maquinaria; la cola queda como evolución si la
+práctica la pide.
+
+**Regla de honestidad hacia el cliente**: cuando la respuesta trae
+`meetingLink: null` + `linkPending: true`, quien confirma NO promete link
+inmediato ("te llega el enlace por este medio"); el contrato lo dice y la guía
+del agente/bot lo instruye.
+
+---
+
+## D9. Los códigos y el sobre son contrato verificado (heredada del fork, endurecida)
+
+**Decisión**: `POST` de reserva → **201**; `PATCH` de reprogramación → 200;
+errores SIEMPRE `{"error":{"code","message"}}` anidado, y en los 409 de agenda
+`slots` como campo hermano. El arnés E2E compara códigos **exactos** (nunca
+`res.ok`) y la forma del sobre.
+
+**Evidencia** (los tres fallos reales del fork, todos invisibles hasta
+producción): (1) el cliente del bot aceptaba solo 200 y el CRM respondía 201 —
+ningún lead pudo agendar hasta encontrarlo, y los mocks daban 200; (2) los
+mocks usaban el sobre plano `{"code"…}` y el CRM el anidado — todo 409 se leyó
+como conflicto genérico y el camino de re-oferta jamás se activó; (3) motivos
+de handoff libres → 422 por enum. La lección transversal: los mocks del
+cliente divergieron del contrato real en código y forma, y por eso aquí el
+contrato escribe ambos y el arnés los verifica contra la app viva.
+
+---
+
+## D10. Qué se hace con la rama `004-motor-agenda` (nueva)
+
+**Decisión**: no se rebasea ni se renumera; se usa como **cantera**. La feature
+nace de `main` con migración `0009`.
+
+**Evidencia**: la rama quedó 76 commits atrás en 26 días; su migración
+`0002_grey_oracle.sql` colisiona de número con el `0002` que main ganó después
+(cadena de Drizzle lineal y hasheada); y 014 refactorizó `send.ts`,
+`actions.ts` y `pipeline.ts` que la rama también toca. Es el caso empírico
+exacto que ADR-001 predijo para "features en ramas" — y por eso se cita en el
+spec como argumento, no solo como obstáculo. Lo que se rescata de la cantera:
+helpers de tiempo con sus tests de DST, motor de disponibilidad, servicio de
+reservas (incluido el mapeo 23505), acciones del agente, contrato y guion E2E —
+adaptados al main de hoy y a la capa de conectores.

--- a/specs/015-motor-agenda-universal/spec.md
+++ b/specs/015-motor-agenda-universal/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-08-26
 
-**Status**: Draft — enmienda constitucional [ratificada y aplicada](./enmienda-constitucional.md) (constitución 1.4.0, 2026-08-26); lista para `/speckit-tasks`
+**Status**: Draft — enmienda constitucional [ratificada y aplicada](./enmienda-constitucional.md) (constitución 1.4.0) y [tareas generadas](./tasks.md) (2026-08-26); lista para `/speckit-implement`
 
 **Input**: Decisión del dueño 2026-08-26: "agregar a Vocero raíz el motor de
 agendamiento con slots así como lo tengo en mi CRM, pero en modo bandera, tal

--- a/specs/015-motor-agenda-universal/spec.md
+++ b/specs/015-motor-agenda-universal/spec.md
@@ -1,0 +1,558 @@
+# Feature Specification: Motor de agendamiento universal (bandera + conectores)
+
+**Feature Branch**: `015-motor-agenda-universal`
+
+**Created**: 2026-08-26
+
+**Status**: Draft — pendiente de ratificar la [enmienda constitucional](./enmienda-constitucional.md) antes de implementar
+
+**Input**: Decisión del dueño 2026-08-26: "agregar a Vocero raíz el motor de
+agendamiento con slots así como lo tengo en mi CRM, pero en modo bandera, tal
+cual como lo hicimos con la multicanalidad de IG. Universal y compatible con
+diversas apps de calendario —por ejemplo Zoom, Google Meet, Google Calendar—
+sin pretender el 100%: si alguien tiene una no compatible, puede crear un fork
+e implementarla. Esa capacidad de desarrollar los complementos faltantes es una
+de las ventajas competitivas de Vocero."
+
+## Contexto de negocio
+
+Un negocio que atiende por WhatsApp convierte cuando **cierra una cita**. Hoy
+Vocero lleva la conversación, califica y mueve el lead de etapa, pero la cita se
+coordina a mano y fuera del sistema. Esta feature agrega el motor: el CRM sabe
+cuándo está libre el negocio, ofrece esos huecos, acepta una reserva **solo**
+sobre un hueco realmente ofrecido y libre, deja la cita registrada junto al
+contacto y su conversación, y —si el negocio conectó un proveedor— **entrega la
+reunión donde el negocio ya vive**: una reunión de Zoom por cita, o un evento en
+su Google Calendar con link de Meet, o simplemente su sala fija de siempre.
+
+### Qué cambió desde el intento 004 y el README
+
+Esta decisión tiene historia y hay que decirla completa:
+
+1. La rama local `004-motor-agenda` (2026-07-31, nunca mergeada) especificó el
+   motor **sin ningún proveedor** —link fijo de texto— porque la Constitución II
+   (Soberanía, endurecida) prohíbe dependencias externas nuevas. Sus dos
+   garantías duras y su contrato sobreviven íntegros en este spec.
+2. El `README.md` (§ "Fuera de alcance a propósito") declara hoy que el motor
+   NO va al core, con dos argumentos: *(a)* "son unas mil líneas y una
+   dependencia de fechas en un proyecto cuyo argumento es ser ligero", y *(b)*
+   "el estado de qué huecos se ofrecieron pertenece a la conversación, o sea al
+   agente, no al CRM".
+3. La feature 014 (canal de Instagram) y el **ADR-001** cambiaron el terreno:
+   lo opcional ya no se entrega en una rama ni en una skill que parchea — se
+   entrega en el core, **apagado, detrás de una bandera**, con la migración
+   siempre aplicada (inerte) y el peso pagado solo por quien la enciende.
+
+Respuesta a los dos argumentos del README, que esta feature revierte por
+escrito (el README se actualiza como parte del alcance):
+
+- *(a) El peso*: detrás de la bandera `AGENDA` (apagada por defecto), una
+  instancia que no agenda no ve rutas, ni navegación, ni acciones del agente,
+  ni pide una sola credencial. Y el motor en sí sigue **sin dependencias
+  nuevas** (la aritmética de zonas usa `Intl` de la plataforma — evidencia en
+  `research.md` D1). El costo del que hablaba el README lo paga únicamente la
+  instancia que enciende la bandera.
+- *(b) Dónde vive "lo ofrecido"*: mantener esa memoria en el agente deja la
+  garantía del lado del cliente — cualquier otro cerebro conectado por
+  `/api/bot/*` (o el agente incluido) podría reservar un instante jamás
+  ofrecido y el CRM lo aceptaría. Bajarla al core la vuelve **inviolable por
+  construcción** y válida para todos los conductores por igual (research D2).
+  El fork de agencia opera hoy con la garantía en el bot y funciona, pero solo
+  porque hay un único cliente de confianza; Vocero promete "conecta TU propio
+  cerebro", y una promesa así no puede depender de que todos los cerebros se
+  porten bien.
+
+### Lo genuinamente nuevo: conectores universales
+
+Donde el 004 ponía un campo de texto y el fork de agencia una integración de
+Zoom cableada a mano (`zoom_meeting_id` en la tabla, cliente propio, sin
+abstracción), este spec introduce la **capa de conectores**: un contrato
+público y pequeño —cuatro operaciones, medido del uso real en producción del
+fork— que separa el motor (genérico, soberano) de la entrega de la reunión
+(opcional, por proveedor). v1 trae tres conectores:
+
+| Conector | Qué entrega | Dependencia externa |
+|---|---|---|
+| `enlace-fijo` | La sala fija del negocio, tal cual (comportamiento 004) | Ninguna |
+| `zoom` | Una reunión de Zoom por cita (crear/actualizar/borrar) | Zoom API (S2S OAuth) |
+| `google` | Un evento en el calendario del dueño + link de Meet | Google Calendar API |
+
+Quien use otra tecnología (Teams, Outlook, CalDAV, Cal.com…) implementa el
+contrato en su fork siguiendo la guía publicada — esa extensibilidad es parte
+del producto, no un accidente.
+
+**Puerta constitucional**: `zoom` y `google` violan la lista cerrada del
+Principio II vigente (que además prohíbe Google explícitamente). Esta feature
+NO se implementa sin ratificar antes la
+[enmienda propuesta](./enmienda-constitucional.md) (1.3.0 → 1.4.0): conectores
+opcionales tras bandera, apagados por defecto, aislados tras adaptador, con
+degradación definida y credenciales cifradas del propio negocio.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - La instancia decide si la agenda existe (Priority: P1)
+
+Una instancia recién instalada no tiene agenda: ni página, ni pestaña de
+ajustes, ni rutas, ni menciones en el prompt del agente. El operador que la
+quiere la enciende con la bandera `AGENDA` en su despliegue — igual que
+enciende el canal de Instagram con `CHANNELS`. Apagarla después no destruye
+nada: los datos quedan, las superficies desaparecen.
+
+**Why this priority**: es la condición del dueño ("en modo bandera, tal cual la
+multicanalidad de IG") y lo que revierte el argumento del README: el peso lo
+paga solo quien la enciende.
+
+**Independent Test**: levantar la app sin `AGENDA`, verificar que las rutas de
+agenda responden 404 y que la UI no la menciona; levantar con `AGENDA=on` y
+verificar que todo aparece con defaults sensatos, sin pedir credenciales de
+terceros.
+
+**Acceptance Scenarios**:
+
+1. **Given** una instancia sin `AGENDA` (o con valor no reconocido), **When**
+   se piden `/api/calendar/*`, `/api/bookings*`, `/api/bot/availability` o
+   `/api/bot/bookings`, **Then** todas responden **404** — el endpoint no
+   existe en esta instancia, no hay nada que revelar (mismo criterio que el
+   canal apagado de ADR-001).
+2. **Given** la bandera apagada, **When** se navega la app, **Then** no
+   aparecen "Citas" en la navegación ni "Agenda" en Ajustes, y el prompt del
+   agente no contiene ninguna instrucción de agendamiento (cero costo de
+   tokens).
+3. **Given** la bandera encendida (`AGENDA=on`) en una instancia recién
+   instalada, **When** se abre la app, **Then** aparecen "Citas" y Ajustes →
+   "Agenda" con defaults sensatos y conector `enlace-fijo` — **sin** pedir
+   ninguna credencial externa.
+4. **Given** una instancia que usó la agenda y luego la apagó, **When**
+   arranca, **Then** las citas y la configuración siguen en la base (la
+   migración es inerte y nada se borra), y las superficies responden 404 hasta
+   que vuelva a encenderse.
+5. **Given** cualquier configuración de la bandera, **When** corre la
+   migración al arranque, **Then** aplica siempre y es re-ejecutable: todas las
+   instancias del mundo comparten la misma estructura (ADR-001).
+
+---
+
+### User Story 2 - El negocio define cuándo atiende y cómo se entrega la reunión (Priority: P1)
+
+El operador abre Ajustes → Agenda y describe su realidad: qué días y en qué
+franjas atiende, cuánto dura una cita, cuánto respiro deja entre citas, con
+cuánta anticipación mínima acepta que le agenden, hasta cuántos días hacia
+adelante abre su agenda, y su zona horaria. Y elige **cómo se entrega la
+reunión**: su sala fija (pegar un link, cero dependencias), su cuenta de Zoom
+(pegar las credenciales S2S de su propia app), o su Google Calendar (pegar las
+credenciales de su propia app de Google). Las credenciales se validan contra el
+proveedor **antes** de guardarse, se cifran en reposo y hacia afuera solo se
+muestran sus últimos 4 caracteres.
+
+**Why this priority**: sin esto no hay disponibilidad que ofrecer ni forma de
+entrega; todo lo demás depende de esta pantalla.
+
+**Independent Test**: configurar horario L-V 09:00-18:00 con citas de 30 min y
+pedir la disponibilidad; verificar huecos dentro de la franja, en la zona
+configurada, respetando el aviso mínimo. Conectar el conector Zoom contra el
+mock y verificar que unas credenciales inválidas se rechazan sin guardarse.
+
+**Acceptance Scenarios**:
+
+1. **Given** una instancia recién encendida sin configuración, **When** se
+   consulta la configuración, **Then** devuelve defaults sensatos (L-V
+   09:00-18:00, cita de 30 min, sin respiro, aviso mínimo 2 h, ventana 7 días,
+   conector `enlace-fijo` con link vacío) — 200, no 404.
+2. **Given** el horario configurado, **When** se piden los huecos disponibles,
+   **Then** solo vienen huecos futuros que cumplen el aviso mínimo, ordenados,
+   cada uno con etiqueta legible en la zona del negocio que incluye el **día en
+   palabras** (ej. "mié 5 ago, 10:00") — la etiqueta corta sin día ya agendó
+   citas el día equivocado en producción del fork.
+3. **Given** una zona horaria con cambio de horario de verano, **When** el
+   rango cruza el cambio, **Then** las horas locales siguen siendo las
+   configuradas y los instantes UTC son correctos.
+4. **Given** el conector `zoom` seleccionado, **When** el operador pega
+   credenciales inválidas y pulsa Probar/Guardar, **Then** se validan contra el
+   proveedor y se rechazan con error claro **sin persistirse**; con
+   credenciales válidas quedan cifradas y la UI muestra solo los últimos 4.
+5. **Given** un conector configurado, **When** se consulta la configuración por
+   API, **Then** ningún secreto viaja en la respuesta (solo `last4` y estado).
+6. **Given** el conector `enlace-fijo` con el campo vacío, **When** se guarda,
+   **Then** se acepta (es opcional): las reservas se crearán sin link.
+
+---
+
+### User Story 3 - Quien conduce la conversación ofrece y reserva (Priority: P1)
+
+El agente de IA incluido, o un cerebro externo conectado por `/api/bot/*`,
+ofrece al cliente horarios concretos y reserva el que eligió. El CRM garantiza
+que **solo se reserva lo que se ofreció** y que **nunca se confirma una cita
+que no se creó**. Al crearse la cita, el conector activo entrega la reunión
+(link de Zoom/Meet o sala fija) y el lead avanza de etapa.
+
+**Why this priority**: es la conversión del producto y donde viven los dos
+fallos caros conocidos: prometer un horario que ya no existe, o confirmar una
+cita que nunca se creó.
+
+**Independent Test**: pedir horarios para una conversación, reservar uno
+ofrecido y comprobar cita creada + hueco desaparecido; intentar reservar un
+horario no ofrecido y comprobar el rechazo con la lista de lo que sí se
+ofreció; simular la carrera (el hueco se ocupa entre oferta y elección) y
+comprobar `slot_taken` con alternativas frescas y cero citas creadas.
+
+**Acceptance Scenarios**:
+
+1. **Given** una conversación activa, **When** se piden horarios para ofrecer,
+   **Then** se devuelven huecos libres **repartidos entre días** (parámetros
+   `limit`, `perDay`, `days`): el catálogo reservable es más ancho que el menú
+   que se muestra — guardar solo lo mostrado dejó al agente del fork sin nada
+   que ofrecer cuando el lead pedía otro día.
+2. **Given** unos horarios ofrecidos, **When** se reserva uno de ellos,
+   **Then** la cita queda creada, la respuesta es **201 Created** (no 200) con
+   la etiqueta legible y el link de reunión (o `null`), y el hueco desaparece
+   de la disponibilidad.
+3. **Given** unos horarios ofrecidos, **When** se intenta reservar un instante
+   que no estaba entre ellos —aunque esté libre—, **Then** se rechaza con
+   `slot_not_offered` (la comparación es por **epoch exacto**, no por texto ni
+   cercanía) y se devuelven los que sí se ofrecieron.
+4. **Given** un horario que se ocupó entre la oferta y la elección, **When** se
+   intenta reservar, **Then** responde `409 slot_taken` con **alternativas
+   frescas ya registradas como nueva oferta**, y no se crea ninguna cita. Dos
+   confirmaciones simultáneas sobre el mismo hueco: una gana, la otra recibe
+   `slot_taken` — jamás dos citas activas en el mismo instante (garantía
+   atómica en la base, no solo re-validación).
+5. **Given** el conector `zoom` o `google` activo, **When** la reserva
+   procede, **Then** la reunión se crea en el proveedor y su link viaja en la
+   respuesta; **y given** el proveedor caído o con credenciales inválidas,
+   **When** la reserva procede, **Then** la cita **se crea igual** con link
+   pendiente (`linkPending: true`), la conversión nunca se pierde por un
+   tercero caído, y quien confirma al cliente no promete un link que no tiene.
+6. **Given** una cita activa del contacto, **When** quien conduce pide
+   reprogramarla a otro hueco ofrecido, **Then** se mueve (200), el hueco
+   anterior se libera y la reunión del proveedor se actualiza **conservando el
+   mismo link**; mover una cita no exige pausar la IA ni un traspaso a humano.
+7. **Given** una conversación del Laboratorio (`is_test`), **When** se reserva,
+   **Then** la cita nace marcada de prueba y **jamás** llama al proveedor real
+   — en crear, reprogramar y cancelar por igual.
+8. **Given** el agente de IA incluido con la bandera encendida, **When**
+   conduce una conversación, **Then** dispone de las acciones `offer_slots` y
+   `book_slot` bajo las mismas reglas (el modelo no inventa horarios: el motor
+   adjunta las etiquetas reales; un `startUtc` no ofrecido se rechaza y se
+   re-ofrece), y un fallo del motor degrada el turno sin tumbarlo.
+
+---
+
+### User Story 4 - El operador ve y maneja sus citas (Priority: P2)
+
+El operador entra a "Citas" y ve lo agendado —por él o por la IA— con la hora
+en su zona, el contacto, el estado, el origen y el link. Desde ahí reprograma,
+cancela, marca realizada o no-show, bloquea huecos para compromisos externos, y
+si una cita quedó con el link pendiente (el proveedor falló al crear), lo
+**reintenta** con un clic.
+
+**Why this priority**: sin esta vista el operador no puede confiar en el motor,
+y sin el reintento un hipo del proveedor sería una pérdida silenciosa (lección
+del fork: hoy nadie repara una sesión que quedó sin reunión).
+
+**Independent Test**: agendar por API, verla en la página, cancelarla desde ahí
+y comprobar que el hueco vuelve a ofrecerse; forzar un fallo del conector
+(mock), ver la cita marcada "sin enlace", reintentar y ver el link aparecer.
+
+**Acceptance Scenarios**:
+
+1. **Given** citas futuras y pasadas, **When** se abre "Citas", **Then** se
+   listan con día y hora en la zona del negocio, contacto, origen (IA o
+   manual), estado, link si existe, y marca visible de prueba cuando aplica.
+2. **Given** una cita agendada, **When** se reprograma a otro hueco libre,
+   **Then** queda a la nueva hora, el hueco anterior vuelve a ofrecerse y la
+   reunión del proveedor se actualiza; **y** una cita cancelada no se
+   reprograma (422).
+3. **Given** una cita agendada, **When** se cancela, **Then** su hueco vuelve a
+   ofrecerse, la cita queda como cancelada (no se borra) y la reunión del
+   proveedor se borra (un 404 del proveedor cuenta como éxito). Cancelar dos
+   veces no falla ni cambia nada.
+4. **Given** un compromiso externo, **When** el operador bloquea ese rango,
+   **Then** deja de ofrecerse aunque caiga dentro del horario de atención.
+5. **Given** una cita con link pendiente, **When** el operador pulsa
+   "Reintentar enlace", **Then** se reintenta contra el conector con el que
+   nació la cita; si procede, el link queda guardado y visible.
+
+---
+
+### User Story 5 - Conector Zoom (Priority: P2)
+
+El negocio que vive en Zoom pega en Ajustes las tres credenciales de su propia
+app Server-to-Server (Account ID, Client ID, Client Secret) y desde entonces
+cada cita crea su reunión de Zoom: reprogramar la mueve conservando el link,
+cancelar la borra. Es el conector de referencia: su forma exacta lleva meses en
+producción en el fork de agencia.
+
+**Why this priority**: es el proveedor del dueño y el único con evidencia de
+producción; valida el contrato de conectores con un caso real.
+
+**Independent Test**: con el mock de Zoom, conectar credenciales, agendar y
+verificar reunión creada con su `join_url`; reprogramar y verificar que el
+proveedor recibió la actualización con el mismo id; cancelar y verificar el
+borrado; credenciales inválidas → la conexión se rechaza sin guardarse.
+
+**Acceptance Scenarios**:
+
+1. **Given** credenciales S2S válidas, **When** se guardan, **Then** se validan
+   primero contra el proveedor, quedan cifradas y el estado es "conectado".
+2. **Given** el conector activo, **When** se crea una cita real, **Then** se
+   crea una reunión programada con el tema, inicio, duración y zona del
+   negocio, y `booking` guarda el id externo y el link.
+3. **Given** una reunión creada, **When** la cita se reprograma, **Then** el
+   proveedor recibe la actualización sobre el **mismo** id (el link no cambia);
+   **When** se cancela, **Then** se borra en el proveedor (404 = ya no estaba:
+   objetivo cumplido).
+4. **Given** el proveedor respondiendo error de autenticación, **When** ocurre
+   un efecto, **Then** la credencial pasa a estado de error visible en Ajustes
+   (tarjeta de reconexión) — el estado de error existe para escribirse, no como
+   enum decorativo (lección del fork, donde nunca se escribe).
+5. **Given** la documentación del conector, **Then** lista TODOS los scopes
+   necesarios, incluido el de lectura de usuario que usa la prueba de conexión
+   (en el fork, la guía omite ese scope y la validación fallaría con
+   credenciales por lo demás correctas).
+
+---
+
+### User Story 6 - Conector Google Calendar + Meet (Priority: P3)
+
+El negocio que vive en Google pega las credenciales de su **propia** app de
+Google Cloud (Client ID, Client Secret y un refresh token obtenido una sola
+vez) y desde entonces cada cita crea un evento en su calendario con link de
+Meet: su agenda personal y la del CRM cuentan la misma historia sin que el CRM
+lea nada del calendario.
+
+**Why this priority**: P3 porque no tiene evidencia de producción previa (a
+diferencia de Zoom) y el motor + Zoom ya entregan la promesa completa; si se
+recorta, la feature sigue siendo entregable.
+
+**Independent Test**: con el mock de Google, conectar, agendar y verificar
+evento creado con `conferenceData` (Meet); reprogramar → el evento se mueve;
+cancelar → el evento se borra; refresh token inválido → error claro y estado de
+reconexión.
+
+**Acceptance Scenarios**:
+
+1. **Given** credenciales de app propia válidas, **When** se guardan, **Then**
+   se valida contra el proveedor antes de persistir, cifradas, últimos 4.
+2. **Given** el conector activo, **When** se crea una cita real, **Then** se
+   crea un evento en el calendario configurado (por defecto el principal) con
+   petición de conferencia Meet, y el link de Meet viaja como link de la cita.
+3. **Given** la guía de conexión, **Then** advierte explícitamente que la app
+   OAuth del negocio debe estar en estado "En producción": en estado "Testing"
+   Google revoca los refresh tokens a los 7 días y la integración moriría en
+   silencio a la semana.
+4. **Given** un refresh token revocado, **When** ocurre un efecto, **Then** la
+   cita no se pierde (link pendiente), y la credencial queda en estado de error
+   visible con instrucción de reconexión.
+
+---
+
+### Edge Cases
+
+- **Sin horario configurado para hoy** (día cerrado): disponibilidad vacía, no
+  error; lista vacía significa "ofrece otra salida" (handoff), no reintento.
+- **Agenda llena**: `slots: []` con 200.
+- **Conector sin configurar o enlace fijo vacío**: la reserva se crea con link
+  `null`; nadie promete un link que no existe.
+- **El proveedor falla al crear** (caído, 5xx, credencial inválida): la cita SE
+  CREA con link pendiente; el operador reintenta desde "Citas". El fallo de un
+  tercero jamás cuesta la conversión ni miente al cliente.
+- **El negocio cambia de conector con citas futuras vivas**: cada cita
+  recuerda el conector con el que nació; reprogramarla o cancelarla habla con
+  ESE conector, no con el nuevo. Las citas nuevas usan el nuevo.
+- **Credenciales borradas con citas futuras**: los efectos hacia el proveedor
+  fallan best-effort (aviso, no bloqueo); la cita y su ciclo de vida en el CRM
+  siguen intactos.
+- **Instante inválido o en el pasado**: 422, sin crear nada.
+- **Reserva sobre conversación inexistente**: 404.
+- **Mensaje repetido del cliente** (reservar dos veces el mismo instante): la
+  segunda recibe 409 — el hueco ya lo ocupa la primera; no hay duplicado.
+- **Cambio de configuración con citas ya agendadas**: las citas existentes no
+  se mueven; cada una conserva la duración con la que se creó.
+- **Bandera apagada a media vida**: datos intactos, superficies 404 (ver US1).
+- **Hora inexistente/ambigua por DST**: se resuelve a un instante real sin
+  lanzar (documentado en research D1); las citas creadas nunca se mueven solas.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**La bandera**
+
+- **FR-001**: La agenda completa DEBE vivir detrás de la bandera de despliegue
+  `AGENDA` (apagada por defecto), hermana de `CHANNELS` y bajo los mismos
+  criterios de ADR-001: apagada ⇒ rutas de agenda (operador y bot) responden
+  404, la UI no la menciona, el agente no recibe acciones ni prompt de agenda,
+  y no se solicita ninguna variable ni credencial suya. La migración se aplica
+  SIEMPRE (estructura idéntica en todas las instancias; apagada es inerte).
+- **FR-002**: Encender la bandera NO DEBE exigir credenciales de terceros: el
+  conector por defecto es `enlace-fijo` (cero dependencias externas). Los
+  conectores externos son opt-in por configuración y credenciales del propio
+  negocio.
+
+**El motor (heredado del 004, innegociables intactos)**
+
+- **FR-003**: Todos los instantes se guardan en UTC; el horario semanal es hora
+  de pared en la zona del negocio; el DST se resuelve correctamente sin
+  dependencias nuevas de fechas.
+- **FR-004**: La disponibilidad DEBE calcularse como: horario semanal − citas
+  activas − bloqueos manuales, en huecos de la duración configurada avanzando
+  duración + respiro, descartando lo anterior a "ahora + aviso mínimo" y lo
+  posterior a la ventana máxima. La disponibilidad NO lee calendarios externos
+  (limitación aceptada y documentada; los compromisos externos se reflejan con
+  bloqueos manuales).
+- **FR-005 (INNEGOCIABLE)**: Una reserva pedida por quien conduce la
+  conversación DEBE aceptarse solo si ese instante exacto figura entre los
+  ofrecidos a ESA conversación (comparación por epoch exacto). Un instante
+  libre pero no ofrecido se rechaza con `slot_not_offered` + la lista de lo
+  ofrecido. Los ofrecidos se guardan en el core, por conversación, con
+  reemplazo completo por oferta nueva y limpieza al reservar.
+- **FR-006 (INNEGOCIABLE)**: Al confirmar, el sistema DEBE re-validar que el
+  hueco sigue libre y garantizar atomicidad en la base: ante confirmaciones
+  concurrentes solo una gana; la otra recibe `409 slot_taken` con alternativas
+  frescas ya registradas como nueva oferta, y ninguna cita se crea para ella.
+  Nunca se confirma una reserva que no se creó.
+- **FR-007**: La creación de cita DEBE responder **201 Created** (no 200), y
+  los códigos y la forma exacta del sobre de error (`{"error":{code,message}}`
+  anidado, con `slots` como hermano en los 409) son **contrato verificado por
+  el arnés E2E comparando códigos exactos** — en el fork, un cliente que solo
+  aceptaba 200 dejó a todos los leads sin agendar, y un mock con el sobre plano
+  ocultó el camino de re-oferta durante semanas.
+- **FR-008**: La oferta de horarios DEBE poder repartirse entre días
+  (`limit`/`perDay`/`days`) y toda etiqueta DEBE incluir el día en palabras
+  además de la hora.
+- **FR-009**: Una cita liga contacto (obligatorio en citas), y cuando existan,
+  conversación y lead; captura la duración vigente al crearse y su origen (IA o
+  manual). Estados: agendada → realizada / no_show / cancelada; cancelar es
+  idempotente; cancelar o reprogramar libera el hueco; una cancelada no se
+  reprograma. Los bloqueos manuales ocupan agenda sin contacto.
+- **FR-010**: Quien conduce la conversación DEBE poder reprogramar la próxima
+  cita activa de la conversación por la superficie de servicio (200, no 201),
+  bajo las mismas garantías de oferta; mover una cita no exige traspaso a
+  humano. Cancelar por esa superficie queda FUERA de v1 (esa la decide el
+  dueño: handoff).
+- **FR-011**: Al crear una cita para un contacto con lead, el lead avanza de
+  etapa solo hacia adelante, por la puerta única de historial de etapas
+  existente; un fallo del avance no impide la cita.
+- **FR-012**: El agente de IA incluido DEBE ofrecer y reservar con acciones
+  propias (`offer_slots`, `book_slot`) bajo las mismas reglas del motor,
+  registradas SOLO con la bandera encendida; el modelo no redacta horarios: el
+  motor adjunta las etiquetas reales. Un fallo del motor degrada el turno sin
+  tumbarlo.
+
+**Los conectores (lo nuevo)**
+
+- **FR-013**: DEBE existir un contrato público de conector con exactamente las
+  operaciones que el uso real exige: crear reunión, actualizar reunión, borrar
+  reunión y probar conexión — más una declaración de capacidades. Leer
+  disponibilidad ajena (free/busy) NO es parte del contrato v1. El contrato y
+  la guía "escribe tu conector" se publican en `docs/` como parte del alcance.
+- **FR-014**: Todos los efectos hacia el proveedor son **best-effort y
+  posteriores a la verdad del CRM**: la cita se crea/mueve/cancela en el CRM
+  aunque el proveedor falle. Un fallo al crear deja la cita con link pendiente,
+  visible en "Citas" y reintentable manualmente contra el conector de origen.
+- **FR-015**: Cada cita registra el conector con el que nació y su referencia
+  externa; reprogramar y cancelar usan ese conector aunque el negocio haya
+  cambiado el activo.
+- **FR-016**: Las credenciales de conector viven cifradas en reposo (mismo
+  mecanismo AES-256-GCM del repo, tabla explícita por proveedor — no un jsonb
+  genérico), se validan contra el proveedor ANTES de persistirse, nunca viajan
+  al cliente (solo últimos 4 + estado), y un error de autenticación detectado
+  en un efecto DEBE escribir el estado de error y mostrarse en Ajustes como
+  tarjeta de reconexión.
+- **FR-017**: Las citas de conversaciones `is_test` (Laboratorio) JAMÁS llaman
+  al proveedor real — la aserción va ANTES de la bifurcación por conector y
+  aplica simétricamente a crear, reprogramar y cancelar (en el fork la
+  protección es asimétrica y accidental).
+- **FR-018**: Cada conector externo DEBE tener su mock bajo el gate de
+  desarrollo existente (404 incondicional en producción), con estado
+  inspeccionable y camino infeliz simulable, para que el arnés E2E ejercite
+  éxito, carrera y fallo sin tocar proveedores reales.
+
+**Transversales**
+
+- **FR-019**: Toda la superficie respeta el aislamiento por organización
+  (tablas con `organization_id` NOT NULL org-first, acceso por la capa
+  `scoped()`), y la superficie `/api/bot/*` exige la llave de API existente.
+- **FR-020**: La feature NO introduce dependencias npm nuevas: los conectores
+  hablan HTTP directo con adaptadores propios (mismo patrón que el cliente de
+  Graph API), y las fechas usan `Intl` de la plataforma.
+- **FR-021**: La CI DEBE correr los gates en al menos dos configuraciones:
+  todo apagado (default) y todo encendido (`AGENDA=on` + canales) — la matriz
+  que ADR-001 prometió y nunca se implementó se paga aquí.
+- **FR-022**: El README DEBE actualizarse: la sección "Fuera de alcance a
+  propósito" se reescribe explicando qué cambió (esta sección del spec), y se
+  agregan la conexión de conectores y la bandera. La decisión de conectores
+  queda registrada como ADR-002.
+
+### Key Entities
+
+- **Configuración de agenda**: una por negocio. Horario semanal (hora de
+  pared), duración, respiro, aviso mínimo, ventana, zona horaria, conector
+  activo y link fijo (para `enlace-fijo`).
+- **Cita (booking)**: instante UTC, duración capturada, tipo (cita/bloqueo),
+  estado, origen, contacto/conversación/lead, marca de prueba, notas, y la
+  entrega: conector de origen, referencia externa, link y si está pendiente.
+- **Horario ofrecido (offered_slot)**: instante ofrecido a una conversación,
+  con su etiqueta y cuándo — la memoria que hace verificable FR-005.
+- **Credencial de conector**: por proveedor y organización, forma fija
+  conocida (tabla explícita), secretos cifrados, estado conectado/error.
+- **Conector**: contrato de 4 operaciones + capacidades declaradas; catálogo
+  en el código, extensible por fork.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Una instancia default (sin bandera) no expone NINGUNA superficie
+  de agenda: 0 rutas que respondan distinto de 404, 0 elementos de UI, 0 tokens
+  de prompt del agente dedicados a agendar.
+- **SC-002**: Con la bandera encendida y sin credenciales de terceros, un
+  negocio pasa de "sin agenda" a "primer hueco ofrecible" configurando una sola
+  pantalla, sin tocar base de datos ni variables adicionales.
+- **SC-003**: Cero doble-agendamiento: ninguna secuencia de reservas
+  concurrentes sobre el mismo hueco produce dos citas activas reales en el
+  mismo instante — verificado con la carrera real contra la app viva, no solo
+  con mocks unitarios.
+- **SC-004**: Cero reservas fantasma y cero conversiones perdidas por
+  terceros: no existe éxito sin cita, ni cita sin que el hueco desaparezca, y
+  con el proveedor caído el 100% de las reservas válidas se crean (con link
+  pendiente y reintento disponible).
+- **SC-005**: El caso "se ocupó a media conversación" termina siempre con el
+  cliente recibiendo alternativas concretas (verificado E2E con códigos y sobre
+  exactos: 201, `409 slot_taken` anidado + `slots`).
+- **SC-006**: Los tres conectores v1 pasan el mismo juego de pruebas de
+  contrato (crear/actualizar/borrar/probar + fallo) contra sus mocks; agregar
+  un conector nuevo toca únicamente los archivos listados en la guía (catálogo,
+  adaptador, credenciales, mock, doc) y cero archivos del motor.
+- **SC-007**: Gate técnico verde en las dos configuraciones de la matriz de CI,
+  y el arnés `pnpm test:e2e` cubre bandera, garantías, carrera, link pendiente
+  y sandbox, saliendo distinto de cero si algo falla.
+
+## Assumptions
+
+- **Un negocio = una agenda**: configuración por organización, no por usuario;
+  múltiples calendarios por agente quedan fuera de v1.
+- **Un conector activo a la vez**: la composición (Zoom + evento en Google a la
+  vez) queda fuera; quien quiera ver sus reuniones de Zoom en su calendario usa
+  la sincronización propia de Zoom, como hace hoy el dueño del fork.
+- **Sin lectura de calendario externo (free/busy) en v1**: consecuencia
+  aceptada de mantener las garantías locales y rápidas; los compromisos
+  externos se reflejan con bloqueos manuales. El contrato v1 ni siquiera
+  declara la operación — un fork puede extenderlo.
+- **Sin recordatorios automáticos en v1**: el core no tiene infraestructura de
+  cron; el fork los resuelve con una tarea programada externa y ese patrón
+  queda documentado como candidato post-v1.
+- **Google por refresh token de app propia** (pegado una vez), no flujo OAuth
+  con redirect en el producto ni service accounts (crear Meet con service
+  account exige delegación de dominio de Workspace — mataría el caso Gmail).
+  La guía exige app en estado "En producción" (en "Testing" los refresh tokens
+  caducan a los 7 días).
+- **Los horarios ofrecidos no caducan por reloj**: la frescura la garantiza la
+  re-validación al confirmar (FR-006).
+- **La rama `004-motor-agenda` no se rebasea**: nació de un main 76 commits
+  atrás y su migración colisiona de número — exactamente el costo que ADR-001
+  predijo para las ramas. Se usa como cantera de código y de evidencia; la
+  feature nace de main.
+- **La enmienda constitucional (1.4.0) se ratifica antes de implementar**; sin
+  ratificación, el alcance se recorta a bandera + motor + `enlace-fijo` (que no
+  violan nada).

--- a/specs/015-motor-agenda-universal/spec.md
+++ b/specs/015-motor-agenda-universal/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-08-26
 
-**Status**: Draft — pendiente de ratificar la [enmienda constitucional](./enmienda-constitucional.md) antes de implementar
+**Status**: Draft — enmienda constitucional [ratificada y aplicada](./enmienda-constitucional.md) (constitución 1.4.0, 2026-08-26); lista para `/speckit-tasks`
 
 **Input**: Decisión del dueño 2026-08-26: "agregar a Vocero raíz el motor de
 agendamiento con slots así como lo tengo en mi CRM, pero en modo bandera, tal
@@ -81,12 +81,14 @@ Quien use otra tecnología (Teams, Outlook, CalDAV, Cal.com…) implementa el
 contrato en su fork siguiendo la guía publicada — esa extensibilidad es parte
 del producto, no un accidente.
 
-**Puerta constitucional**: `zoom` y `google` violan la lista cerrada del
-Principio II vigente (que además prohíbe Google explícitamente). Esta feature
-NO se implementa sin ratificar antes la
-[enmienda propuesta](./enmienda-constitucional.md) (1.3.0 → 1.4.0): conectores
-opcionales tras bandera, apagados por defecto, aislados tras adaptador, con
-degradación definida y credenciales cifradas del propio negocio.
+**Puerta constitucional**: `zoom` y `google` violaban la lista cerrada del
+Principio II de la constitución 1.3.0 (que además prohibía Google
+nominalmente). La [enmienda](./enmienda-constitucional.md) (1.3.0 → 1.4.0) fue
+**ratificada por el responsable y aplicada el 2026-08-26**: los conectores
+opcionales son admisibles bajo cinco condiciones —apagados por defecto tras
+bandera, aislados tras adaptador, instancia completa sin ellos con degradación
+definida, credenciales cifradas del propio negocio, verificables en CI en ambas
+configuraciones— y este diseño cumple las cinco.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -553,6 +555,6 @@ reconexión.
   atrás y su migración colisiona de número — exactamente el costo que ADR-001
   predijo para las ramas. Se usa como cantera de código y de evidencia; la
   feature nace de main.
-- **La enmienda constitucional (1.4.0) se ratifica antes de implementar**; sin
-  ratificación, el alcance se recorta a bandera + motor + `enlace-fijo` (que no
-  violan nada).
+- **La enmienda constitucional (1.4.0) fue ratificada y aplicada el
+  2026-08-26**; el plan B de recorte (bandera + motor + `enlace-fijo`) quedó
+  sin efecto.

--- a/specs/015-motor-agenda-universal/tasks.md
+++ b/specs/015-motor-agenda-universal/tasks.md
@@ -1,0 +1,441 @@
+# Tasks: Motor de agendamiento universal (bandera + conectores)
+
+**Input**: Design documents from `/specs/015-motor-agenda-universal/`
+
+**Prerequisites**: plan.md, spec.md, research.md (D1..D10), data-model.md,
+contracts/agenda.md, contracts/conector.md, quickstart.md. Constitución
+**1.4.0** (enmienda de conectores ratificada 2026-08-26 — sin ella, US5/US6 no
+existirían).
+
+**Tests**: SÍ se incluyen — no son opcionales en este repo: la Constitución V
+exige verificación y la IX el self-test de comportamiento contra la app viva;
+SC-006/SC-007 los piden por nombre. La rama `004-motor-agenda` es **cantera**:
+varios módulos y tests se portan de ahí adaptados (research D10) — portar ≠
+copiar: cada task lo dice cuando aplica.
+
+**Organization**: por historia de usuario (US1..US6 del spec), cada fase es un
+incremento independiente verificable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: paralelizable (archivos distintos, sin dependencia pendiente)
+- **[Story]**: historia a la que pertenece (US1..US6)
+- Rutas exactas en cada descripción (proyecto único: `src/`, `tests/`, raíz)
+
+---
+
+## Phase 1: Setup (infraestructura compartida)
+
+**Purpose**: esquema, migración y variables — la estructura idéntica en todas
+las instancias (ADR-001).
+
+- [ ] T001 Agregar las cinco tablas de data-model.md (`calendar_settings`,
+      `booking`, `offered_slot`, `zoom_credentials`, `google_credentials`) a
+      `src/lib/db/schema.ts`, con columnas, FKs, índices y comentarios de
+      intención (por qué `meeting_link`/`connector` se copian en la cita)
+- [ ] T002 [P] Registrar los prefijos de id `cal_`, `bk_`, `ofs_`, `zcred_`,
+      `gcred_` en `src/lib/db/ids.ts`
+- [ ] T003 [P] Declarar `AGENDA`, `ZOOM_BASE_URL`, `ZOOM_OAUTH_BASE_URL`,
+      `GOOGLE_CAL_BASE_URL`, `GOOGLE_OAUTH_BASE_URL` en el esquema zod de
+      `src/lib/env.ts` (opcionales, defaults reales; NO `process.env` directo —
+      no repetir la inconsistencia de `IG_GRAPH_BASE_URL`) y documentarlas en
+      `.env.example` con guía inline (`AGENDA` apagada por defecto)
+- [ ] T004 Generar `drizzle/0009_motor_agenda.sql` con `pnpm db:generate` y
+      editarla a mano para que sea re-ejecutable (`IF NOT EXISTS`, FKs en
+      DO-blocks) e incluya el índice **UNIQUE parcial**
+      `booking_org_active_slot_uq (organization_id, scheduled_at) WHERE status
+      IN ('agendada','realizada') AND is_test = false` (drizzle-kit no emite el
+      predicado — copiar el patrón del 0002 de la cantera); verificar doble
+      aplicación idempotente con `pnpm db:migrate`
+
+---
+
+## Phase 2: Foundational (bloqueante para TODAS las historias)
+
+**Purpose**: los módulos puros que cada historia consume.
+
+**⚠️ CRITICAL**: ninguna historia arranca sin esta fase completa.
+
+- [ ] T005 [P] Portar de la cantera los helpers puros de tiempo a
+      `src/lib/time/slots.ts` (`Intl`, sin dependencias: expandir horario de
+      pared a UTC, día de semana en zona, etiquetas es-MX con día en palabras,
+      `overlaps` fin-exclusivo) — research D1
+- [ ] T006 [P] Portar `tests/unit/slots.test.ts` (DST Nueva York/Madrid/México,
+      hora inexistente y ambigua, franjas partidas)
+- [ ] T007 Crear `src/server/agenda/settings.ts`: tipos + defaults (L-V
+      09:00-18:00, 30 min, aviso 2 h, ventana 7 días, `enlace-fijo`) +
+      get/upsert con clamps, validación de timezone contra el runtime (422) y
+      de `connector` contra el catálogo
+- [ ] T008 Crear `src/server/agenda/availability.ts`:
+      `computeAvailability` (horario − citas activas − bloqueos, aviso mínimo,
+      ventana) y `findSlot` (re-validación acotada ±1 día, coincidencia por
+      epoch exacto, `excludeBookingId` para reprogramar) — portado de la
+      cantera; ocupan agenda solo `agendada`/`realizada` reales
+- [ ] T009 Crear `src/server/agenda/spread.ts`: reparto de huecos por día
+      (`perDay`/`days`) con `dayIso`/`dayLabel`/`time` — patrón del fork,
+      incidente 2026-08-07 (el catálogo es más ancho que el menú)
+- [ ] T010 [P] Crear `tests/unit/availability.test.ts` (franja partida, aviso
+      mínimo, respiro, ventana, bloqueo oculta, cancelada libera, reparto por
+      día)
+- [ ] T011 [P] Crear `src/server/agenda/connectors/types.ts` con el contrato
+      exacto de contracts/conector.md (4 operaciones + `ConnectorCapabilities`)
+- [ ] T012 Crear `src/server/agenda/connectors/enlace-fijo.ts` (createMeeting →
+      link de settings o null; update/delete no-op; test siempre ok) y el
+      catálogo `src/server/agenda/connectors/index.ts` (registro por id, el
+      motor pregunta capacidades — molde de `src/server/channels/capabilities.ts`)
+
+**Checkpoint**: motor puro calculable y testeable sin app viva.
+
+---
+
+## Phase 3: User Story 1 — La instancia decide si la agenda existe (P1) 🎯
+
+**Goal**: la bandera `AGENDA` y su plomería, con CI probando ambas
+configuraciones (FR-001, FR-021).
+
+**Independent Test**: unit de parseo en verde; con bandera ausente la app se ve
+y se comporta EXACTAMENTE como hoy; matriz de CI verde en las dos
+configuraciones.
+
+- [ ] T013 [US1] Crear `src/server/agenda/flag.ts`: `agendaEnabled()` (acepta
+      `on`/`1`/`true`, tolerante a mayúsculas/espacios; cualquier otra cosa =
+      apagada) y `agendaDisabledResponse()` → 404 con el razonamiento de
+      ADR-001 ("el endpoint no existe en esta instancia") — molde de
+      `src/server/channels/enabled.ts`
+- [ ] T014 [P] [US1] Crear `tests/unit/agenda-flag.test.ts` (ausente, `on`,
+      valores raros, mayúsculas) — molde de `tests/unit/channels.test.ts`
+- [ ] T015 [US1] En `src/app/(app)/layout.tsx` calcular `agendaEnabled()` en el
+      servidor y pasarlo por prop a través de `AppShell` hasta `AppNav`
+      (patrón server-calcula→prop de `inbox/page.tsx`; los navs NO leen env)
+- [ ] T016 [US1] En `src/components/app-nav.tsx` y
+      `src/components/settings/settings-nav.tsx` aceptar la prop de bandera
+      (default apagada) SIN agregar entradas aún: con la prop ausente el render
+      actual queda byte a byte idéntico
+- [ ] T017 [US1] En `src/app/(app)/settings/layout.tsx` (server component)
+      calcular la bandera y pasarla a `SettingsNav`
+- [ ] T018 [US1] En `.github/workflows/ci.yml` agregar la matriz de dos
+      configuraciones al job `gates`: `default` (sin `CHANNELS` ni `AGENDA`) y
+      `completo` (`CHANNELS=whatsapp,instagram`, `AGENDA=on`) — paga la deuda
+      que ADR-001 prometió y nunca implementó
+
+**Checkpoint**: bandera operativa y verificada; nada visible cambió para una
+instancia default.
+
+---
+
+## Phase 4: User Story 2 — El negocio define cuándo atiende y cómo se entrega la reunión (P1)
+
+**Goal**: Ajustes → Agenda completo con el conector `enlace-fijo` (FR-002,
+FR-003, FR-004).
+
+**Independent Test**: escenarios 1-3 y 6 de US2 del spec: defaults con 200,
+huecos correctos con etiqueta con día, DST correcto, enlace fijo opcional.
+
+- [ ] T019 [US2] Crear `src/app/api/calendar/settings/route.ts` GET/PUT según
+      contracts/agenda.md (primera línea: `agendaDisabledResponse()` si la
+      bandera está apagada; zod; clamps; 422 por timezone/connector inválidos;
+      jamás credenciales en la respuesta)
+- [ ] T020 [US2] Crear `src/app/api/calendar/availability/route.ts` GET
+      (`from`/`to`, vista del operador, NO registra oferta, `{"slots":[]}` con
+      200 cuando no hay)
+- [ ] T021 [US2] Crear `src/app/(app)/settings/calendar/page.tsx` +
+      `src/components/settings/agenda-client.tsx`: editor de horario semanal,
+      duración/respiro/aviso/ventana, zona horaria, selector de conector desde
+      el catálogo (con sus capacidades como descripción), campo de enlace fijo,
+      y aviso visible si se elige un conector externo sin credenciales
+      configuradas
+- [ ] T022 [US2] Agregar la pestaña "Agenda" (`/settings/calendar`) a `TABS` en
+      `src/components/settings/settings-nav.tsx`, renderizada solo con la prop
+      de bandera encendida (T016)
+- [ ] T023 [US2] Crear el guion `tests/e2e/us-agenda.md` (historias US1+US2) y
+      la sección "agenda: bandera y ajustes" en `scripts/e2e-selftest.mjs`:
+      settings/availability → 404 con bandera apagada; defaults 200; guardar
+      horario; huecos dentro de franja con etiqueta con día; enlace fijo vacío
+      se acepta
+
+**Checkpoint**: un negocio configura su agenda de punta a punta sin terceros
+(SC-002).
+
+---
+
+## Phase 5: User Story 3 — Quien conduce la conversación ofrece y reserva (P1)
+
+**Goal**: el corazón — las dos garantías innegociables + superficie de bot +
+acciones del agente (FR-005..FR-012).
+
+**Independent Test**: escenarios 1-8 de US3: 201 exacto, `slot_not_offered`,
+carrera → `slot_taken` con alternativas frescas, reprogramación por bot,
+sandbox, agente incluido.
+
+- [ ] T024 [US3] Crear `src/server/agenda/offers.ts`: reemplazo completo
+      transaccional de `offered_slot` por conversación, lectura y limpieza
+      (portado de la cantera)
+- [ ] T025 [P] [US3] Crear `tests/unit/offers.test.ts` (reemplazo, limpieza al
+      reservar, cascade con la conversación)
+- [ ] T026 [US3] Crear `src/server/agenda/service.ts` —
+      `createSessionBooking`: exige instante ofrecido a ESA conversación (epoch
+      exacto → `slot_not_offered` + lo ofrecido); re-valida con `findSlot` →
+      `slot_taken` + alternativas frescas re-registradas como nueva oferta;
+      INSERT capturando `23505` → `slot_taken` (research D7); copia
+      `connector`/`meeting_link` vigentes; efecto `createMeeting` best-effort
+      DESPUÉS de escribir (fallo ⇒ `link_pending=true`; error de auth ⇒ marcar
+      credencial en error); **aserción `is_test` ANTES de la bifurcación por
+      conector**; avance del lead solo-adelante por la puerta única
+      `src/server/leads/stage-history.ts` en try/catch (un fallo no impide la
+      cita); etiqueta con día en palabras
+- [ ] T027 [US3] Completar `src/server/agenda/service.ts` — reprogramar
+      (excluye la propia cita; `updateMeeting` sobre el MISMO `external_ref`,
+      conserva link; `reminder` no aplica: fuera de v1), cancelar (idempotente;
+      `deleteMeeting` con 404=éxito; cancelada no se reprograma → 422), marcar
+      realizada/no_show, y crear bloqueos — el guard de `is_test` simétrico en
+      las TRES mutaciones (FR-017)
+- [ ] T028 [P] [US3] Crear `tests/unit/booking-race.test.ts`: dos confirmaciones
+      del mismo instante — una gana, la otra recibe `slot_taken` mapeado del
+      unique-violation; jamás dos citas activas reales en el mismo epoch
+- [ ] T029 [US3] Crear `src/app/api/bot/availability/route.ts`: bandera→404,
+      `requireBotKey`, registra la oferta (T024), clamps `limit` 1-48 default
+      12 / `perDay` 1-8 / `days` 1-14, respuesta con `diasConAgenda`
+      (contracts/agenda.md); `export const dynamic = "force-dynamic"`
+- [ ] T030 [US3] Crear `src/app/api/bot/bookings/route.ts`: POST → **201**
+      `{bookingId, meetingLink, linkPending, label}` / 409 con sobre ANIDADO +
+      `slots` hermano / 404 / 422; PATCH → **200** reprograma la próxima cita
+      activa de la conversación bajo las mismas reglas de oferta (sin cancel:
+      esa la decide el dueño — handoff)
+- [ ] T031 [US3] Extender `tests/unit/bot-gateway.test.ts`: 404 con bandera
+      apagada, 401 sin llave, y la FORMA exacta de 201/409 (los mocks del fork
+      divergieron del contrato real y costó un outage — research D9)
+- [ ] T032 [US3] Agregar `offer_slots {reply?}` y `book_slot {startUtc, reply?}`
+      a la unión de `src/server/ai/actions.ts` SOLO con bandera encendida, la
+      sección condicional del prompt en `src/server/ai/prompts.ts` (apagada = 0
+      tokens) y la ejecución en `src/server/ai/pipeline.ts` con degradación (el
+      motor adjunta las etiquetas reales; `startUtc` no ofrecido se rechaza y
+      re-ofrece; fallo del motor → responde sin agendar, jamás tumba el turno)
+- [ ] T033 [US3] Sección "agenda: garantías" en `scripts/e2e-selftest.mjs` +
+      extender `tests/e2e/us-agenda.md`: feliz con enlace-fijo (201 exacto),
+      `slot_not_offered`, carrera con `slot_taken` + reservar la alternativa de
+      inmediato, repetido → 409, lead avanza de etapa, Laboratorio agenda
+      `is_test` sin efectos externos
+
+**Checkpoint**: motor completo usable por bot externo y agente incluido —
+**este es el MVP funcional** (SC-003, SC-004, SC-005 parciales).
+
+---
+
+## Phase 6: User Story 4 — El operador ve y maneja sus citas (P2)
+
+**Goal**: la página "Citas" con ciclo de vida completo y reintento de enlace
+(FR-009, FR-014, FR-015).
+
+**Independent Test**: escenarios 1-5 de US4: listar, reprogramar libera hueco,
+cancelar idempotente, bloquear, reintentar enlace (el e2e del reintento se
+completa en US5, que introduce el primer conector que puede fallar).
+
+- [ ] T034 [US4] Crear `src/server/agenda/queries.ts`: listado con
+      fecha/hora/día en zona del negocio, contacto, origen, estado, `connector`,
+      `meetingLink`, `linkPending`, `isTest`
+- [ ] T035 [US4] Crear `src/app/api/bookings/route.ts` (GET; POST **201** con
+      unión discriminada `session|block`, 409/422) y
+      `src/app/api/bookings/[id]/route.ts` (PATCH
+      `reschedule`/`cancel`/`status`/`retry_link` según contracts/agenda.md)
+- [ ] T036 [US4] Implementar `retry_link` en `src/server/agenda/service.ts`:
+      re-invoca `createMeeting` contra el conector de ORIGEN de la cita
+      (`booking.connector`, no el activo); éxito escribe
+      `external_ref`/`meeting_link` y limpia `link_pending`; 422 si no había
+      pendiente
+- [ ] T037 [US4] Crear `src/app/(app)/bookings/page.tsx` +
+      `src/components/bookings/bookings-client.tsx`: lista, acciones
+      (reprogramar con huecos disponibles, cancelar, realizada/no_show), crear
+      bloqueo, distintivo de prueba, y botón "Reintentar enlace" cuando
+      `linkPending`
+- [ ] T038 [US4] Agregar la entrada "Citas" (`/bookings`, icono de calendario
+      de lucide-react) a `NAV` en `src/components/app-nav.tsx`, renderizada
+      solo con la prop de bandera (T016)
+- [ ] T039 [US4] Sección "agenda: operador" en `scripts/e2e-selftest.mjs` +
+      guion: listar tras agendar por bot, reprogramar libera el hueco anterior,
+      cancelar dos veces sin fallo, bloqueo oculta huecos, cita de prueba
+      marcada
+
+**Checkpoint**: el operador confía en el motor — pipeline de citas visible y
+manejable.
+
+---
+
+## Phase 7: User Story 5 — Conector Zoom (P2)
+
+**Goal**: el conector de referencia, portado del fork con sus lecciones
+(FR-013..FR-018, research D5).
+
+**Independent Test**: escenarios 1-5 de US5 contra el zoom-mock: crear/mover/
+borrar reunión, credencial inválida no persiste, 401 marca error visible,
+scopes completos documentados.
+
+- [ ] T040 [US5] Crear `src/server/agenda/connectors/zoom.ts`: token S2S
+      (`grant_type=account_credentials`, `Basic`), caché en memoria con
+      expiración anticipada 60 s e invalidación al cambiar credenciales;
+      `createMeeting` (`type:2`, start UTC sin milisegundos, settings
+      `join_before_host`/sin waiting room), `updateMeeting` (mismo id ⇒ mismo
+      link), `deleteMeeting` (404 tolerado), `testConnection` (`GET /users/me`);
+      error de auth tipado para que el motor marque la credencial
+- [ ] T041 [US5] Crear `src/server/agenda/connectors/zoom-credentials.ts`:
+      cifrado con `src/lib/crypto` (secret cipher/iv/tag), `last4`, upsert que
+      invalida la caché de token, `markError` — y el estado `error` SE ESCRIBE
+      (en el fork es un enum decorativo; research D5)
+- [ ] T042 [US5] Crear `src/app/api/settings/zoom/route.ts` (GET forma pública
+      con `secretLast4`+`status`; PUT valida contra el proveedor ANTES de
+      persistir → `422 zoom_invalid`; DELETE desconecta) y
+      `src/app/api/settings/zoom/test/route.ts` (probar sin guardar) — bandera
+      →404, molde de `/api/settings/whatsapp`
+- [ ] T043 [US5] Sección de credenciales Zoom en
+      `src/components/settings/agenda-client.tsx`: tres campos, botón Probar,
+      `…last4`, tarjeta roja de reconexión si `status="error"`, y la guía de
+      los CUATRO scopes granulares incluido `user:read:user` (la guía del fork
+      lo omite y la validación fallaría — research D5)
+- [ ] T044 [P] [US5] Crear el mock: `src/app/api/dev/zoom-mock/[...path]/route.ts`
+      + `src/server/dev/zoom-mock-state.ts` tras `mockGuard()` (404 en
+      producción): `oauth/token`, `users/me/meetings` CRUD, `users/me`,
+      `_state`/`_reset`, y camino infeliz determinista (client secret terminado
+      en `-invalid` → 400) — molde del zoom-mock del fork
+- [ ] T045 [US5] Crear `tests/unit/connectors.test.ts`: suite de contrato
+      COMPARTIDA parametrizada por conector (enlace-fijo + zoom): las 4
+      operaciones, 404-tolerancia del delete, y el mapeo fallo→`link_pending` /
+      auth→`status error` en el servicio
+- [ ] T046 [US5] Sección "agenda: zoom" en `scripts/e2e-selftest.mjs` + guion:
+      conectar (inválida → 422 sin persistir; válida → conectado), agendar crea
+      reunión visible en `_state`, reprogramar conserva link, cancelar borra,
+      **fallo al crear → 201 con `linkPending` → "Reintentar enlace" en la UI
+      lo repara**, y sandbox: `_state` vacío tras una corrida del Laboratorio
+
+**Checkpoint**: contrato de conectores validado con un proveedor real (SC-006
+parcial).
+
+---
+
+## Phase 8: User Story 6 — Conector Google Calendar + Meet (P3)
+
+**Goal**: evento en el calendario del dueño + link de Meet, sin SDK (research
+D6). Recortable sin romper la feature.
+
+**Independent Test**: escenarios 1-4 de US6 contra el google-mock; guía con la
+advertencia de "En producción".
+
+- [ ] T047 [US6] Resolver el NEEDS VERIFICATION de research D6: confirmar
+      (documentación oficial de Calendar API y, si hay credenciales de prueba,
+      llamada real) si `events.insert` con `conferenceDataVersion=1` devuelve
+      el link de Meet en la respuesta síncrona o exige releer el evento; fijar
+      el contrato del adaptador y el comportamiento del mock según lo
+      confirmado; registrar el hallazgo en
+      `specs/015-motor-agenda-universal/research.md`
+- [ ] T048 [US6] Crear `src/server/agenda/connectors/google.ts`: refresh→access
+      token (`oauth2.googleapis.com/token`) con caché; `createMeeting` (evento
+      + `conferenceData.createRequest`), `updateMeeting` (patch de fechas),
+      `deleteMeeting` (404 tolerado), `testConnection` (GET del calendario);
+      scope `…/auth/calendar.events`
+- [ ] T049 [US6] Crear `src/server/agenda/connectors/google-credentials.ts`:
+      DOS secretos cifrados (client secret + refresh token), `calendar_id`
+      default `primary`, `last4`, `markError`
+- [ ] T050 [US6] Crear `src/app/api/settings/google/route.ts` + `test/route.ts`
+      (mismo molde que Zoom; `422 google_invalid`)
+- [ ] T051 [US6] Sección de credenciales Google en
+      `src/components/settings/agenda-client.tsx` con la advertencia en
+      negritas: la app OAuth del negocio debe estar "En producción" — en
+      "Testing" Google revoca el refresh token a los 7 días y la integración
+      muere en silencio (research D6)
+- [ ] T052 [P] [US6] Crear el mock: `src/app/api/dev/google-mock/[...path]/route.ts`
+      + `src/server/dev/google-mock-state.ts` (`token`, events CRUD con link de
+      Meet según T047, `_state`/`_reset`, refresh token `-invalid` → 400
+      `invalid_grant`)
+- [ ] T053 [US6] Extender `tests/unit/connectors.test.ts` con google + sección
+      "agenda: google" en `scripts/e2e-selftest.mjs` + guion (conectar, evento
+      creado/movido/borrado, token revocado → cita con `linkPending` +
+      credencial en error visible)
+
+**Checkpoint**: los tres conectores pasan la misma suite de contrato (SC-006).
+
+---
+
+## Phase 9: Polish & Cross-Cutting
+
+**Purpose**: la documentación que es PARTE del alcance (FR-022) y la
+verificación final.
+
+- [ ] T054 [P] Crear `docs/agenda-conectores.md`: el contrato público, la guía
+      "escribe tu conector" (los 6 archivos exactos que toca un fork y las 5
+      condiciones constitucionales), scopes de Zoom y gotchas de Google —
+      contenido base en contracts/conector.md
+- [ ] T055 [P] Crear `docs/adr-002-conectores-de-agenda.md`: bandera `AGENDA`
+      hermana de `CHANNELS`, contrato de 4 operaciones, sin free-busy en v1, y
+      el criterio de revisión (a la tercera bandera, conversación sobre una
+      interfaz común — research D3)
+- [ ] T056 Reescribir en `README.md` la sección "Fuera de alcance a propósito"
+      (el motor ENTRA al core tras ADR-001 y la constitución 1.4.0, con la
+      respuesta a sus dos argumentos originales — sección "Qué cambió" del
+      spec) y agregar "Agenda y conectores": la bandera, la conexión de Zoom y
+      Google, y el enlace fijo
+- [ ] T057 [P] Actualizar `CLAUDE.md` (fila del mapa del código: agenda →
+      `src/server/agenda/` + conectores; nota de la bandera) y
+      `specs/README.md` (fila de `015` en la tabla de specs: ciclo completo)
+- [ ] T058 Corrida final: gate técnico (`pnpm typecheck && pnpm lint && pnpm
+      build && pnpm test`) + `pnpm test:e2e` completo en LAS DOS
+      configuraciones de la matriz + recorrido manual de
+      `specs/015-motor-agenda-universal/quickstart.md`; lo intrínsecamente no
+      automatizable (juicio visual de la UI) se marca pendiente de verificación
+      humana (Constitución V/IX)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (1)** → **Foundational (2)** → historias en orden de prioridad →
+  **Polish (9)**
+- **US1 (3)**: tras Foundational. Sin dependencias de otras historias.
+- **US2 (4)**: tras US1 (usa la plomería de props T015-T017) y Foundational
+  (T007-T012).
+- **US3 (5)**: tras Foundational + T013 (el guard de bandera de sus rutas) +
+  T007/T008/T012 (settings, disponibilidad, conector default). No depende de
+  US2 para funcionar (usa defaults), aunque US2 la vuelve configurable.
+- **US4 (6)**: tras US3 (consume `service.ts` y las citas creadas).
+- **US5 (7)**: tras US3 (los puntos de efecto en `service.ts`) y US2 (la
+  pantalla donde viven las credenciales).
+- **US6 (8)**: tras US5 (reusa molde de rutas/mock y la suite de contrato).
+  T047/T048/T052 pueden avanzar en paralelo con el cierre de US5 si hay manos.
+- **Polish (9)**: tras las historias que se decida entregar.
+
+### Parallel Opportunities
+
+- Setup: T002 ∥ T003 (T004 espera a T001+T002).
+- Foundational: (T005→T006) ∥ (T011→T012) ∥ T010; T007-T009 tras T005.
+- US1: T014 ∥ T015-T017; T018 en cualquier momento de la fase.
+- US3: T025 ∥ T028 ∥ el resto una vez existan sus módulos.
+- US5: T044 (mock) ∥ T040-T043 (adaptador/UI); ídem US6 con T052.
+- Polish: T054 ∥ T055 ∥ T057.
+
+---
+
+## Implementation Strategy
+
+**MVP = Fases 1-5** (Setup + Foundational + US1 + US2 + US3): agendamiento
+completo y garantizado con `enlace-fijo`, usable por el agente incluido y por
+cualquier cerebro externo. **Recomendación antes de llamarlo producción**:
+sumar US4 (sin la página "Citas" el operador no puede confiar en el motor —
+rationale de US4 en el spec).
+
+Entrega incremental: cada checkpoint es desplegable y se valida con su sección
+del arnés antes de avanzar. US6 (Google) es la única historia recortable sin
+tocar la promesa central; si se recorta, queda como primera aplicación de la
+guía de forks.
+
+**Regla transversal** (Constitución V/IX + CLAUDE.md): ninguna task se declara
+Hecha sin el gate técnico en verde, y ninguna historia sin su sección del
+self-test E2E corrida contra la app viva — camino feliz Y camino infeliz. Los
+códigos HTTP se comparan EXACTOS (201/200/404/409/422), nunca `res.ok`.
+
+## Notes
+
+- La cantera (`git show 004-motor-agenda:<ruta>`) acelera T005-T008, T012,
+  T024, T026-T028, T033 y el guion E2E — siempre adaptando a la capa de
+  conectores y al main actual (research D10).
+- Commit por task o grupo lógico, en la rama `015-motor-agenda-universal`.
+- Evitar: tasks vagas, dos tasks [P] sobre el mismo archivo, dependencias
+  cruzadas que rompan la independencia de las historias.

--- a/specs/015-motor-agenda-universal/tasks.md
+++ b/specs/015-motor-agenda-universal/tasks.md
@@ -29,18 +29,18 @@ incremento independiente verificable.
 **Purpose**: esquema, migración y variables — la estructura idéntica en todas
 las instancias (ADR-001).
 
-- [ ] T001 Agregar las cinco tablas de data-model.md (`calendar_settings`,
+- [X] T001 Agregar las cinco tablas de data-model.md (`calendar_settings`,
       `booking`, `offered_slot`, `zoom_credentials`, `google_credentials`) a
       `src/lib/db/schema.ts`, con columnas, FKs, índices y comentarios de
       intención (por qué `meeting_link`/`connector` se copian en la cita)
-- [ ] T002 [P] Registrar los prefijos de id `cal_`, `bk_`, `ofs_`, `zcred_`,
+- [X] T002 [P] Registrar los prefijos de id `cal_`, `bk_`, `ofs_`, `zcred_`,
       `gcred_` en `src/lib/db/ids.ts`
-- [ ] T003 [P] Declarar `AGENDA`, `ZOOM_BASE_URL`, `ZOOM_OAUTH_BASE_URL`,
+- [X] T003 [P] Declarar `AGENDA`, `ZOOM_BASE_URL`, `ZOOM_OAUTH_BASE_URL`,
       `GOOGLE_CAL_BASE_URL`, `GOOGLE_OAUTH_BASE_URL` en el esquema zod de
       `src/lib/env.ts` (opcionales, defaults reales; NO `process.env` directo —
       no repetir la inconsistencia de `IG_GRAPH_BASE_URL`) y documentarlas en
       `.env.example` con guía inline (`AGENDA` apagada por defecto)
-- [ ] T004 Generar `drizzle/0009_motor_agenda.sql` con `pnpm db:generate` y
+- [X] T004 Generar `drizzle/0009_motor_agenda.sql` con `pnpm db:generate` y
       editarla a mano para que sea re-ejecutable (`IF NOT EXISTS`, FKs en
       DO-blocks) e incluya el índice **UNIQUE parcial**
       `booking_org_active_slot_uq (organization_id, scheduled_at) WHERE status
@@ -56,30 +56,30 @@ las instancias (ADR-001).
 
 **⚠️ CRITICAL**: ninguna historia arranca sin esta fase completa.
 
-- [ ] T005 [P] Portar de la cantera los helpers puros de tiempo a
+- [X] T005 [P] Portar de la cantera los helpers puros de tiempo a
       `src/lib/time/slots.ts` (`Intl`, sin dependencias: expandir horario de
       pared a UTC, día de semana en zona, etiquetas es-MX con día en palabras,
       `overlaps` fin-exclusivo) — research D1
-- [ ] T006 [P] Portar `tests/unit/slots.test.ts` (DST Nueva York/Madrid/México,
+- [X] T006 [P] Portar `tests/unit/slots.test.ts` (DST Nueva York/Madrid/México,
       hora inexistente y ambigua, franjas partidas)
-- [ ] T007 Crear `src/server/agenda/settings.ts`: tipos + defaults (L-V
+- [X] T007 Crear `src/server/agenda/settings.ts`: tipos + defaults (L-V
       09:00-18:00, 30 min, aviso 2 h, ventana 7 días, `enlace-fijo`) +
       get/upsert con clamps, validación de timezone contra el runtime (422) y
       de `connector` contra el catálogo
-- [ ] T008 Crear `src/server/agenda/availability.ts`:
+- [X] T008 Crear `src/server/agenda/availability.ts`:
       `computeAvailability` (horario − citas activas − bloqueos, aviso mínimo,
       ventana) y `findSlot` (re-validación acotada ±1 día, coincidencia por
       epoch exacto, `excludeBookingId` para reprogramar) — portado de la
       cantera; ocupan agenda solo `agendada`/`realizada` reales
-- [ ] T009 Crear `src/server/agenda/spread.ts`: reparto de huecos por día
+- [X] T009 Crear `src/server/agenda/spread.ts`: reparto de huecos por día
       (`perDay`/`days`) con `dayIso`/`dayLabel`/`time` — patrón del fork,
       incidente 2026-08-07 (el catálogo es más ancho que el menú)
-- [ ] T010 [P] Crear `tests/unit/availability.test.ts` (franja partida, aviso
+- [X] T010 [P] Crear `tests/unit/availability.test.ts` (franja partida, aviso
       mínimo, respiro, ventana, bloqueo oculta, cancelada libera, reparto por
       día)
-- [ ] T011 [P] Crear `src/server/agenda/connectors/types.ts` con el contrato
+- [X] T011 [P] Crear `src/server/agenda/connectors/types.ts` con el contrato
       exacto de contracts/conector.md (4 operaciones + `ConnectorCapabilities`)
-- [ ] T012 Crear `src/server/agenda/connectors/enlace-fijo.ts` (createMeeting →
+- [X] T012 Crear `src/server/agenda/connectors/enlace-fijo.ts` (createMeeting →
       link de settings o null; update/delete no-op; test siempre ok) y el
       catálogo `src/server/agenda/connectors/index.ts` (registro por id, el
       motor pregunta capacidades — molde de `src/server/channels/capabilities.ts`)
@@ -97,23 +97,23 @@ configuraciones (FR-001, FR-021).
 y se comporta EXACTAMENTE como hoy; matriz de CI verde en las dos
 configuraciones.
 
-- [ ] T013 [US1] Crear `src/server/agenda/flag.ts`: `agendaEnabled()` (acepta
+- [X] T013 [US1] Crear `src/server/agenda/flag.ts`: `agendaEnabled()` (acepta
       `on`/`1`/`true`, tolerante a mayúsculas/espacios; cualquier otra cosa =
       apagada) y `agendaDisabledResponse()` → 404 con el razonamiento de
       ADR-001 ("el endpoint no existe en esta instancia") — molde de
       `src/server/channels/enabled.ts`
-- [ ] T014 [P] [US1] Crear `tests/unit/agenda-flag.test.ts` (ausente, `on`,
+- [X] T014 [P] [US1] Crear `tests/unit/agenda-flag.test.ts` (ausente, `on`,
       valores raros, mayúsculas) — molde de `tests/unit/channels.test.ts`
-- [ ] T015 [US1] En `src/app/(app)/layout.tsx` calcular `agendaEnabled()` en el
+- [X] T015 [US1] En `src/app/(app)/layout.tsx` calcular `agendaEnabled()` en el
       servidor y pasarlo por prop a través de `AppShell` hasta `AppNav`
       (patrón server-calcula→prop de `inbox/page.tsx`; los navs NO leen env)
-- [ ] T016 [US1] En `src/components/app-nav.tsx` y
+- [X] T016 [US1] En `src/components/app-nav.tsx` y
       `src/components/settings/settings-nav.tsx` aceptar la prop de bandera
       (default apagada) SIN agregar entradas aún: con la prop ausente el render
       actual queda byte a byte idéntico
-- [ ] T017 [US1] En `src/app/(app)/settings/layout.tsx` (server component)
+- [X] T017 [US1] En `src/app/(app)/settings/layout.tsx` (server component)
       calcular la bandera y pasarla a `SettingsNav`
-- [ ] T018 [US1] En `.github/workflows/ci.yml` agregar la matriz de dos
+- [X] T018 [US1] En `.github/workflows/ci.yml` agregar la matriz de dos
       configuraciones al job `gates`: `default` (sin `CHANNELS` ni `AGENDA`) y
       `completo` (`CHANNELS=whatsapp,instagram`, `AGENDA=on`) — paga la deuda
       que ADR-001 prometió y nunca implementó

--- a/specs/015-motor-agenda-universal/tasks.md
+++ b/specs/015-motor-agenda-universal/tasks.md
@@ -131,20 +131,20 @@ FR-003, FR-004).
 **Independent Test**: escenarios 1-3 y 6 de US2 del spec: defaults con 200,
 huecos correctos con etiqueta con día, DST correcto, enlace fijo opcional.
 
-- [ ] T019 [US2] Crear `src/app/api/calendar/settings/route.ts` GET/PUT según
+- [X] T019 [US2] Crear `src/app/api/calendar/settings/route.ts` GET/PUT según
       contracts/agenda.md (primera línea: `agendaDisabledResponse()` si la
       bandera está apagada; zod; clamps; 422 por timezone/connector inválidos;
       jamás credenciales en la respuesta)
-- [ ] T020 [US2] Crear `src/app/api/calendar/availability/route.ts` GET
+- [X] T020 [US2] Crear `src/app/api/calendar/availability/route.ts` GET
       (`from`/`to`, vista del operador, NO registra oferta, `{"slots":[]}` con
       200 cuando no hay)
-- [ ] T021 [US2] Crear `src/app/(app)/settings/calendar/page.tsx` +
+- [X] T021 [US2] Crear `src/app/(app)/settings/calendar/page.tsx` +
       `src/components/settings/agenda-client.tsx`: editor de horario semanal,
       duración/respiro/aviso/ventana, zona horaria, selector de conector desde
       el catálogo (con sus capacidades como descripción), campo de enlace fijo,
       y aviso visible si se elige un conector externo sin credenciales
       configuradas
-- [ ] T022 [US2] Agregar la pestaña "Agenda" (`/settings/calendar`) a `TABS` en
+- [X] T022 [US2] Agregar la pestaña "Agenda" (`/settings/calendar`) a `TABS` en
       `src/components/settings/settings-nav.tsx`, renderizada solo con la prop
       de bandera encendida (T016)
 - [ ] T023 [US2] Crear el guion `tests/e2e/us-agenda.md` (historias US1+US2) y
@@ -167,12 +167,12 @@ acciones del agente (FR-005..FR-012).
 carrera → `slot_taken` con alternativas frescas, reprogramación por bot,
 sandbox, agente incluido.
 
-- [ ] T024 [US3] Crear `src/server/agenda/offers.ts`: reemplazo completo
+- [X] T024 [US3] Crear `src/server/agenda/offers.ts`: reemplazo completo
       transaccional de `offered_slot` por conversación, lectura y limpieza
       (portado de la cantera)
-- [ ] T025 [P] [US3] Crear `tests/unit/offers.test.ts` (reemplazo, limpieza al
+- [X] T025 [P] [US3] Crear `tests/unit/offers.test.ts` (reemplazo, limpieza al
       reservar, cascade con la conversación)
-- [ ] T026 [US3] Crear `src/server/agenda/service.ts` —
+- [X] T026 [US3] Crear `src/server/agenda/service.ts` —
       `createSessionBooking`: exige instante ofrecido a ESA conversación (epoch
       exacto → `slot_not_offered` + lo ofrecido); re-valida con `findSlot` →
       `slot_taken` + alternativas frescas re-registradas como nueva oferta;
@@ -183,28 +183,28 @@ sandbox, agente incluido.
       conector**; avance del lead solo-adelante por la puerta única
       `src/server/leads/stage-history.ts` en try/catch (un fallo no impide la
       cita); etiqueta con día en palabras
-- [ ] T027 [US3] Completar `src/server/agenda/service.ts` — reprogramar
+- [X] T027 [US3] Completar `src/server/agenda/service.ts` — reprogramar
       (excluye la propia cita; `updateMeeting` sobre el MISMO `external_ref`,
       conserva link; `reminder` no aplica: fuera de v1), cancelar (idempotente;
       `deleteMeeting` con 404=éxito; cancelada no se reprograma → 422), marcar
       realizada/no_show, y crear bloqueos — el guard de `is_test` simétrico en
       las TRES mutaciones (FR-017)
-- [ ] T028 [P] [US3] Crear `tests/unit/booking-race.test.ts`: dos confirmaciones
+- [X] T028 [P] [US3] Crear `tests/unit/booking-race.test.ts`: dos confirmaciones
       del mismo instante — una gana, la otra recibe `slot_taken` mapeado del
       unique-violation; jamás dos citas activas reales en el mismo epoch
-- [ ] T029 [US3] Crear `src/app/api/bot/availability/route.ts`: bandera→404,
+- [X] T029 [US3] Crear `src/app/api/bot/availability/route.ts`: bandera→404,
       `requireBotKey`, registra la oferta (T024), clamps `limit` 1-48 default
       12 / `perDay` 1-8 / `days` 1-14, respuesta con `diasConAgenda`
       (contracts/agenda.md); `export const dynamic = "force-dynamic"`
-- [ ] T030 [US3] Crear `src/app/api/bot/bookings/route.ts`: POST → **201**
+- [X] T030 [US3] Crear `src/app/api/bot/bookings/route.ts`: POST → **201**
       `{bookingId, meetingLink, linkPending, label}` / 409 con sobre ANIDADO +
       `slots` hermano / 404 / 422; PATCH → **200** reprograma la próxima cita
       activa de la conversación bajo las mismas reglas de oferta (sin cancel:
       esa la decide el dueño — handoff)
-- [ ] T031 [US3] Extender `tests/unit/bot-gateway.test.ts`: 404 con bandera
+- [X] T031 [US3] Extender `tests/unit/bot-gateway.test.ts`: 404 con bandera
       apagada, 401 sin llave, y la FORMA exacta de 201/409 (los mocks del fork
       divergieron del contrato real y costó un outage — research D9)
-- [ ] T032 [US3] Agregar `offer_slots {reply?}` y `book_slot {startUtc, reply?}`
+- [X] T032 [US3] Agregar `offer_slots {reply?}` y `book_slot {startUtc, reply?}`
       a la unión de `src/server/ai/actions.ts` SOLO con bandera encendida, la
       sección condicional del prompt en `src/server/ai/prompts.ts` (apagada = 0
       tokens) y la ejecución en `src/server/ai/pipeline.ts` con degradación (el
@@ -230,24 +230,24 @@ sandbox, agente incluido.
 cancelar idempotente, bloquear, reintentar enlace (el e2e del reintento se
 completa en US5, que introduce el primer conector que puede fallar).
 
-- [ ] T034 [US4] Crear `src/server/agenda/queries.ts`: listado con
+- [X] T034 [US4] Crear `src/server/agenda/queries.ts`: listado con
       fecha/hora/día en zona del negocio, contacto, origen, estado, `connector`,
       `meetingLink`, `linkPending`, `isTest`
-- [ ] T035 [US4] Crear `src/app/api/bookings/route.ts` (GET; POST **201** con
+- [X] T035 [US4] Crear `src/app/api/bookings/route.ts` (GET; POST **201** con
       unión discriminada `session|block`, 409/422) y
       `src/app/api/bookings/[id]/route.ts` (PATCH
       `reschedule`/`cancel`/`status`/`retry_link` según contracts/agenda.md)
-- [ ] T036 [US4] Implementar `retry_link` en `src/server/agenda/service.ts`:
+- [X] T036 [US4] Implementar `retry_link` en `src/server/agenda/service.ts`:
       re-invoca `createMeeting` contra el conector de ORIGEN de la cita
       (`booking.connector`, no el activo); éxito escribe
       `external_ref`/`meeting_link` y limpia `link_pending`; 422 si no había
       pendiente
-- [ ] T037 [US4] Crear `src/app/(app)/bookings/page.tsx` +
+- [X] T037 [US4] Crear `src/app/(app)/bookings/page.tsx` +
       `src/components/bookings/bookings-client.tsx`: lista, acciones
       (reprogramar con huecos disponibles, cancelar, realizada/no_show), crear
       bloqueo, distintivo de prueba, y botón "Reintentar enlace" cuando
       `linkPending`
-- [ ] T038 [US4] Agregar la entrada "Citas" (`/bookings`, icono de calendario
+- [X] T038 [US4] Agregar la entrada "Citas" (`/bookings`, icono de calendario
       de lucide-react) a `NAV` en `src/components/app-nav.tsx`, renderizada
       solo con la prop de bandera (T016)
 - [ ] T039 [US4] Sección "agenda: operador" en `scripts/e2e-selftest.mjs` +

--- a/specs/015-motor-agenda-universal/tasks.md
+++ b/specs/015-motor-agenda-universal/tasks.md
@@ -269,33 +269,33 @@ manejable.
 borrar reunión, credencial inválida no persiste, 401 marca error visible,
 scopes completos documentados.
 
-- [ ] T040 [US5] Crear `src/server/agenda/connectors/zoom.ts`: token S2S
+- [X] T040 [US5] Crear `src/server/agenda/connectors/zoom.ts`: token S2S
       (`grant_type=account_credentials`, `Basic`), caché en memoria con
       expiración anticipada 60 s e invalidación al cambiar credenciales;
       `createMeeting` (`type:2`, start UTC sin milisegundos, settings
       `join_before_host`/sin waiting room), `updateMeeting` (mismo id ⇒ mismo
       link), `deleteMeeting` (404 tolerado), `testConnection` (`GET /users/me`);
       error de auth tipado para que el motor marque la credencial
-- [ ] T041 [US5] Crear `src/server/agenda/connectors/zoom-credentials.ts`:
+- [X] T041 [US5] Crear `src/server/agenda/connectors/zoom-credentials.ts`:
       cifrado con `src/lib/crypto` (secret cipher/iv/tag), `last4`, upsert que
       invalida la caché de token, `markError` — y el estado `error` SE ESCRIBE
       (en el fork es un enum decorativo; research D5)
-- [ ] T042 [US5] Crear `src/app/api/settings/zoom/route.ts` (GET forma pública
+- [X] T042 [US5] Crear `src/app/api/settings/zoom/route.ts` (GET forma pública
       con `secretLast4`+`status`; PUT valida contra el proveedor ANTES de
       persistir → `422 zoom_invalid`; DELETE desconecta) y
       `src/app/api/settings/zoom/test/route.ts` (probar sin guardar) — bandera
       →404, molde de `/api/settings/whatsapp`
-- [ ] T043 [US5] Sección de credenciales Zoom en
+- [X] T043 [US5] Sección de credenciales Zoom en
       `src/components/settings/agenda-client.tsx`: tres campos, botón Probar,
       `…last4`, tarjeta roja de reconexión si `status="error"`, y la guía de
       los CUATRO scopes granulares incluido `user:read:user` (la guía del fork
       lo omite y la validación fallaría — research D5)
-- [ ] T044 [P] [US5] Crear el mock: `src/app/api/dev/zoom-mock/[...path]/route.ts`
+- [X] T044 [P] [US5] Crear el mock: `src/app/api/dev/zoom-mock/[...path]/route.ts`
       + `src/server/dev/zoom-mock-state.ts` tras `mockGuard()` (404 en
       producción): `oauth/token`, `users/me/meetings` CRUD, `users/me`,
       `_state`/`_reset`, y camino infeliz determinista (client secret terminado
       en `-invalid` → 400) — molde del zoom-mock del fork
-- [ ] T045 [US5] Crear `tests/unit/connectors.test.ts`: suite de contrato
+- [X] T045 [US5] Crear `tests/unit/connectors.test.ts`: suite de contrato
       COMPARTIDA parametrizada por conector (enlace-fijo + zoom): las 4
       operaciones, 404-tolerancia del delete, y el mapeo fallo→`link_pending` /
       auth→`status error` en el servicio
@@ -318,29 +318,29 @@ D6). Recortable sin romper la feature.
 **Independent Test**: escenarios 1-4 de US6 contra el google-mock; guía con la
 advertencia de "En producción".
 
-- [ ] T047 [US6] Resolver el NEEDS VERIFICATION de research D6: confirmar
+- [X] T047 [US6] Resolver el NEEDS VERIFICATION de research D6: confirmar
       (documentación oficial de Calendar API y, si hay credenciales de prueba,
       llamada real) si `events.insert` con `conferenceDataVersion=1` devuelve
       el link de Meet en la respuesta síncrona o exige releer el evento; fijar
       el contrato del adaptador y el comportamiento del mock según lo
       confirmado; registrar el hallazgo en
       `specs/015-motor-agenda-universal/research.md`
-- [ ] T048 [US6] Crear `src/server/agenda/connectors/google.ts`: refresh→access
+- [X] T048 [US6] Crear `src/server/agenda/connectors/google.ts`: refresh→access
       token (`oauth2.googleapis.com/token`) con caché; `createMeeting` (evento
       + `conferenceData.createRequest`), `updateMeeting` (patch de fechas),
       `deleteMeeting` (404 tolerado), `testConnection` (GET del calendario);
       scope `…/auth/calendar.events`
-- [ ] T049 [US6] Crear `src/server/agenda/connectors/google-credentials.ts`:
+- [X] T049 [US6] Crear `src/server/agenda/connectors/google-credentials.ts`:
       DOS secretos cifrados (client secret + refresh token), `calendar_id`
       default `primary`, `last4`, `markError`
-- [ ] T050 [US6] Crear `src/app/api/settings/google/route.ts` + `test/route.ts`
+- [X] T050 [US6] Crear `src/app/api/settings/google/route.ts` + `test/route.ts`
       (mismo molde que Zoom; `422 google_invalid`)
-- [ ] T051 [US6] Sección de credenciales Google en
+- [X] T051 [US6] Sección de credenciales Google en
       `src/components/settings/agenda-client.tsx` con la advertencia en
       negritas: la app OAuth del negocio debe estar "En producción" — en
       "Testing" Google revoca el refresh token a los 7 días y la integración
       muere en silencio (research D6)
-- [ ] T052 [P] [US6] Crear el mock: `src/app/api/dev/google-mock/[...path]/route.ts`
+- [X] T052 [P] [US6] Crear el mock: `src/app/api/dev/google-mock/[...path]/route.ts`
       + `src/server/dev/google-mock-state.ts` (`token`, events CRUD con link de
       Meet según T047, `_state`/`_reset`, refresh token `-invalid` → 400
       `invalid_grant`)

--- a/specs/015-motor-agenda-universal/tasks.md
+++ b/specs/015-motor-agenda-universal/tasks.md
@@ -147,7 +147,7 @@ huecos correctos con etiqueta con día, DST correcto, enlace fijo opcional.
 - [X] T022 [US2] Agregar la pestaña "Agenda" (`/settings/calendar`) a `TABS` en
       `src/components/settings/settings-nav.tsx`, renderizada solo con la prop
       de bandera encendida (T016)
-- [ ] T023 [US2] Crear el guion `tests/e2e/us-agenda.md` (historias US1+US2) y
+- [X] T023 [US2] Crear el guion `tests/e2e/us-agenda.md` (historias US1+US2) y
       la sección "agenda: bandera y ajustes" en `scripts/e2e-selftest.mjs`:
       settings/availability → 404 con bandera apagada; defaults 200; guardar
       horario; huecos dentro de franja con etiqueta con día; enlace fijo vacío
@@ -210,7 +210,7 @@ sandbox, agente incluido.
       tokens) y la ejecución en `src/server/ai/pipeline.ts` con degradación (el
       motor adjunta las etiquetas reales; `startUtc` no ofrecido se rechaza y
       re-ofrece; fallo del motor → responde sin agendar, jamás tumba el turno)
-- [ ] T033 [US3] Sección "agenda: garantías" en `scripts/e2e-selftest.mjs` +
+- [X] T033 [US3] Sección "agenda: garantías" en `scripts/e2e-selftest.mjs` +
       extender `tests/e2e/us-agenda.md`: feliz con enlace-fijo (201 exacto),
       `slot_not_offered`, carrera con `slot_taken` + reservar la alternativa de
       inmediato, repetido → 409, lead avanza de etapa, Laboratorio agenda
@@ -250,7 +250,7 @@ completa en US5, que introduce el primer conector que puede fallar).
 - [X] T038 [US4] Agregar la entrada "Citas" (`/bookings`, icono de calendario
       de lucide-react) a `NAV` en `src/components/app-nav.tsx`, renderizada
       solo con la prop de bandera (T016)
-- [ ] T039 [US4] Sección "agenda: operador" en `scripts/e2e-selftest.mjs` +
+- [X] T039 [US4] Sección "agenda: operador" en `scripts/e2e-selftest.mjs` +
       guion: listar tras agendar por bot, reprogramar libera el hueco anterior,
       cancelar dos veces sin fallo, bloqueo oculta huecos, cita de prueba
       marcada
@@ -299,7 +299,7 @@ scopes completos documentados.
       COMPARTIDA parametrizada por conector (enlace-fijo + zoom): las 4
       operaciones, 404-tolerancia del delete, y el mapeo fallo→`link_pending` /
       auth→`status error` en el servicio
-- [ ] T046 [US5] Sección "agenda: zoom" en `scripts/e2e-selftest.mjs` + guion:
+- [X] T046 [US5] Sección "agenda: zoom" en `scripts/e2e-selftest.mjs` + guion:
       conectar (inválida → 422 sin persistir; válida → conectado), agendar crea
       reunión visible en `_state`, reprogramar conserva link, cancelar borra,
       **fallo al crear → 201 con `linkPending` → "Reintentar enlace" en la UI
@@ -344,7 +344,7 @@ advertencia de "En producción".
       + `src/server/dev/google-mock-state.ts` (`token`, events CRUD con link de
       Meet según T047, `_state`/`_reset`, refresh token `-invalid` → 400
       `invalid_grant`)
-- [ ] T053 [US6] Extender `tests/unit/connectors.test.ts` con google + sección
+- [X] T053 [US6] Extender `tests/unit/connectors.test.ts` con google + sección
       "agenda: google" en `scripts/e2e-selftest.mjs` + guion (conectar, evento
       creado/movido/borrado, token revocado → cita con `linkPending` +
       credencial en error visible)
@@ -358,23 +358,23 @@ advertencia de "En producción".
 **Purpose**: la documentación que es PARTE del alcance (FR-022) y la
 verificación final.
 
-- [ ] T054 [P] Crear `docs/agenda-conectores.md`: el contrato público, la guía
+- [X] T054 [P] Crear `docs/agenda-conectores.md`: el contrato público, la guía
       "escribe tu conector" (los 6 archivos exactos que toca un fork y las 5
       condiciones constitucionales), scopes de Zoom y gotchas de Google —
       contenido base en contracts/conector.md
-- [ ] T055 [P] Crear `docs/adr-002-conectores-de-agenda.md`: bandera `AGENDA`
+- [X] T055 [P] Crear `docs/adr-002-conectores-de-agenda.md`: bandera `AGENDA`
       hermana de `CHANNELS`, contrato de 4 operaciones, sin free-busy en v1, y
       el criterio de revisión (a la tercera bandera, conversación sobre una
       interfaz común — research D3)
-- [ ] T056 Reescribir en `README.md` la sección "Fuera de alcance a propósito"
+- [X] T056 Reescribir en `README.md` la sección "Fuera de alcance a propósito"
       (el motor ENTRA al core tras ADR-001 y la constitución 1.4.0, con la
       respuesta a sus dos argumentos originales — sección "Qué cambió" del
       spec) y agregar "Agenda y conectores": la bandera, la conexión de Zoom y
       Google, y el enlace fijo
-- [ ] T057 [P] Actualizar `CLAUDE.md` (fila del mapa del código: agenda →
+- [X] T057 [P] Actualizar `CLAUDE.md` (fila del mapa del código: agenda →
       `src/server/agenda/` + conectores; nota de la bandera) y
       `specs/README.md` (fila de `015` en la tabla de specs: ciclo completo)
-- [ ] T058 Corrida final: gate técnico (`pnpm typecheck && pnpm lint && pnpm
+- [X] T058 Corrida final: gate técnico (`pnpm typecheck && pnpm lint && pnpm
       build && pnpm test`) + `pnpm test:e2e` completo en LAS DOS
       configuraciones de la matriz + recorrido manual de
       `specs/015-motor-agenda-universal/quickstart.md`; lo intrínsecamente no

--- a/specs/README.md
+++ b/specs/README.md
@@ -10,6 +10,8 @@ producto** — y saberlo antes de leerla ahorra una confusión.
 | `001-vocero-core` | Ciclo completo | spec, plan, research, data-model, 5 contratos, tasks, checklist |
 | `002-diseno-atlas-white-label` | — | spec + plan |
 | `003-paridad-inbox-whatsapp` | — | spec |
+| `014-canal-instagram` | Ciclo completo | spec |
+| `015-motor-agenda-universal` | Ciclo completo | spec, plan, research, data-model, 2 contratos, quickstart, checklist, tasks + la enmienda constitucional que habilitó los conectores |
 
 Los tres carriles —ciclo completo, ligero y exento— están definidos en el
 [Principio VI de la constitución](../.specify/memory/constitution.md). El

--- a/src/app/(app)/bookings/page.tsx
+++ b/src/app/(app)/bookings/page.tsx
@@ -1,0 +1,20 @@
+import { notFound } from "next/navigation";
+import { BookingsClient } from "@/components/bookings/bookings-client";
+import { agendaEnabled } from "@/server/agenda/flag";
+
+export const dynamic = "force-dynamic";
+
+export default function BookingsPage() {
+  // Sin la bandera esta pantalla no existe en esta instancia.
+  if (!agendaEnabled()) notFound();
+  return (
+    <div className="flex h-full flex-col">
+      <header className="border-b px-4 py-3 sm:px-6 sm:py-4">
+        <h2 className="font-semibold">Citas</h2>
+      </header>
+      <div className="min-h-0 flex-1 overflow-y-auto p-4 sm:p-6">
+        <BookingsClient />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -6,6 +6,7 @@ import { normalizeThemePreference, THEME_COOKIE } from "@/lib/theme";
 import { getBranding } from "@/server/branding";
 import { AppShell } from "@/components/app-shell";
 import { resolveBuildCommit } from "@/lib/version";
+import { agendaEnabled } from "@/server/agenda/flag";
 
 export default async function AppLayout({
   children,
@@ -28,6 +29,10 @@ export default async function AppLayout({
       theme={theme}
       // Se resuelve aquí, en el servidor: el cliente no ve `SOURCE_COMMIT`.
       commit={resolveBuildCommit()}
+      // Qué módulos opcionales existen se decide en el servidor y baja por
+      // prop, igual que los canales de la Bandeja. El nav es un componente de
+      // cliente: no puede —ni debe— leer variables de entorno.
+      agenda={agendaEnabled()}
     >
       {children}
     </AppShell>

--- a/src/app/(app)/settings/calendar/page.tsx
+++ b/src/app/(app)/settings/calendar/page.tsx
@@ -1,0 +1,11 @@
+import { notFound } from "next/navigation";
+import { AgendaClient } from "@/components/settings/agenda-client";
+import { agendaEnabled } from "@/server/agenda/flag";
+
+export const dynamic = "force-dynamic";
+
+export default function AgendaSettingsPage() {
+  // Sin la bandera esta pantalla no existe en esta instancia.
+  if (!agendaEnabled()) notFound();
+  return <AgendaClient />;
+}

--- a/src/app/(app)/settings/layout.tsx
+++ b/src/app/(app)/settings/layout.tsx
@@ -1,4 +1,10 @@
 import { SettingsNav } from "@/components/settings/settings-nav";
+import { agendaEnabled } from "@/server/agenda/flag";
+
+// La bandera se lee en cada petición: si esto se resolviera al construir, la
+// imagen quedaría con la agenda apagada para siempre y encenderla en la
+// plataforma no haría nada.
+export const dynamic = "force-dynamic";
 
 export default function SettingsLayout({
   children,
@@ -10,7 +16,7 @@ export default function SettingsLayout({
       </header>
       {/* En móvil las pestañas van arriba (en fila), no como columna lateral. */}
       <div className="flex min-h-0 flex-1 flex-col sm:flex-row">
-        <SettingsNav />
+        <SettingsNav agenda={agendaEnabled()} />
         <div className="min-w-0 flex-1 overflow-y-auto p-4 sm:p-6">{children}</div>
       </div>
     </div>

--- a/src/app/api/bookings/[id]/route.ts
+++ b/src/app/api/bookings/[id]/route.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+import { parseBody, withAuth } from "@/lib/api";
+import { agendaDisabledResponse, agendaEnabled } from "@/server/agenda/flag";
+import {
+  cancelBooking,
+  markBookingStatus,
+  rescheduleBooking,
+  retryMeetingLink,
+} from "@/server/agenda/service";
+import { bookingErrorResponse } from "@/server/agenda/http";
+
+export const dynamic = "force-dynamic";
+
+type Params = { params: Promise<{ id: string }> };
+
+const patchSchema = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("reschedule"), startUtc: z.string().min(1) }),
+  z.object({ action: z.literal("cancel") }),
+  z.object({
+    action: z.literal("status"),
+    status: z.enum(["realizada", "no_show"]),
+  }),
+  z.object({ action: z.literal("retry_link") }),
+]);
+
+/**
+ * 015 — Reprogramar, cancelar (idempotente), marcar el resultado o reintentar
+ * el enlace que el proveedor no entregó.
+ */
+export const PATCH = withAuth(async (session, req: Request, ctx: Params) => {
+  if (!agendaEnabled()) return agendaDisabledResponse();
+  const { id } = await ctx.params;
+  const body = await parseBody(req, patchSchema);
+  if (!body.ok) return body.response;
+
+  try {
+    switch (body.data.action) {
+      case "reschedule": {
+        const result = await rescheduleBooking({
+          organizationId: session.organizationId,
+          bookingId: id,
+          startUtc: body.data.startUtc,
+        });
+        return Response.json({ ok: true, label: result.label });
+      }
+      case "cancel": {
+        await cancelBooking({
+          organizationId: session.organizationId,
+          bookingId: id,
+        });
+        return Response.json({ ok: true });
+      }
+      case "status": {
+        await markBookingStatus({
+          organizationId: session.organizationId,
+          bookingId: id,
+          status: body.data.status,
+        });
+        return Response.json({ ok: true });
+      }
+      case "retry_link": {
+        const result = await retryMeetingLink({
+          organizationId: session.organizationId,
+          bookingId: id,
+        });
+        return Response.json({
+          ok: true,
+          meetingLink: result.meetingLink,
+          linkPending: result.linkPending,
+        });
+      }
+    }
+  } catch (err) {
+    return bookingErrorResponse(err);
+  }
+});

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+import { parseBody, withAuth } from "@/lib/api";
+import { agendaDisabledResponse, agendaEnabled } from "@/server/agenda/flag";
+import { listBookings } from "@/server/agenda/queries";
+import { createBlock, createSessionBooking } from "@/server/agenda/service";
+import { bookingErrorResponse, bookingPayload } from "@/server/agenda/http";
+
+export const dynamic = "force-dynamic";
+
+export const GET = withAuth(async (session) => {
+  if (!agendaEnabled()) return agendaDisabledResponse();
+  const bookings = await listBookings(session.organizationId);
+  return Response.json({ bookings });
+});
+
+const postSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("session"),
+    contactId: z.string().min(1),
+    conversationId: z.string().min(1).nullish(),
+    startUtc: z.string().min(1),
+    notes: z.string().nullish(),
+  }),
+  z.object({
+    kind: z.literal("block"),
+    startUtc: z.string().min(1),
+    durationMinutes: z.number().int().min(5).max(600),
+    notes: z.string().nullish(),
+  }),
+]);
+
+/**
+ * 015 — El operador agenda o bloquea.
+ *
+ * Responde **201**, igual que la superficie del bot: el código de creación es
+ * contrato, no un detalle.
+ *
+ * A diferencia del agente, el operador NO pasa por `offered_slot`: elige de la
+ * disponibilidad que está viendo en pantalla. La re-validación y el candado
+ * anti doble-booking sí aplican igual.
+ */
+export const POST = withAuth(async (session, req: Request) => {
+  if (!agendaEnabled()) return agendaDisabledResponse();
+  const body = await parseBody(req, postSchema);
+  if (!body.ok) return body.response;
+
+  try {
+    if (body.data.kind === "block") {
+      const block = await createBlock({
+        organizationId: session.organizationId,
+        startUtc: body.data.startUtc,
+        durationMinutes: body.data.durationMinutes,
+        notes: body.data.notes ?? null,
+      });
+      return Response.json({ booking: { id: block.id } }, { status: 201 });
+    }
+
+    const result = await createSessionBooking({
+      organizationId: session.organizationId,
+      contactId: body.data.contactId,
+      conversationId: body.data.conversationId ?? null,
+      startUtc: body.data.startUtc,
+      notes: body.data.notes ?? null,
+      source: "manual",
+      requireOffer: false,
+    });
+    return Response.json(
+      { booking: { id: result.booking.id }, ...bookingPayload(result) },
+      { status: 201 }
+    );
+  } catch (err) {
+    return bookingErrorResponse(err);
+  }
+});

--- a/src/app/api/bot/availability/route.ts
+++ b/src/app/api/bot/availability/route.ts
@@ -1,0 +1,124 @@
+import { eq } from "drizzle-orm";
+import { getDb, schema } from "@/lib/db";
+import { apiError } from "@/lib/api";
+import { scoped } from "@/lib/db/tenant";
+import { requireBotKey, resolveInstanceOrg } from "@/server/bot/auth";
+import { agendaDisabledResponse, agendaEnabled } from "@/server/agenda/flag";
+import { computeAvailability } from "@/server/agenda/availability";
+import { getSettings } from "@/server/agenda/settings";
+import { daysWithAgenda, spreadByDay } from "@/server/agenda/spread";
+import { replaceOffers } from "@/server/agenda/offers";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * 015 — Los horarios que se le van a ofrecer al cliente, para quien conduce la
+ * conversación.
+ *
+ * A diferencia de la vista del operador, esta REGISTRA la oferta: es ese
+ * registro lo que después habilita la reserva. Sin él, `POST /api/bot/bookings`
+ * rechaza cualquier instante.
+ *
+ * El catálogo reservable (`limit`) es más ancho que el menú que el agente
+ * enseña: guardar solo los tres que se muestran deja al agente sin nada
+ * legítimo que aceptar cuando el cliente pide otro día.
+ */
+
+const LIMITS = {
+  limit: { min: 1, max: 48, def: 12 },
+  perDay: { min: 1, max: 8, def: 3 },
+  days: { min: 1, max: 14, def: 5 },
+};
+
+function clamp(raw: string | null, l: { min: number; max: number; def: number }) {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return l.def;
+  return Math.max(l.min, Math.min(l.max, Math.round(n)));
+}
+
+export async function GET(req: Request) {
+  // La bandera se evalúa ANTES que la llave: si esta instancia no tiene
+  // agenda, el endpoint no existe — no hay nada que autenticar.
+  if (!agendaEnabled()) return agendaDisabledResponse();
+
+  const denied = requireBotKey(req);
+  if (denied) return denied;
+
+  const organizationId = await resolveInstanceOrg();
+  if (!organizationId) {
+    return apiError(409, "no_org", "La instancia aún no tiene organización");
+  }
+
+  const url = new URL(req.url);
+  const conversationId = url.searchParams.get("conversationId");
+  if (!conversationId) {
+    return apiError(422, "invalid_body", "Falta conversationId");
+  }
+
+  const db = getDb();
+  const rows = await db
+    .select({ id: schema.conversation.id })
+    .from(schema.conversation)
+    .where(
+      scoped(
+        schema.conversation.organizationId,
+        organizationId,
+        eq(schema.conversation.id, conversationId)
+      )
+    )
+    .limit(1);
+  if (!rows[0]) return apiError(404, "not_found", "Conversación no encontrada");
+
+  const limit = clamp(url.searchParams.get("limit"), LIMITS.limit);
+  const perDay = clamp(url.searchParams.get("perDay"), LIMITS.perDay);
+  const days = clamp(url.searchParams.get("days"), LIMITS.days);
+
+  const settings = await getSettings(organizationId);
+  const now = new Date();
+  const all = await computeAvailability(organizationId, { settings, now });
+  const slots = spreadByDay(all, {
+    timezone: settings.timezone,
+    limit,
+    perDay,
+    now,
+  }).filter((s) => withinDays(s.dayIso, days, settings.timezone, now));
+
+  // Reemplazo completo: la oferta vigente es siempre la última.
+  await replaceOffers(
+    organizationId,
+    conversationId,
+    slots.map((s) => ({ startUtc: s.startUtc, label: s.label }))
+  );
+
+  return Response.json({
+    slots: slots.map((s) => ({
+      startUtc: s.startUtc,
+      endUtc: s.endUtc,
+      label: s.label,
+      dayIso: s.dayIso,
+      dayLabel: s.dayLabel,
+      time: s.time,
+    })),
+    // Los días que NO están aquí no tienen agenda: es la lista que evita que
+    // el modelo invente un jueves que el negocio tiene cerrado.
+    diasConAgenda: daysWithAgenda(slots),
+  });
+}
+
+function withinDays(
+  dayIso: string,
+  days: number,
+  timezone: string,
+  now: Date
+): boolean {
+  const today = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+  const diff =
+    (Date.parse(`${dayIso}T00:00:00Z`) - Date.parse(`${today}T00:00:00Z`)) /
+    86_400_000;
+  return diff >= 0 && diff < days;
+}

--- a/src/app/api/bot/bookings/route.ts
+++ b/src/app/api/bot/bookings/route.ts
@@ -1,0 +1,97 @@
+import { z } from "zod";
+import { apiError, parseBody } from "@/lib/api";
+import { requireBotKey, resolveInstanceOrg } from "@/server/bot/auth";
+import { agendaDisabledResponse, agendaEnabled } from "@/server/agenda/flag";
+import {
+  createSessionBooking,
+  rescheduleForConversation,
+} from "@/server/agenda/service";
+import { bookingErrorResponse, bookingPayload } from "@/server/agenda/http";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * 015 — Reservar y mover citas, para quien conduce la conversación.
+ *
+ * CONTRATO: crear responde **201**, mover responde **200**. No es purismo: en
+ * un sistema real un cliente que validaba `status === 200` dejó a TODOS los
+ * leads sin poder agendar durante horas, y los mocks no lo detectaron porque
+ * respondían 200. Si escribes un cliente, acepta 2xx.
+ *
+ * Y el sobre del error va ANIDADO (`{"error":{"code":…}}`) con `slots` como
+ * hermano: un mock con la forma plana escondió el camino de re-oferta durante
+ * semanas en ese mismo sistema.
+ */
+
+const createSchema = z.object({
+  conversationId: z.string().min(1),
+  startUtc: z.string().min(1),
+  notes: z.string().nullish(),
+});
+
+const rescheduleSchema = z.object({
+  conversationId: z.string().min(1),
+  startUtc: z.string().min(1),
+});
+
+export async function POST(req: Request) {
+  const gate = await guard(req);
+  if ("response" in gate) return gate.response;
+
+  const body = await parseBody(req, createSchema);
+  if (!body.ok) return body.response;
+
+  try {
+    const result = await createSessionBooking({
+      organizationId: gate.organizationId,
+      conversationId: body.data.conversationId,
+      startUtc: body.data.startUtc,
+      notes: body.data.notes ?? null,
+      source: "ai",
+      // La regla innegociable: el agente solo reserva lo que ya ofreció.
+      requireOffer: true,
+    });
+    return Response.json(bookingPayload(result), { status: 201 });
+  } catch (err) {
+    return bookingErrorResponse(err);
+  }
+}
+
+export async function PATCH(req: Request) {
+  const gate = await guard(req);
+  if ("response" in gate) return gate.response;
+
+  const body = await parseBody(req, rescheduleSchema);
+  if (!body.ok) return body.response;
+
+  try {
+    const result = await rescheduleForConversation({
+      organizationId: gate.organizationId,
+      conversationId: body.data.conversationId,
+      startUtc: body.data.startUtc,
+    });
+    // 200 y no 201: mover una cita no crea un recurso nuevo.
+    return Response.json(bookingPayload(result));
+  } catch (err) {
+    return bookingErrorResponse(err);
+  }
+}
+
+/* Cancelar NO existe por esta superficie a propósito: esa decisión es del
+ * dueño del negocio, no del agente. El camino es el handoff. */
+
+type Gate = { organizationId: string } | { response: Response };
+
+async function guard(req: Request): Promise<Gate> {
+  if (!agendaEnabled()) return { response: agendaDisabledResponse() };
+  const denied = requireBotKey(req);
+  if (denied) return { response: denied };
+  const organizationId = await resolveInstanceOrg();
+  if (!organizationId) {
+    return {
+      response: apiError(409, "no_org", "La instancia aún no tiene organización"),
+    };
+  }
+  return { organizationId };
+}
+

--- a/src/app/api/calendar/availability/route.ts
+++ b/src/app/api/calendar/availability/route.ts
@@ -1,0 +1,44 @@
+import { withAuth } from "@/lib/api";
+import { dayIsoInTz, timeInTz, dayLabelInTz } from "@/lib/time/slots";
+import { agendaDisabledResponse, agendaEnabled } from "@/server/agenda/flag";
+import { computeAvailability } from "@/server/agenda/availability";
+import { getSettings } from "@/server/agenda/settings";
+
+export const dynamic = "force-dynamic";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * 015 — Los huecos libres, para el operador.
+ *
+ * A diferencia de la superficie del bot, esta NO registra oferta: es la vista
+ * de quien ya está mirando la agenda y elige de lo que ve.
+ *
+ * Sin huecos responde `{"slots":[]}` con 200: agenda llena es una respuesta,
+ * no un error.
+ */
+export const GET = withAuth(async (session, req: Request) => {
+  if (!agendaEnabled()) return agendaDisabledResponse();
+
+  const url = new URL(req.url);
+  const from = url.searchParams.get("from");
+  const to = url.searchParams.get("to");
+
+  const settings = await getSettings(session.organizationId);
+  const now = new Date();
+  const slots = await computeAvailability(session.organizationId, {
+    fromISO: from && ISO_DATE.test(from) ? from : undefined,
+    toISO: to && ISO_DATE.test(to) ? to : undefined,
+    settings,
+    now,
+  });
+
+  return Response.json({
+    slots: slots.map((s) => ({
+      ...s,
+      dayIso: dayIsoInTz(new Date(s.startUtc), settings.timezone),
+      dayLabel: dayLabelInTz(s.startUtc, settings.timezone, now),
+      time: timeInTz(s.startUtc, settings.timezone),
+    })),
+  });
+});

--- a/src/app/api/calendar/settings/route.ts
+++ b/src/app/api/calendar/settings/route.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+import { apiError, parseBody, withAuth } from "@/lib/api";
+import { CONNECTOR_ORDER } from "@/lib/agenda-connectors";
+import { agendaDisabledResponse, agendaEnabled } from "@/server/agenda/flag";
+import {
+  CalendarSettingsError,
+  getSettings,
+  upsertSettings,
+} from "@/server/agenda/settings";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * 015 — La configuración de la agenda del negocio.
+ *
+ * Una instancia sin configurar responde 200 con los defaults, no 404: la
+ * agenda ya es usable el día que se enciende.
+ *
+ * Jamás devuelve credenciales de un conector — esas viven en su propio
+ * endpoint y solo salen como últimos 4 dígitos.
+ */
+export const GET = withAuth(async (session) => {
+  if (!agendaEnabled()) return agendaDisabledResponse();
+  const settings = await getSettings(session.organizationId);
+  return Response.json({ settings });
+});
+
+const intervalSchema = z.object({
+  start: z.string(),
+  end: z.string(),
+});
+
+const putSchema = z.object({
+  weeklyHours: z.record(z.string(), z.array(intervalSchema)).optional(),
+  slotMinutes: z.number().optional(),
+  bufferMinutes: z.number().optional(),
+  minNoticeHours: z.number().optional(),
+  maxDaysAhead: z.number().optional(),
+  timezone: z.string().optional(),
+  // El catálogo manda: un conector que no existe se rechaza aquí, y el
+  // servicio lo vuelve a comprobar por si el llamador no es esta ruta.
+  connector: z
+    .string()
+    .refine((v) => (CONNECTOR_ORDER as readonly string[]).includes(v), {
+      message: "Conector desconocido",
+    })
+    .optional(),
+  meetingLink: z.string().nullish(),
+});
+
+/**
+ * Guarda lo que se pueda salvar: los enteros fuera de rango se recortan y los
+ * intervalos mal escritos se descartan, en vez de tumbar el horario entero por
+ * una celda. Lo que sí se rechaza es lo que rompería el motor después: una
+ * zona horaria que el runtime no conoce, o un conector inexistente.
+ */
+export const PUT = withAuth(async (session, req: Request) => {
+  if (!agendaEnabled()) return agendaDisabledResponse();
+  const body = await parseBody(req, putSchema);
+  if (!body.ok) return body.response;
+
+  try {
+    const settings = await upsertSettings(session.organizationId, {
+      ...body.data,
+      // `undefined` = no lo tocaron; `null` = lo vaciaron a propósito.
+      meetingLink:
+        body.data.meetingLink === undefined ? undefined : body.data.meetingLink,
+    });
+    return Response.json({ settings });
+  } catch (err) {
+    if (err instanceof CalendarSettingsError) {
+      return apiError(422, "invalid_body", err.message);
+    }
+    throw err;
+  }
+});

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -137,8 +137,16 @@ export const POST = withAuth(async (session, req: Request) => {
       notes: body.data.notes ?? null,
       source: body.data.source ?? null,
     })
+    // El canal entra en el target porque entra en el índice único desde 014
+    // (`contact_org_channel_identity_uq`). Postgres exige que el ON CONFLICT
+    // nombre EXACTAMENTE las columnas de un índice existente: sin `channel`,
+    // el alta manual falla con "no unique or exclusion constraint matching".
     .onConflictDoNothing({
-      target: [schema.contact.organizationId, schema.contact.waIdentity],
+      target: [
+        schema.contact.organizationId,
+        schema.contact.channel,
+        schema.contact.waIdentity,
+      ],
     })
     .returning();
   if (!inserted[0]) {

--- a/src/app/api/dev/google-mock/[...path]/route.ts
+++ b/src/app/api/dev/google-mock/[...path]/route.ts
@@ -1,0 +1,164 @@
+import { mockGuard } from "@/lib/dev-guard";
+import {
+  googleMockSnapshot,
+  googleMockState,
+  mockRefreshTokenIsBad,
+  resetGoogleMock,
+} from "@/server/dev/google-mock-state";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * 015 — Google de mentira para el self-test, tras `mockGuard()` (404
+ * incondicional en producción).
+ *
+ * Cubre lo que el conector usa: refrescar el token, crear/leer/mover/borrar un
+ * evento y leer el calendario. Y reproduce la asincronía de la conferencia:
+ * al crear NO hay enlace de Meet, y aparece en una lectura posterior.
+ */
+
+type Ctx = { params: Promise<{ path: string[] }> };
+
+const TOKEN = "google-token-de-mentira";
+
+export async function POST(req: Request, ctx: Ctx) {
+  const denied = mockGuard();
+  if (denied) return denied;
+  const { path } = await ctx.params;
+  const route = path.join("/");
+
+  if (route === "token") {
+    const body = await req.text();
+    if (mockRefreshTokenIsBad(body)) {
+      return Response.json(
+        { error: "invalid_grant", error_description: "Token has been expired or revoked." },
+        { status: 400 }
+      );
+    }
+    return Response.json({ access_token: TOKEN, expires_in: 3600 });
+  }
+
+  if (route === "_reset") {
+    resetGoogleMock();
+    return Response.json({ ok: true });
+  }
+
+  // POST /calendars/{id}/events
+  if (path[0] === "calendars" && path[2] === "events" && path.length === 3) {
+    const unauthorized = requireToken(req);
+    if (unauthorized) return unauthorized;
+
+    const body = (await req.json().catch(() => ({}))) as {
+      summary?: string;
+      start?: { dateTime?: string };
+      end?: { dateTime?: string };
+    };
+    const state = googleMockState();
+    const id = `evt_${state.nextId++}`;
+    state.events.set(id, {
+      id,
+      summary: body.summary ?? "",
+      start: body.start?.dateTime ?? "",
+      end: body.end?.dateTime ?? "",
+      reads: 0,
+      meetLink: null,
+      updates: 0,
+    });
+    // Sin enlace todavía: la conferencia se está creando. Es el
+    // comportamiento real de Google y por eso el conector re-lee.
+    return Response.json({
+      id,
+      summary: body.summary,
+      conferenceData: { createRequest: { status: { statusCode: "pending" } } },
+    });
+  }
+
+  return new Response(null, { status: 404 });
+}
+
+export async function GET(req: Request, ctx: Ctx) {
+  const denied = mockGuard();
+  if (denied) return denied;
+  const { path } = await ctx.params;
+
+  if (path.join("/") === "_state") return Response.json(googleMockSnapshot());
+
+  const unauthorized = requireToken(req);
+  if (unauthorized) return unauthorized;
+
+  // GET /calendars/{id} — la prueba de conexión.
+  if (path[0] === "calendars" && path.length === 2) {
+    return Response.json({ id: path[1], summary: "Calendario de prueba" });
+  }
+
+  // GET /calendars/{id}/events/{eventId}
+  const event = eventFrom(path);
+  if (!event) return new Response(null, { status: 404 });
+
+  const state = googleMockState();
+  event.reads += 1;
+  if (!event.meetLink && event.reads > state.conferenceDelayReads) {
+    event.meetLink = `https://meet.google.mock/${event.id}`;
+  }
+
+  return Response.json({
+    id: event.id,
+    summary: event.summary,
+    conferenceData: event.meetLink
+      ? {
+          createRequest: { status: { statusCode: "success" } },
+          entryPoints: [{ entryPointType: "video", uri: event.meetLink }],
+        }
+      : { createRequest: { status: { statusCode: "pending" } } },
+  });
+}
+
+export async function PATCH(req: Request, ctx: Ctx) {
+  const denied = mockGuard();
+  if (denied) return denied;
+  const unauthorized = requireToken(req);
+  if (unauthorized) return unauthorized;
+
+  const { path } = await ctx.params;
+  const event = eventFrom(path);
+  if (!event) return new Response(null, { status: 404 });
+
+  const body = (await req.json().catch(() => ({}))) as {
+    start?: { dateTime?: string };
+    end?: { dateTime?: string };
+  };
+  if (body.start?.dateTime) event.start = body.start.dateTime;
+  if (body.end?.dateTime) event.end = body.end.dateTime;
+  event.updates += 1;
+  // El evento se movió: su enlace de Meet es el mismo.
+  return Response.json({ id: event.id });
+}
+
+export async function DELETE(req: Request, ctx: Ctx) {
+  const denied = mockGuard();
+  if (denied) return denied;
+  const unauthorized = requireToken(req);
+  if (unauthorized) return unauthorized;
+
+  const { path } = await ctx.params;
+  const event = eventFrom(path);
+  if (!event) return new Response(null, { status: 404 });
+
+  const state = googleMockState();
+  state.events.delete(event.id);
+  state.deleted.push(event.id);
+  return new Response(null, { status: 204 });
+}
+
+function eventFrom(path: string[]) {
+  if (path[0] !== "calendars" || path[2] !== "events" || !path[3]) return null;
+  return googleMockState().events.get(path[3]) ?? null;
+}
+
+function requireToken(req: Request): Response | null {
+  if (req.headers.get("authorization") === `Bearer ${TOKEN}`) return null;
+  return Response.json(
+    { error: { code: 401, message: "Invalid Credentials" } },
+    { status: 401 }
+  );
+}

--- a/src/app/api/dev/zoom-mock/[...path]/route.ts
+++ b/src/app/api/dev/zoom-mock/[...path]/route.ts
@@ -1,0 +1,140 @@
+import { mockGuard } from "@/lib/dev-guard";
+import {
+  mockCredentialsAreBad,
+  resetZoomMock,
+  zoomMockSnapshot,
+  zoomMockState,
+} from "@/server/dev/zoom-mock-state";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * 015 — Zoom de mentira para el self-test. Tras `mockGuard()`: 404
+ * incondicional en producción, indistinguible de una ruta inexistente.
+ *
+ * Imita lo que el conector realmente usa —token, crear, mover, borrar y
+ * `users/me`— y además expone `_state` y `_reset` para que el arnés pueda
+ * afirmar sobre lo que recibió.
+ */
+
+type Ctx = { params: Promise<{ path: string[] }> };
+
+const TOKEN = "token-de-mentira-para-el-self-test";
+
+export async function POST(req: Request, ctx: Ctx) {
+  const denied = mockGuard();
+  if (denied) return denied;
+  const { path } = await ctx.params;
+  const route = path.join("/");
+
+  if (route === "oauth/token") {
+    if (mockCredentialsAreBad(req.headers.get("authorization"))) {
+      // Igual que Zoom: el endpoint de token responde 400 cuando el secreto no
+      // sirve.
+      return Response.json(
+        { reason: "Invalid client_id or client_secret", error: "invalid_client" },
+        { status: 400 }
+      );
+    }
+    return Response.json({ access_token: TOKEN, expires_in: 3600 });
+  }
+
+  if (route === "_reset") {
+    resetZoomMock();
+    return Response.json({ ok: true });
+  }
+
+  if (route === "users/me/meetings") {
+    const unauthorized = requireToken(req);
+    if (unauthorized) return unauthorized;
+
+    const body = (await req.json().catch(() => ({}))) as {
+      topic?: string;
+      start_time?: string;
+      duration?: number;
+      timezone?: string;
+    };
+    const state = zoomMockState();
+    const id = String(90_000_000 + state.nextId++);
+    const meeting = {
+      id,
+      topic: body.topic ?? "",
+      startTime: body.start_time ?? "",
+      duration: body.duration ?? 0,
+      timezone: body.timezone ?? "",
+      joinUrl: `https://zoom.mock/j/${id}`,
+      updates: 0,
+    };
+    state.meetings.set(id, meeting);
+    return Response.json({ id: Number(id), join_url: meeting.joinUrl }, { status: 201 });
+  }
+
+  return new Response(null, { status: 404 });
+}
+
+export async function GET(req: Request, ctx: Ctx) {
+  const denied = mockGuard();
+  if (denied) return denied;
+  const { path } = await ctx.params;
+  const route = path.join("/");
+
+  if (route === "_state") return Response.json(zoomMockSnapshot());
+
+  if (route === "users/me") {
+    const unauthorized = requireToken(req);
+    if (unauthorized) return unauthorized;
+    return Response.json({ id: "u_mock", email: "mock@zoom.test" });
+  }
+
+  return new Response(null, { status: 404 });
+}
+
+export async function PATCH(req: Request, ctx: Ctx) {
+  const denied = mockGuard();
+  if (denied) return denied;
+  const unauthorized = requireToken(req);
+  if (unauthorized) return unauthorized;
+
+  const { path } = await ctx.params;
+  const id = meetingIdFrom(path);
+  const meeting = id ? zoomMockState().meetings.get(id) : undefined;
+  if (!meeting) return new Response(null, { status: 404 });
+
+  const body = (await req.json().catch(() => ({}))) as {
+    start_time?: string;
+    duration?: number;
+  };
+  // Mismo id ⇒ mismo joinUrl: es la misma reunión, movida de hora.
+  if (body.start_time) meeting.startTime = body.start_time;
+  if (body.duration) meeting.duration = body.duration;
+  meeting.updates += 1;
+  return new Response(null, { status: 204 });
+}
+
+export async function DELETE(req: Request, ctx: Ctx) {
+  const denied = mockGuard();
+  if (denied) return denied;
+  const unauthorized = requireToken(req);
+  if (unauthorized) return unauthorized;
+
+  const { path } = await ctx.params;
+  const id = meetingIdFrom(path);
+  const state = zoomMockState();
+  if (!id || !state.meetings.has(id)) {
+    // Zoom devuelve 404 y el conector lo trata como éxito.
+    return new Response(null, { status: 404 });
+  }
+  state.meetings.delete(id);
+  state.deleted.push(id);
+  return new Response(null, { status: 204 });
+}
+
+function meetingIdFrom(path: string[]): string | null {
+  return path[0] === "meetings" && path[1] ? path[1] : null;
+}
+
+function requireToken(req: Request): Response | null {
+  const auth = req.headers.get("authorization");
+  if (auth === `Bearer ${TOKEN}`) return null;
+  return Response.json({ code: 124, message: "Invalid access token" }, { status: 401 });
+}

--- a/src/app/api/settings/google/route.ts
+++ b/src/app/api/settings/google/route.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+import { apiError, parseBody, withAuth } from "@/lib/api";
+import { agendaDisabledResponse, agendaEnabled } from "@/server/agenda/flag";
+import { googleConnector } from "@/server/agenda/connectors/google";
+import {
+  deleteGoogleCredentials,
+  getGoogleCredentials,
+  saveGoogleCredentials,
+  secretLast4,
+} from "@/server/agenda/connectors/google-credentials";
+
+export const dynamic = "force-dynamic";
+
+/** 015 — Conexión de Google Calendar. Los secretos entran y no vuelven a salir. */
+
+export const GET = withAuth(async (session) => {
+  if (!agendaEnabled()) return agendaDisabledResponse();
+  const creds = await getGoogleCredentials(session.organizationId);
+  if (!creds) return Response.json({ connection: null });
+  return Response.json({
+    connection: {
+      status: creds.status,
+      secretLast4: secretLast4(creds.clientSecret),
+      fields: { clientId: creds.clientId, calendarId: creds.calendarId },
+    },
+  });
+});
+
+const credsSchema = z.object({
+  clientId: z.string().trim().min(1),
+  clientSecret: z.string().trim().min(1),
+  refreshToken: z.string().trim().min(1),
+  calendarId: z.string().trim().optional(),
+});
+
+export const PUT = withAuth(async (session, req: Request) => {
+  if (!agendaEnabled()) return agendaDisabledResponse();
+  const body = await parseBody(req, credsSchema);
+  if (!body.ok) return body.response;
+
+  const calendarId = body.data.calendarId?.trim() || "primary";
+  const check = await googleConnector.testConnection({
+    ...body.data,
+    calendarId,
+    status: "connected",
+  });
+  if (!check.ok) return apiError(422, "google_invalid", check.error);
+
+  await saveGoogleCredentials({
+    organizationId: session.organizationId,
+    ...body.data,
+    calendarId,
+  });
+
+  return Response.json({
+    connection: {
+      status: "connected",
+      secretLast4: secretLast4(body.data.clientSecret),
+      fields: { clientId: body.data.clientId, calendarId },
+    },
+  });
+});
+
+export const DELETE = withAuth(async (session) => {
+  if (!agendaEnabled()) return agendaDisabledResponse();
+  await deleteGoogleCredentials(session.organizationId);
+  return Response.json({ ok: true });
+});

--- a/src/app/api/settings/google/test/route.ts
+++ b/src/app/api/settings/google/test/route.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { apiError, parseBody, withAuth } from "@/lib/api";
+import { agendaDisabledResponse, agendaEnabled } from "@/server/agenda/flag";
+import { googleConnector } from "@/server/agenda/connectors/google";
+import { getGoogleCredentials } from "@/server/agenda/connectors/google-credentials";
+
+export const dynamic = "force-dynamic";
+
+const schema = z.object({
+  clientId: z.string().trim().optional(),
+  clientSecret: z.string().trim().optional(),
+  refreshToken: z.string().trim().optional(),
+  calendarId: z.string().trim().optional(),
+});
+
+/** Probar sin guardar; con los campos vacíos prueba lo ya guardado. */
+export const POST = withAuth(async (session, req: Request) => {
+  if (!agendaEnabled()) return agendaDisabledResponse();
+  const body = await parseBody(req, schema);
+  if (!body.ok) return body.response;
+
+  const stored = await getGoogleCredentials(session.organizationId);
+  const clientId = body.data.clientId || stored?.clientId;
+  const clientSecret = body.data.clientSecret || stored?.clientSecret;
+  const refreshToken = body.data.refreshToken || stored?.refreshToken;
+  const calendarId =
+    body.data.calendarId || stored?.calendarId || "primary";
+
+  if (!clientId || !clientSecret || !refreshToken) {
+    return apiError(422, "invalid_body", "Faltan credenciales que probar");
+  }
+
+  const check = await googleConnector.testConnection({
+    clientId,
+    clientSecret,
+    refreshToken,
+    calendarId,
+    status: "connected",
+  });
+  if (!check.ok) return apiError(422, "google_invalid", check.error);
+  return Response.json({ ok: true, detail: check.detail ?? null });
+});

--- a/src/app/api/settings/zoom/route.ts
+++ b/src/app/api/settings/zoom/route.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+import { apiError, parseBody, withAuth } from "@/lib/api";
+import { agendaDisabledResponse, agendaEnabled } from "@/server/agenda/flag";
+import { zoomConnector } from "@/server/agenda/connectors/zoom";
+import {
+  deleteZoomCredentials,
+  getZoomCredentials,
+  saveZoomCredentials,
+  secretLast4,
+} from "@/server/agenda/connectors/zoom-credentials";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * 015 — Conexión de Zoom. El secreto entra, pero nunca vuelve a salir: hacia
+ * el navegador solo van sus últimos 4 y el estado.
+ */
+
+export const GET = withAuth(async (session) => {
+  if (!agendaEnabled()) return agendaDisabledResponse();
+  const creds = await getZoomCredentials(session.organizationId);
+  if (!creds) return Response.json({ connection: null });
+  return Response.json({
+    connection: {
+      status: creds.status,
+      secretLast4: secretLast4(creds.clientSecret),
+      fields: { accountId: creds.accountId, clientId: creds.clientId },
+    },
+  });
+});
+
+const credsSchema = z.object({
+  accountId: z.string().trim().min(1),
+  clientId: z.string().trim().min(1),
+  clientSecret: z.string().trim().min(1),
+});
+
+/** Guarda validando ANTES contra Zoom: unas credenciales que no sirven no llegan a la base. */
+export const PUT = withAuth(async (session, req: Request) => {
+  if (!agendaEnabled()) return agendaDisabledResponse();
+  const body = await parseBody(req, credsSchema);
+  if (!body.ok) return body.response;
+
+  const check = await zoomConnector.testConnection({
+    ...body.data,
+    status: "connected",
+  });
+  if (!check.ok) return apiError(422, "zoom_invalid", check.error);
+
+  await saveZoomCredentials({
+    organizationId: session.organizationId,
+    ...body.data,
+  });
+
+  return Response.json({
+    connection: {
+      status: "connected",
+      secretLast4: secretLast4(body.data.clientSecret),
+      fields: { accountId: body.data.accountId, clientId: body.data.clientId },
+    },
+  });
+});
+
+export const DELETE = withAuth(async (session) => {
+  if (!agendaEnabled()) return agendaDisabledResponse();
+  await deleteZoomCredentials(session.organizationId);
+  return Response.json({ ok: true });
+});

--- a/src/app/api/settings/zoom/test/route.ts
+++ b/src/app/api/settings/zoom/test/route.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { apiError, parseBody, withAuth } from "@/lib/api";
+import { agendaDisabledResponse, agendaEnabled } from "@/server/agenda/flag";
+import { zoomConnector } from "@/server/agenda/connectors/zoom";
+import { getZoomCredentials } from "@/server/agenda/connectors/zoom-credentials";
+
+export const dynamic = "force-dynamic";
+
+const schema = z.object({
+  accountId: z.string().trim().optional(),
+  clientId: z.string().trim().optional(),
+  clientSecret: z.string().trim().optional(),
+});
+
+/**
+ * Probar sin guardar. Con los campos vacíos prueba las credenciales YA
+ * guardadas — así el operador puede verificar una conexión sin volver a pegar
+ * un secreto que la UI nunca le devolvió.
+ */
+export const POST = withAuth(async (session, req: Request) => {
+  if (!agendaEnabled()) return agendaDisabledResponse();
+  const body = await parseBody(req, schema);
+  if (!body.ok) return body.response;
+
+  const stored = await getZoomCredentials(session.organizationId);
+  const accountId = body.data.accountId || stored?.accountId;
+  const clientId = body.data.clientId || stored?.clientId;
+  const clientSecret = body.data.clientSecret || stored?.clientSecret;
+
+  if (!accountId || !clientId || !clientSecret) {
+    return apiError(422, "invalid_body", "Faltan credenciales que probar");
+  }
+
+  const check = await zoomConnector.testConnection({
+    accountId,
+    clientId,
+    clientSecret,
+    status: "connected",
+  });
+  if (!check.ok) return apiError(422, "zoom_invalid", check.error);
+  return Response.json({ ok: true, detail: check.detail ?? null });
+});

--- a/src/components/app-nav.tsx
+++ b/src/components/app-nav.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import {
+  CalendarDays,
   FlaskConical,
   Inbox,
   Kanban,
@@ -21,13 +22,27 @@ import { useEvents } from "@/components/use-events";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { APP_VERSION, BUILD_COMMIT, versionLabel } from "@/lib/version";
 
-const NAV = [
+type NavItem = {
+  href: string;
+  label: string;
+  icon: typeof Inbox;
+  badge?: boolean;
+};
+
+const NAV: NavItem[] = [
   { href: "/inbox", label: "Bandeja", icon: Inbox, badge: true },
   { href: "/pipeline", label: "Pipeline", icon: Kanban },
   { href: "/contacts", label: "Contactos", icon: Users },
   { href: "/agent", label: "Agente", icon: Sparkles },
   { href: "/lab", label: "Laboratorio", icon: FlaskConical },
-] as const;
+];
+
+/** 015 — "Citas" solo existe si esta instancia encendió la agenda. */
+const AGENDA_ITEM: NavItem = {
+  href: "/bookings",
+  label: "Citas",
+  icon: CalendarDays,
+};
 
 export function AppNav({
   branding,
@@ -35,6 +50,7 @@ export function AppNav({
   role,
   theme,
   commit,
+  agenda = false,
   open = false,
   onClose,
 }: {
@@ -47,6 +63,12 @@ export function AppNav({
    * plataforma cuando quien construyó no lo pasó como build-arg.
    */
   commit?: string;
+  /**
+   * 015 — ¿hay agenda en esta instancia? Viene del servidor por prop y no se
+   * deduce de los datos: una instancia con la agenda encendida pero sin citas
+   * todavía debe mostrar igual su pantalla.
+   */
+  agenda?: boolean;
   /** Solo aplica por debajo de `lg`: en escritorio el lateral es fijo. */
   open?: boolean;
   onClose?: () => void;
@@ -74,6 +96,11 @@ export function AppNav({
   });
 
   const sha = commit || BUILD_COMMIT;
+  // Citas va después de Pipeline: es el paso siguiente de un trato, no una
+  // sección aparte.
+  const items = agenda
+    ? [...NAV.slice(0, 2), AGENDA_ITEM, ...NAV.slice(2)]
+    : NAV;
 
   return (
     <aside
@@ -114,7 +141,7 @@ export function AppNav({
       </div>
 
       <nav className="flex flex-col gap-0.5">
-        {NAV.map((item) => {
+        {items.map((item) => {
           const active =
             pathname === item.href || pathname.startsWith(`${item.href}/`);
           return (
@@ -133,7 +160,7 @@ export function AppNav({
                 strokeWidth={1.7}
               />
               <span className="flex-1">{item.label}</span>
-              {"badge" in item && item.badge && unread > 0 && (
+              {item.badge && unread > 0 && (
                 <span
                   className={cn(
                     "flex h-[18px] min-w-[18px] items-center justify-center rounded-full px-1.5 text-[10.5px] font-semibold",

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -25,6 +25,7 @@ export function AppShell({
   role,
   theme,
   commit,
+  agenda = false,
   children,
 }: {
   branding: Branding;
@@ -33,6 +34,8 @@ export function AppShell({
   theme: ThemePreference;
   /** Commit resuelto en el servidor (build-arg o variable de la plataforma). */
   commit?: string;
+  /** 015 — ¿esta instancia tiene agenda? Lo decide el servidor. */
+  agenda?: boolean;
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
@@ -70,6 +73,7 @@ export function AppShell({
         userName={userName}
         role={role}
         theme={theme}
+        agenda={agenda}
         open={navOpen}
         onClose={() => setNavOpen(false)}
       />

--- a/src/components/bookings/bookings-client.tsx
+++ b/src/components/bookings/bookings-client.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useEvents } from "@/components/use-events";
+
+/** 015 — Citas: lo agendado por el operador y por la IA, con sus acciones. */
+
+type Booking = {
+  id: string;
+  kind: "session" | "block";
+  status: "agendada" | "realizada" | "no_show" | "cancelada";
+  source: "manual" | "ai";
+  scheduledAtUtc: string;
+  durationMinutes: number;
+  date: string;
+  time: string;
+  weekday: string;
+  contact: { id: string; name: string } | null;
+  conversationId: string | null;
+  connector: string | null;
+  meetingLink: string | null;
+  linkPending: boolean;
+  isTest: boolean;
+  notes: string | null;
+};
+
+type Slot = { startUtc: string; label: string };
+
+const STATUS_LABEL: Record<Booking["status"], string> = {
+  agendada: "Agendada",
+  realizada: "Realizada",
+  no_show: "No asistió",
+  cancelada: "Cancelada",
+};
+
+export function BookingsClient() {
+  const [bookings, setBookings] = useState<Booking[] | null>(null);
+  const [slots, setSlots] = useState<Slot[]>([]);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [rescheduling, setRescheduling] = useState<string | null>(null);
+  const [blockStart, setBlockStart] = useState("");
+  const [blockMinutes, setBlockMinutes] = useState(60);
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  // La agenda cambia también cuando agenda la IA: SSE mantiene la vista viva.
+  useEvents({ onBookingUpdated: () => void refresh() });
+
+  async function refresh() {
+    const [list, avail] = await Promise.all([
+      fetch("/api/bookings").catch(() => null),
+      fetch("/api/calendar/availability").catch(() => null),
+    ]);
+    if (list?.ok) {
+      const data = (await list.json()) as { bookings: Booking[] };
+      setBookings(data.bookings);
+    } else {
+      setBookings([]);
+    }
+    if (avail?.ok) {
+      const data = (await avail.json()) as { slots: Slot[] };
+      setSlots(data.slots.slice(0, 12));
+    }
+  }
+
+  async function act(id: string, body: unknown) {
+    setBusy(id);
+    setError(null);
+    const res = await fetch(`/api/bookings/${id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }).catch(() => null);
+    setBusy(null);
+    if (!res?.ok) {
+      const data = (await res?.json().catch(() => null)) as {
+        error?: { message?: string };
+      } | null;
+      setError(data?.error?.message ?? "No se pudo completar la acción");
+      return;
+    }
+    setRescheduling(null);
+    await refresh();
+  }
+
+  async function createBlock() {
+    if (!blockStart) return;
+    setError(null);
+    const res = await fetch("/api/bookings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        kind: "block",
+        // El input datetime-local da hora local del navegador.
+        startUtc: new Date(blockStart).toISOString(),
+        durationMinutes: blockMinutes,
+      }),
+    }).catch(() => null);
+    if (res?.status !== 201) {
+      const data = (await res?.json().catch(() => null)) as {
+        error?: { message?: string };
+      } | null;
+      setError(data?.error?.message ?? "No se pudo bloquear ese rango");
+      return;
+    }
+    setBlockStart("");
+    await refresh();
+  }
+
+  if (!bookings) return <p className="text-sm text-text-3">Cargando…</p>;
+
+  return (
+    <div className="space-y-6">
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      <section className="space-y-2">
+        <h3 className="text-sm font-semibold">Bloquear un rango</h3>
+        <p className="text-sm text-text-3">
+          Para compromisos que viven fuera del CRM: ese tiempo deja de
+          ofrecerse.
+        </p>
+        <div className="flex flex-wrap items-end gap-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="block-start">Inicio</Label>
+            <Input
+              id="block-start"
+              type="datetime-local"
+              value={blockStart}
+              onChange={(e) => setBlockStart(e.target.value)}
+              className="w-56"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="block-min">Minutos</Label>
+            <Input
+              id="block-min"
+              type="number"
+              min={10}
+              max={480}
+              value={blockMinutes}
+              onChange={(e) => setBlockMinutes(Number(e.target.value))}
+              className="w-24"
+            />
+          </div>
+          <Button
+            variant="secondary"
+            onClick={createBlock}
+            disabled={!blockStart}
+          >
+            Bloquear
+          </Button>
+        </div>
+      </section>
+
+      <section className="space-y-2">
+        <h3 className="text-sm font-semibold">
+          Citas <span className="text-text-3">({bookings.length})</span>
+        </h3>
+        {bookings.length === 0 && (
+          <p className="text-sm text-text-3">
+            Todavía no hay nada agendado. Configura tu horario en Ajustes →
+            Agenda para empezar a recibir citas.
+          </p>
+        )}
+        <ul className="divide-y rounded-md border">
+          {bookings.map((b) => (
+            <li key={b.id} className="space-y-2 p-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-sm font-medium">
+                  {b.weekday} {b.date} · {b.time}
+                </span>
+                <span className="text-xs text-text-3">
+                  {b.durationMinutes} min
+                </span>
+                <Badge
+                  variant={b.status === "cancelada" ? "secondary" : "default"}
+                >
+                  {STATUS_LABEL[b.status]}
+                </Badge>
+                {b.kind === "block" ? (
+                  <Badge variant="secondary">Bloqueo</Badge>
+                ) : (
+                  <Badge variant="secondary">
+                    {b.source === "ai" ? "Agendó la IA" : "Manual"}
+                  </Badge>
+                )}
+                {b.isTest && <Badge variant="secondary">Prueba</Badge>}
+                {b.linkPending && b.status !== "cancelada" && (
+                  <Badge variant="secondary">Sin enlace</Badge>
+                )}
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3 text-sm text-text-3">
+                {b.contact && <span>{b.contact.name}</span>}
+                {b.meetingLink && (
+                  <a
+                    href={b.meetingLink}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="text-brand-text hover:underline"
+                  >
+                    Enlace de la reunión
+                  </a>
+                )}
+                {b.notes && <span>{b.notes}</span>}
+              </div>
+
+              {/* El proveedor falló al crear la reunión. La cita existe; lo
+                  único que falta es el enlace, y se reintenta desde aquí — sin
+                  esto, un hipo del proveedor sería una pérdida silenciosa. */}
+              {b.linkPending && b.status !== "cancelada" && (
+                <div className="flex flex-wrap items-center gap-2 rounded-sm bg-subtle p-2">
+                  <span className="text-sm text-text-2">
+                    Esta cita quedó sin enlace: el proveedor no respondió.
+                  </span>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    disabled={busy === b.id}
+                    onClick={() => act(b.id, { action: "retry_link" })}
+                  >
+                    Reintentar enlace
+                  </Button>
+                </div>
+              )}
+
+              {b.status === "agendada" && (
+                <div className="flex flex-wrap gap-2">
+                  {/* Un bloqueo no se "realiza" ni tiene quien falte: solo se
+                      mueve o se quita. */}
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    disabled={busy === b.id}
+                    onClick={() =>
+                      setRescheduling((r) => (r === b.id ? null : b.id))
+                    }
+                  >
+                    Reprogramar
+                  </Button>
+                  {b.kind === "session" && (
+                    <>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        disabled={busy === b.id}
+                        onClick={() =>
+                          act(b.id, { action: "status", status: "realizada" })
+                        }
+                      >
+                        Realizada
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        disabled={busy === b.id}
+                        onClick={() =>
+                          act(b.id, { action: "status", status: "no_show" })
+                        }
+                      >
+                        No asistió
+                      </Button>
+                    </>
+                  )}
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={busy === b.id}
+                    onClick={() => act(b.id, { action: "cancel" })}
+                  >
+                    {b.kind === "block" ? "Quitar bloqueo" : "Cancelar"}
+                  </Button>
+                </div>
+              )}
+
+              {rescheduling === b.id && (
+                <div className="space-y-1 rounded-sm bg-subtle p-2">
+                  {slots.length === 0 && (
+                    <p className="text-sm text-text-3">
+                      No hay huecos libres para mover esta cita.
+                    </p>
+                  )}
+                  {slots.map((s) => (
+                    <button
+                      key={s.startUtc}
+                      type="button"
+                      disabled={busy === b.id}
+                      onClick={() =>
+                        act(b.id, {
+                          action: "reschedule",
+                          startUtc: s.startUtc,
+                        })
+                      }
+                      className="block w-full rounded-sm px-2 py-1 text-left text-sm hover:bg-accent"
+                    >
+                      {s.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/src/components/settings/agenda-client.tsx
+++ b/src/components/settings/agenda-client.tsx
@@ -1,0 +1,408 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import {
+  CONNECTOR_META,
+  CONNECTOR_ORDER,
+  type ConnectorId,
+} from "@/lib/agenda-connectors";
+import { ConnectorCredentials } from "@/components/settings/connector-credentials";
+
+/**
+ * 015 — Ajustes → Agenda: cuándo atiende el negocio y cómo se entrega la
+ * reunión.
+ */
+
+type Interval = { start: string; end: string };
+type DayKey = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun";
+type WeeklyHours = Partial<Record<DayKey, Interval[]>>;
+
+type Settings = {
+  weeklyHours: WeeklyHours;
+  slotMinutes: number;
+  bufferMinutes: number;
+  minNoticeHours: number;
+  maxDaysAhead: number;
+  timezone: string;
+  connector: ConnectorId;
+  meetingLink: string | null;
+};
+
+const DAYS: { key: DayKey; label: string }[] = [
+  { key: "mon", label: "Lunes" },
+  { key: "tue", label: "Martes" },
+  { key: "wed", label: "Miércoles" },
+  { key: "thu", label: "Jueves" },
+  { key: "fri", label: "Viernes" },
+  { key: "sat", label: "Sábado" },
+  { key: "sun", label: "Domingo" },
+];
+
+const DEFAULT_INTERVAL: Interval = { start: "09:00", end: "18:00" };
+
+export function AgendaClient() {
+  const [settings, setSettings] = useState<Settings | null>(null);
+  const [slots, setSlots] = useState<{ label: string }[] | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    void (async () => {
+      const [cfg, avail] = await Promise.all([
+        fetch("/api/calendar/settings").catch(() => null),
+        fetch("/api/calendar/availability").catch(() => null),
+      ]);
+      if (cfg?.ok) {
+        const data = (await cfg.json()) as { settings: Settings };
+        setSettings(data.settings);
+      }
+      if (avail?.ok) {
+        const data = (await avail.json()) as { slots: { label: string }[] };
+        setSlots(data.slots.slice(0, 5));
+      } else {
+        setSlots([]);
+      }
+    })();
+  }, []);
+
+  async function refreshPreview() {
+    const res = await fetch("/api/calendar/availability").catch(() => null);
+    if (!res?.ok) return setSlots([]);
+    const data = (await res.json()) as { slots: { label: string }[] };
+    setSlots(data.slots.slice(0, 5));
+  }
+
+  function patch(next: Partial<Settings>) {
+    setSettings((s) => (s ? { ...s, ...next } : s));
+    setSaved(false);
+  }
+
+  function toggleDay(day: DayKey) {
+    if (!settings) return;
+    const current = settings.weeklyHours[day];
+    const weeklyHours = { ...settings.weeklyHours };
+    if (current && current.length > 0) delete weeklyHours[day];
+    else weeklyHours[day] = [{ ...DEFAULT_INTERVAL }];
+    patch({ weeklyHours });
+  }
+
+  function setIntervalAt(day: DayKey, index: number, next: Partial<Interval>) {
+    if (!settings) return;
+    const intervals = [...(settings.weeklyHours[day] ?? [])];
+    const current = intervals[index];
+    if (!current) return;
+    intervals[index] = { ...current, ...next };
+    patch({ weeklyHours: { ...settings.weeklyHours, [day]: intervals } });
+  }
+
+  function addInterval(day: DayKey) {
+    if (!settings) return;
+    const intervals = [...(settings.weeklyHours[day] ?? [])];
+    intervals.push({ start: "16:00", end: "18:00" });
+    patch({ weeklyHours: { ...settings.weeklyHours, [day]: intervals } });
+  }
+
+  function removeInterval(day: DayKey, index: number) {
+    if (!settings) return;
+    const intervals = (settings.weeklyHours[day] ?? []).filter(
+      (_, i) => i !== index
+    );
+    const weeklyHours = { ...settings.weeklyHours };
+    if (intervals.length === 0) delete weeklyHours[day];
+    else weeklyHours[day] = intervals;
+    patch({ weeklyHours });
+  }
+
+  async function save() {
+    if (!settings) return;
+    setSaving(true);
+    setError(null);
+    setSaved(false);
+    const res = await fetch("/api/calendar/settings", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        weeklyHours: settings.weeklyHours,
+        slotMinutes: settings.slotMinutes,
+        bufferMinutes: settings.bufferMinutes,
+        minNoticeHours: settings.minNoticeHours,
+        maxDaysAhead: settings.maxDaysAhead,
+        timezone: settings.timezone.trim(),
+        connector: settings.connector,
+        meetingLink: settings.meetingLink?.trim()
+          ? settings.meetingLink.trim()
+          : null,
+      }),
+    }).catch(() => null);
+    setSaving(false);
+    if (!res?.ok) {
+      const data = (await res?.json().catch(() => null)) as {
+        error?: { message?: string };
+      } | null;
+      setError(data?.error?.message ?? "No se pudo guardar");
+      return;
+    }
+    const data = (await res.json()) as { settings: Settings };
+    setSettings(data.settings);
+    setSaved(true);
+    void refreshPreview();
+  }
+
+  if (!settings) return <p className="text-sm text-text-3">Cargando…</p>;
+
+  return (
+    <div className="max-w-2xl space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Horario de atención</CardTitle>
+          <CardDescription>
+            En qué franjas puede agendarte un cliente. Las horas son las de tu
+            zona; un día sin franjas está cerrado.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {DAYS.map((day) => {
+            const intervals = settings.weeklyHours[day.key] ?? [];
+            const open = intervals.length > 0;
+            return (
+              <div key={day.key} className="flex items-start gap-3">
+                <button
+                  type="button"
+                  onClick={() => toggleDay(day.key)}
+                  className={cn(
+                    "mt-1 w-24 shrink-0 rounded-sm px-2 py-1 text-left text-sm font-medium transition-colors",
+                    open
+                      ? "bg-brand-tint text-brand-text"
+                      : "text-text-3 hover:bg-accent"
+                  )}
+                >
+                  {day.label}
+                </button>
+                <div className="flex-1 space-y-1.5">
+                  {!open && <span className="text-sm text-text-3">Cerrado</span>}
+                  {intervals.map((iv, i) => (
+                    <div key={i} className="flex items-center gap-2">
+                      <Input
+                        type="time"
+                        value={iv.start}
+                        onChange={(e) =>
+                          setIntervalAt(day.key, i, { start: e.target.value })
+                        }
+                        className="w-28"
+                      />
+                      <span className="text-text-3">a</span>
+                      <Input
+                        type="time"
+                        value={iv.end}
+                        onChange={(e) =>
+                          setIntervalAt(day.key, i, { end: e.target.value })
+                        }
+                        className="w-28"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => removeInterval(day.key, i)}
+                        className="text-sm text-text-3 hover:text-foreground"
+                        aria-label="Quitar franja"
+                      >
+                        ×
+                      </button>
+                    </div>
+                  ))}
+                  {open && (
+                    <button
+                      type="button"
+                      onClick={() => addInterval(day.key)}
+                      className="text-xs text-brand-text hover:underline"
+                    >
+                      + otra franja
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Cómo se generan los huecos</CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-2 gap-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="slot">Duración de la cita (min)</Label>
+            <Input
+              id="slot"
+              type="number"
+              min={10}
+              max={240}
+              value={settings.slotMinutes}
+              onChange={(e) => patch({ slotMinutes: Number(e.target.value) })}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="buffer">Respiro entre citas (min)</Label>
+            <Input
+              id="buffer"
+              type="number"
+              min={0}
+              max={120}
+              value={settings.bufferMinutes}
+              onChange={(e) => patch({ bufferMinutes: Number(e.target.value) })}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="notice">Aviso mínimo (horas)</Label>
+            <Input
+              id="notice"
+              type="number"
+              min={0}
+              max={72}
+              value={settings.minNoticeHours}
+              onChange={(e) => patch({ minNoticeHours: Number(e.target.value) })}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="ahead">Agenda abierta (días)</Label>
+            <Input
+              id="ahead"
+              type="number"
+              min={1}
+              max={60}
+              value={settings.maxDaysAhead}
+              onChange={(e) => patch({ maxDaysAhead: Number(e.target.value) })}
+            />
+          </div>
+          <div className="col-span-2 space-y-1.5">
+            <Label htmlFor="tz">Zona horaria</Label>
+            <Input
+              id="tz"
+              value={settings.timezone}
+              onChange={(e) => patch({ timezone: e.target.value })}
+              placeholder="America/Mexico_City"
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Cómo se entrega la reunión</CardTitle>
+          <CardDescription>
+            El enlace fijo no depende de nadie. Los demás conectan con tu propia
+            cuenta del proveedor y, si alguna vez falla, la cita se agenda igual
+            y el enlace queda pendiente de reintentar.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {CONNECTOR_ORDER.map((id) => {
+            const meta = CONNECTOR_META[id];
+            const active = settings.connector === id;
+            return (
+              <button
+                key={id}
+                type="button"
+                onClick={() => patch({ connector: id })}
+                className={cn(
+                  "block w-full rounded-sm border px-3 py-2.5 text-left transition-colors",
+                  active
+                    ? "border-brand bg-brand-tint"
+                    : "border-border hover:bg-accent"
+                )}
+              >
+                <span
+                  className={cn(
+                    "block text-sm font-semibold",
+                    active && "text-brand-text"
+                  )}
+                >
+                  {meta.label}
+                  {!meta.external && (
+                    <span className="ml-2 text-[11px] font-normal text-text-3">
+                      sin dependencias
+                    </span>
+                  )}
+                </span>
+                <span className="mt-0.5 block text-xs text-text-2">
+                  {meta.description}
+                </span>
+              </button>
+            );
+          })}
+        </CardContent>
+      </Card>
+
+      {settings.connector === "enlace-fijo" && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Tu sala de siempre</CardTitle>
+            <CardDescription>
+              Se comparte tal cual al confirmar una cita. Si lo dejas vacío, las
+              citas se agendan igual y sin enlace — nadie promete un enlace que
+              no existe.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Input
+              value={settings.meetingLink ?? ""}
+              onChange={(e) => patch({ meetingLink: e.target.value })}
+              placeholder="https://…  (opcional)"
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="flex items-center gap-3">
+        <Button onClick={save} disabled={saving}>
+          {saving ? "Guardando…" : "Guardar"}
+        </Button>
+        {saved && <span className="text-sm text-brand-text">Guardado</span>}
+        {error && <span className="text-sm text-destructive">{error}</span>}
+      </div>
+
+      {/* Las credenciales se guardan por su cuenta, no con el botón de arriba:
+          se validan contra el proveedor antes de tocar la base. */}
+      {settings.connector !== "enlace-fijo" && (
+        <ConnectorCredentials connector={settings.connector} />
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Próximos huecos</CardTitle>
+          <CardDescription>
+            Lo que se le ofrecería a un cliente ahora mismo.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {slots === null && <p className="text-sm text-text-3">Calculando…</p>}
+          {slots?.length === 0 && (
+            <p className="text-sm text-text-3">
+              Sin huecos: revisa el horario, el aviso mínimo o si ya está todo
+              ocupado.
+            </p>
+          )}
+          {slots && slots.length > 0 && (
+            <ul className="space-y-1 text-sm">
+              {slots.map((s, i) => (
+                <li key={i}>{s.label}</li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/settings/connector-credentials.tsx
+++ b/src/components/settings/connector-credentials.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { CONNECTOR_META, type ConnectorId } from "@/lib/agenda-connectors";
+
+/**
+ * 015 — Las credenciales de un conector externo.
+ *
+ * Se guardan por su cuenta, no con el botón de la pantalla: primero se validan
+ * CONTRA EL PROVEEDOR y solo entonces tocan la base. Unas credenciales que no
+ * sirven no llegan a guardarse — el mismo trato que el wizard de WhatsApp.
+ *
+ * Hacia fuera nunca vuelve un secreto: solo sus últimos 4 y el estado.
+ */
+
+type ExternalConnector = Exclude<ConnectorId, "enlace-fijo">;
+
+type Field = {
+  name: string;
+  label: string;
+  placeholder?: string;
+  secret?: boolean;
+  help?: string;
+};
+
+const FIELDS: Record<ExternalConnector, Field[]> = {
+  zoom: [
+    { name: "accountId", label: "Account ID", placeholder: "abc123..." },
+    { name: "clientId", label: "Client ID" },
+    { name: "clientSecret", label: "Client Secret", secret: true },
+  ],
+  google: [
+    { name: "clientId", label: "Client ID", placeholder: "…apps.googleusercontent.com" },
+    { name: "clientSecret", label: "Client Secret", secret: true },
+    {
+      name: "refreshToken",
+      label: "Refresh token",
+      secret: true,
+      help: "Se obtiene una sola vez autorizando tu propia app.",
+    },
+    {
+      name: "calendarId",
+      label: "Calendario",
+      placeholder: "primary",
+      help: "Déjalo en «primary» para tu calendario principal.",
+    },
+  ],
+};
+
+/** Lo que hay que saber ANTES de pegar nada. Son los tropiezos reales. */
+const HELP: Record<ExternalConnector, { title: string; items: string[] }> = {
+  zoom: {
+    title: "Crea una app Server-to-Server OAuth en el Marketplace de Zoom",
+    items: [
+      "Copia de ahí el Account ID, el Client ID y el Client Secret.",
+      "Dale los cuatro permisos: crear, actualizar y borrar reunión, y leer el usuario (meeting:write, meeting:update, meeting:delete y user:read).",
+      "El de leer usuario es el que usa el botón «Probar»: sin él la conexión falla aunque las credenciales sean correctas.",
+    ],
+  },
+  google: {
+    title: "Crea un proyecto en Google Cloud con la API de Calendar activada",
+    items: [
+      "Necesitas Client ID, Client Secret y un refresh token con el permiso de eventos de calendario (calendar.events).",
+      "IMPORTANTE: publica tu app OAuth «en producción». Si la dejas en modo prueba, Google revoca el permiso a los 7 días y las citas dejarán de crear su enlace sin previo aviso.",
+    ],
+  },
+};
+
+type Connection = {
+  status: "connected" | "error";
+  secretLast4: string | null;
+  fields: Record<string, string>;
+};
+
+export function ConnectorCredentials({
+  connector,
+}: {
+  connector: ExternalConnector;
+}) {
+  const meta = CONNECTOR_META[connector];
+  const fields = FIELDS[connector];
+  const help = HELP[connector];
+
+  const [connection, setConnection] = useState<Connection | null>(null);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<{
+    kind: "ok" | "error";
+    text: string;
+  } | null>(null);
+
+  useEffect(() => {
+    setConnection(null);
+    setValues({});
+    setMessage(null);
+    void (async () => {
+      const res = await fetch(`/api/settings/${connector}`).catch(() => null);
+      if (!res?.ok) return;
+      const data = (await res.json()) as { connection: Connection | null };
+      setConnection(data.connection);
+      if (data.connection) setValues({ ...data.connection.fields });
+    })();
+  }, [connector]);
+
+  async function submit(mode: "test" | "save") {
+    setBusy(true);
+    setMessage(null);
+    const url =
+      mode === "test"
+        ? `/api/settings/${connector}/test`
+        : `/api/settings/${connector}`;
+    const res = await fetch(url, {
+      method: mode === "test" ? "POST" : "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(values),
+    }).catch(() => null);
+    setBusy(false);
+
+    if (!res?.ok) {
+      const data = (await res?.json().catch(() => null)) as {
+        error?: { message?: string };
+      } | null;
+      setMessage({
+        kind: "error",
+        text:
+          data?.error?.message ??
+          `No se pudo conectar con ${meta.label}. Revisa las credenciales.`,
+      });
+      return;
+    }
+    if (mode === "test") {
+      setMessage({ kind: "ok", text: "Conexión correcta" });
+      return;
+    }
+    const data = (await res.json()) as { connection: Connection };
+    setConnection(data.connection);
+    setMessage({ kind: "ok", text: `${meta.label} conectado` });
+  }
+
+  async function disconnect() {
+    setBusy(true);
+    await fetch(`/api/settings/${connector}`, { method: "DELETE" }).catch(
+      () => null
+    );
+    setBusy(false);
+    setConnection(null);
+    setValues({});
+    setMessage(null);
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Conectar {meta.label}</CardTitle>
+        <CardDescription>{help.title}.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <ul className="list-disc space-y-1 pl-5 text-xs text-text-2">
+          {help.items.map((item, i) => (
+            <li key={i}>{item}</li>
+          ))}
+        </ul>
+
+        {connection?.status === "error" && (
+          <p className="rounded-sm border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {meta.label} rechazó las últimas credenciales. Las citas se siguen
+            agendando, pero sin enlace hasta que vuelvas a conectar.
+          </p>
+        )}
+
+        <div className="space-y-3">
+          {fields.map((f) => (
+            <div key={f.name} className="space-y-1.5">
+              <Label htmlFor={`${connector}-${f.name}`}>{f.label}</Label>
+              <Input
+                id={`${connector}-${f.name}`}
+                type={f.secret ? "password" : "text"}
+                value={values[f.name] ?? ""}
+                placeholder={
+                  f.secret && connection?.secretLast4
+                    ? `•••• ${connection.secretLast4}`
+                    : f.placeholder
+                }
+                onChange={(e) =>
+                  setValues((v) => ({ ...v, [f.name]: e.target.value }))
+                }
+              />
+              {f.help && <p className="text-xs text-text-3">{f.help}</p>}
+            </div>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <Button variant="outline" onClick={() => submit("test")} disabled={busy}>
+            Probar
+          </Button>
+          <Button onClick={() => submit("save")} disabled={busy}>
+            {connection ? "Actualizar" : "Conectar"}
+          </Button>
+          {connection && (
+            <button
+              type="button"
+              onClick={disconnect}
+              disabled={busy}
+              className="text-sm text-text-3 hover:text-foreground"
+            >
+              Desconectar
+            </button>
+          )}
+          {message && (
+            <span
+              className={
+                message.kind === "ok"
+                  ? "text-sm text-brand-text"
+                  : "text-sm text-destructive"
+              }
+            >
+              {message.text}
+            </span>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/settings/settings-nav.tsx
+++ b/src/components/settings/settings-nav.tsx
@@ -4,18 +4,26 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 
-const TABS = [
+type Tab = { href: string; label: string };
+
+const TABS: Tab[] = [
   { href: "/settings/whatsapp", label: "WhatsApp" },
   { href: "/settings/branding", label: "Marca" },
   { href: "/settings/templates", label: "Plantillas" },
   { href: "/settings/team", label: "Equipo" },
-] as const;
+];
 
-export function SettingsNav() {
+/** 015 — "Agenda" solo existe si esta instancia encendió la bandera. */
+const AGENDA_TAB: Tab = { href: "/settings/calendar", label: "Agenda" };
+
+export function SettingsNav({ agenda = false }: { agenda?: boolean }) {
   const pathname = usePathname();
+  // Qué pestañas existen lo decide el servidor y baja por prop: este es un
+  // componente de cliente y no puede leer variables de entorno.
+  const tabs = agenda ? [...TABS, AGENDA_TAB] : TABS;
   return (
     <nav className="flex shrink-0 gap-1 overflow-x-auto border-b p-2 sm:w-44 sm:flex-col sm:space-y-1 sm:overflow-visible sm:border-b-0 sm:border-r sm:p-3">
-      {TABS.map((t) => (
+      {tabs.map((t) => (
         <Link
           key={t.href}
           href={t.href}

--- a/src/components/use-events.ts
+++ b/src/components/use-events.ts
@@ -18,6 +18,8 @@ export type EventHandlers = {
     progress: { done: number; total: number };
     score?: number | null;
   }) => void;
+  /** 015 — Algo cambió en la agenda (también cuando agenda la IA). */
+  onBookingUpdated?: (data: { bookingId: string }) => void;
   /** Se llama tras RECONECTAR (no en la conexión inicial): catch-up con refetch. */
   onReconnect?: () => void;
 };
@@ -53,6 +55,9 @@ export function useEvents(handlers: EventHandlers): void {
       handlersRef.current.onConversationUpdated?.(d as never)
     );
     listen("lab.run", (d) => handlersRef.current.onLabRun?.(d as never));
+    listen("booking.updated", (d) =>
+      handlersRef.current.onBookingUpdated?.(d as never)
+    );
 
     source.onerror = () => {
       hadError = true;

--- a/src/lib/agenda-connectors.ts
+++ b/src/lib/agenda-connectors.ts
@@ -1,0 +1,78 @@
+/**
+ * 015 — El catálogo de conectores de agenda, sin dependencias de servidor.
+ *
+ * Vive en `lib/` por la misma razón que `lib/channels.ts`: la interfaz también
+ * necesita saber qué conectores existen, cómo se llaman y qué prometen, para
+ * que Ajustes → Agenda pueda ofrecerlos sin duplicar la lista a mano.
+ *
+ * Un conector es la forma en que la cita se convierte en una reunión. El motor
+ * no sabe de proveedores: PREGUNTA capacidades, igual que el envío pregunta las
+ * del canal. Agregar el tuyo en un fork es escribir su adaptador y declararlo
+ * aquí — ver docs/agenda-conectores.md.
+ */
+
+export type ConnectorId = "enlace-fijo" | "zoom" | "google";
+
+/** Orden en que se le presentan al operador. El soberano primero. */
+export const CONNECTOR_ORDER: readonly ConnectorId[] = [
+  "enlace-fijo",
+  "zoom",
+  "google",
+];
+
+export type ConnectorMeta = {
+  label: string;
+  /** Qué hace, en una línea, para la pantalla de Ajustes. */
+  description: string;
+  /** ¿Genera un link distinto por cita? (`enlace-fijo` no: es la sala de siempre.) */
+  perBookingLink: boolean;
+  /** ¿Reprogramar mueve la reunión en el proveedor? */
+  updatesMeeting: boolean;
+  /** ¿La cita aparece además en el calendario del dueño? */
+  writesCalendarEvent: boolean;
+  /**
+   * ¿Habla con un servicio de terceros? Es la puerta constitucional: los
+   * conectores externos existen solo apagados por defecto, aislados tras su
+   * adaptador y degradando sin bloquear (Principio II, 1.4.0).
+   */
+  external: boolean;
+};
+
+export const CONNECTOR_META: Record<ConnectorId, ConnectorMeta> = {
+  "enlace-fijo": {
+    label: "Enlace fijo",
+    description:
+      "Tu sala de siempre: pegas la URL una vez y cada cita la reparte. Sin conectar nada.",
+    perBookingLink: false,
+    updatesMeeting: false,
+    writesCalendarEvent: false,
+    external: false,
+  },
+  zoom: {
+    label: "Zoom",
+    description:
+      "Cada cita crea su reunión de Zoom. Reprogramar la mueve; cancelar la borra.",
+    perBookingLink: true,
+    updatesMeeting: true,
+    // Zoom sincroniza con el calendario del dueño por su cuenta, si él lo
+    // configuró allá; el CRM no lo hace ni lo sabe.
+    writesCalendarEvent: false,
+    external: true,
+  },
+  google: {
+    label: "Google Calendar + Meet",
+    description:
+      "Cada cita crea un evento en tu calendario con su enlace de Meet.",
+    perBookingLink: true,
+    updatesMeeting: true,
+    writesCalendarEvent: true,
+    external: true,
+  },
+};
+
+export function isConnectorId(value: string): value is ConnectorId {
+  return (CONNECTOR_ORDER as readonly string[]).includes(value);
+}
+
+/** El conector por defecto: el único que no depende de nadie. */
+export const DEFAULT_CONNECTOR: ConnectorId = "enlace-fijo";

--- a/src/lib/db/ids.ts
+++ b/src/lib/db/ids.ts
@@ -19,6 +19,12 @@ const prefixes = {
   testRun: "run",
   testCase: "case",
   mediaAsset: "ma",
+  // 015 — motor de agenda
+  calendarSettings: "cal",
+  booking: "bk",
+  offeredSlot: "ofs",
+  zoomCredentials: "zcred",
+  googleCredentials: "gcred",
 } as const;
 
 export type IdKind = keyof typeof prefixes;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -621,6 +621,203 @@ export const agentTestRun = pgTable(
   ]
 );
 
+/* ============================================================
+ * 015 — Motor de agenda (detrás de la bandera AGENDA)
+ *
+ * Las tablas se crean SIEMPRE, encendida o apagada la bandera: una tabla
+ * vacía es inerte, y a cambio todas las instancias del mundo comparten la
+ * misma estructura y la misma cadena de migraciones (ADR-001).
+ * ============================================================ */
+
+/** Configuración de la agenda del negocio: una fila por organización. */
+export const calendarSettings = pgTable(
+  "calendar_settings",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    /** `{"mon":[{"start":"09:00","end":"18:00"}]}` — hora de PARED, no UTC. */
+    weeklyHours: jsonb("weekly_hours").notNull(),
+    slotMinutes: integer("slot_minutes").notNull().default(30),
+    bufferMinutes: integer("buffer_minutes").notNull().default(0),
+    minNoticeHours: integer("min_notice_hours").notNull().default(2),
+    maxDaysAhead: integer("max_days_ahead").notNull().default(7),
+    timezone: text("timezone").notNull().default("America/Mexico_City"),
+    /**
+     * Cómo se entrega la reunión. `enlace-fijo` no habla con nadie: es el
+     * default y la razón de que encender la agenda no exija terceros.
+     * Un fork agrega el suyo al catálogo del código sin tocar esta columna.
+     */
+    connector: text("connector").notNull().default("enlace-fijo"),
+    /** Sala fija del conector `enlace-fijo`; null ⇒ citas sin link. */
+    meetingLink: text("meeting_link"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (t) => [uniqueIndex("calendar_settings_org_uq").on(t.organizationId)]
+);
+
+/**
+ * La cita. Una sola tabla para sesiones y bloqueos manuales: un bloqueo es
+ * una cita sin contacto que ocupa agenda igual.
+ */
+export const booking = pgTable(
+  "booking",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    kind: text("kind", { enum: ["session", "block"] })
+      .notNull()
+      .default("session"),
+    status: text("status", {
+      enum: ["agendada", "realizada", "no_show", "cancelada"],
+    })
+      .notNull()
+      .default("agendada"),
+    source: text("source", { enum: ["manual", "ai"] })
+      .notNull()
+      .default("manual"),
+    contactId: text("contact_id").references(() => contact.id, {
+      onDelete: "cascade",
+    }),
+    conversationId: text("conversation_id").references(() => conversation.id, {
+      onDelete: "set null",
+    }),
+    leadId: text("lead_id").references(() => lead.id, { onDelete: "set null" }),
+    /** Instante UTC. El horario semanal es de pared; esto ya está resuelto. */
+    scheduledAt: timestamp("scheduled_at").notNull(),
+    /** Capturada al crear: cambiar la configuración no reescribe el pasado. */
+    durationMinutes: integer("duration_minutes").notNull(),
+    /**
+     * Con qué conector nació la ENTREGA. Reprogramar y cancelar hablan con
+     * ESTE, no con el activo: si el negocio cambia de proveedor, las citas ya
+     * confirmadas siguen viviendo donde se crearon.
+     */
+    connector: text("connector"),
+    /** Id de la reunión/evento en el proveedor; null en `enlace-fijo`. */
+    externalRef: text("external_ref"),
+    /**
+     * El link que se le dio al cliente. Se COPIA, no se lee de la
+     * configuración: la cita es un hecho histórico, no una vista del presente.
+     */
+    meetingLink: text("meeting_link"),
+    /**
+     * El proveedor falló al crear la reunión. La cita existe igual —un tercero
+     * caído no cuesta la conversión— y el operador reintenta desde "Citas".
+     */
+    linkPending: boolean("link_pending").notNull().default(false),
+    /** Conversación del Laboratorio: jamás llama a un conector real. */
+    isTest: boolean("is_test").notNull().default(false),
+    notes: text("notes"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (t) => [
+    index("booking_org_when_idx").on(t.organizationId, t.scheduledAt),
+    index("booking_org_status_idx").on(t.organizationId, t.status),
+    /**
+     * Anti doble-booking ATÓMICO. La re-validación al confirmar deja una
+     * ventana entre leer y escribir; esto la cierra en la BASE: dos
+     * confirmaciones simultáneas del mismo instante no pueden ganar las dos, y
+     * la perdedora recibe un 23505 que el servicio traduce a `slot_taken` con
+     * alternativas frescas. Las citas de prueba quedan fuera: no consumen la
+     * agenda real.
+     */
+    uniqueIndex("booking_org_active_slot_uq")
+      .on(t.organizationId, t.scheduledAt)
+      .where(
+        sql`${t.status} in ('agendada','realizada') and ${t.isTest} = false`
+      ),
+  ]
+);
+
+/**
+ * La memoria de lo ofrecido. Es lo que hace verificable el requisito
+ * innegociable: sin fila aquí, no hay reserva.
+ *
+ * Vive en el CRM y no en quien conduce la conversación porque Vocero promete
+ * "conecta TU propio cerebro": con la garantía del lado del cliente, cualquier
+ * cerebro podría reservar un instante que jamás se ofreció y el CRM lo
+ * aceptaría.
+ */
+export const offeredSlot = pgTable(
+  "offered_slot",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    conversationId: text("conversation_id")
+      .notNull()
+      .references(() => conversation.id, { onDelete: "cascade" }),
+    startUtc: timestamp("start_utc").notNull(),
+    /** La etiqueta EXACTA que se le mostró al cliente. */
+    label: text("label").notNull(),
+    offeredAt: timestamp("offered_at").notNull().defaultNow(),
+  },
+  (t) => [index("offered_slot_conv_idx").on(t.conversationId, t.startUtc)]
+);
+
+/**
+ * Credenciales del conector Zoom (app Server-to-Server del propio negocio).
+ * Tabla explícita como las de WhatsApp e Instagram: unas credenciales tienen
+ * forma fija y conocida, y así conservan tipado e índices. El secreto se cifra
+ * con los mismos helpers; un segundo mecanismo sería otro que auditar.
+ */
+export const zoomCredentials = pgTable(
+  "zoom_credentials",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    accountId: text("account_id").notNull(),
+    clientId: text("client_id").notNull(),
+    secretCipher: text("secret_cipher").notNull(),
+    secretIv: text("secret_iv").notNull(),
+    secretTag: text("secret_tag").notNull(),
+    /** `error` SE ESCRIBE cuando el proveedor rechaza la autenticación. */
+    status: text("status", { enum: ["connected", "error"] })
+      .notNull()
+      .default("connected"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (t) => [uniqueIndex("zoom_credentials_org_uq").on(t.organizationId)]
+);
+
+/**
+ * Credenciales del conector Google (Calendar + Meet), de la app de Google
+ * Cloud del propio negocio. DOS secretos cifrados: el client secret y el
+ * refresh token pegado una sola vez.
+ */
+export const googleCredentials = pgTable(
+  "google_credentials",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    clientId: text("client_id").notNull(),
+    clientSecretCipher: text("client_secret_cipher").notNull(),
+    clientSecretIv: text("client_secret_iv").notNull(),
+    clientSecretTag: text("client_secret_tag").notNull(),
+    refreshTokenCipher: text("refresh_token_cipher").notNull(),
+    refreshTokenIv: text("refresh_token_iv").notNull(),
+    refreshTokenTag: text("refresh_token_tag").notNull(),
+    calendarId: text("calendar_id").notNull().default("primary"),
+    status: text("status", { enum: ["connected", "error"] })
+      .notNull()
+      .default("connected"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (t) => [uniqueIndex("google_credentials_org_uq").on(t.organizationId)]
+);
+
 export const agentTestCase = pgTable(
   "agent_test_case",
   {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -30,6 +30,18 @@ const envSchema = z.object({
   // Ej.: CHANNELS=whatsapp,instagram. Sin ella, la instancia es solo WhatsApp
   // y las superficies de los demas canales responden 404.
   CHANNELS: z.string().optional(),
+  // 015: motor de agenda. Apagado por defecto — sin el, toda la superficie de
+  // agenda responde 404 y la UI no la menciona. Ej.: AGENDA=on
+  AGENDA: z.string().optional(),
+  // 015: bases de los conectores. Solo se sobreescriben para apuntar a los
+  // mocks en el self-test; en producción se usan las reales.
+  ZOOM_BASE_URL: z.string().url().default("https://api.zoom.us/v2"),
+  ZOOM_OAUTH_BASE_URL: z.string().url().default("https://zoom.us"),
+  GOOGLE_CAL_BASE_URL: z
+    .string()
+    .url()
+    .default("https://www.googleapis.com/calendar/v3"),
+  GOOGLE_OAUTH_BASE_URL: z.string().url().default("https://oauth2.googleapis.com"),
   ALLOW_SIGNUP: z.string().optional(),
   AGENT_COALESCE_MS: z.coerce.number().int().min(0).default(6000),
   WA_MOCK_ENABLED: z.string().optional(),

--- a/src/lib/time/slots.ts
+++ b/src/lib/time/slots.ts
@@ -1,0 +1,289 @@
+/**
+ * 015 — Helpers puros de tiempo para el motor de agenda.
+ *
+ * Regla de oro: los instantes viven en UTC. La zona horaria del negocio solo
+ * sirve para (a) expandir el horario semanal, que es hora de PARED, y (b)
+ * etiquetar para el cliente.
+ *
+ * Sin dependencias: todo se resuelve con `Intl` de la plataforma, que ya trae
+ * la base de datos de zonas (verificado también en el contenedor Alpine de
+ * producción: 418 zonas y formato es-MX correcto). Ver
+ * specs/015-motor-agenda-universal/research.md D1.
+ */
+
+export type Interval = { start: string; end: string }; // "HH:mm" hora de pared
+
+export type WeekdayKey = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun";
+
+export type SlotUtc = { startUtc: string; endUtc: string };
+
+export const WEEKDAYS: WeekdayKey[] = [
+  "mon",
+  "tue",
+  "wed",
+  "thu",
+  "fri",
+  "sat",
+  "sun",
+];
+
+const HHMM = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+export function isValidInterval(iv: unknown): iv is Interval {
+  if (typeof iv !== "object" || iv === null) return false;
+  const { start, end } = iv as { start?: unknown; end?: unknown };
+  return (
+    typeof start === "string" &&
+    typeof end === "string" &&
+    HHMM.test(start) &&
+    HHMM.test(end) &&
+    start < end
+  );
+}
+
+/** ¿El runtime conoce esta zona IANA? Evita guardar basura que rompa el motor. */
+export function isValidTimeZone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Offset de la zona (minutos al este de UTC) EN un instante dado. Se formatea
+ * el instante en la zona y se lee el resultado como si fuera UTC: la
+ * diferencia es el offset vigente ahí, con DST ya aplicado.
+ */
+export function tzOffsetMinutes(date: Date, tz: string): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(date);
+
+  const map: Record<string, string> = {};
+  for (const p of parts) map[p.type] = p.value;
+  const asUtc = Date.UTC(
+    Number(map.year),
+    Number(map.month) - 1,
+    Number(map.day),
+    // Intl puede devolver "24" a medianoche en algunos entornos.
+    Number(map.hour) % 24,
+    Number(map.minute),
+    Number(map.second)
+  );
+  return (asUtc - date.getTime()) / 60_000;
+}
+
+/**
+ * Hora de pared (`YYYY-MM-DD` + `HH:mm`) en una zona → instante UTC.
+ *
+ * Dos pasadas: la primera estima el offset, la segunda lo corrige cuando el
+ * cambio de horario cae justo en ese punto. En una hora inexistente (salto de
+ * primavera) devuelve un instante real usando el offset previo; en una hora
+ * ambigua (retroceso) elige la primera ocurrencia. Nunca lanza.
+ */
+export function zonedWallClockToUtc(
+  dayISODate: string,
+  hhmm: string,
+  tz: string
+): Date | null {
+  const day = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dayISODate);
+  if (!day || !HHMM.test(hhmm)) return null;
+  const [h, m] = hhmm.split(":").map(Number) as [number, number];
+  const guess = Date.UTC(
+    Number(day[1]),
+    Number(day[2]) - 1,
+    Number(day[3]),
+    h,
+    m
+  );
+  const first = tzOffsetMinutes(new Date(guess), tz);
+  let ts = guess - first * 60_000;
+  const second = tzOffsetMinutes(new Date(ts), tz);
+  if (second !== first) ts = guess - second * 60_000;
+  return new Date(ts);
+}
+
+/** Día de la semana (mon..sun) de una fecha ISO en una zona dada. */
+export function weekdayKeyOf(dayISODate: string, tz: string): WeekdayKey | null {
+  // Mediodía: ningún offset del mundo lo empuja al día vecino.
+  const noon = zonedWallClockToUtc(dayISODate, "12:00", tz);
+  if (!noon) return null;
+  const short = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    weekday: "short",
+  })
+    .format(noon)
+    .toLowerCase();
+  const key = WEEKDAYS.find((d) => short.startsWith(d));
+  return key ?? null;
+}
+
+/** Fechas ISO (YYYY-MM-DD) de cada día del rango [from, to] inclusive. */
+export function eachDateInRange(fromISO: string, toISO: string): string[] {
+  const out: string[] = [];
+  const from = Date.parse(`${fromISO}T00:00:00Z`);
+  const to = Date.parse(`${toISO}T00:00:00Z`);
+  if (Number.isNaN(from) || Number.isNaN(to) || to < from) return out;
+  // Tope defensivo: la ventana máxima configurable es de 60 días.
+  for (let t = from, i = 0; t <= to && i < 400; t += 86_400_000, i++) {
+    out.push(new Date(t).toISOString().slice(0, 10));
+  }
+  return out;
+}
+
+/** Fecha ISO (YYYY-MM-DD) de un instante en la zona del negocio. */
+export function dayIsoInTz(instant: Date, tz: string): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(instant);
+  const map: Record<string, string> = {};
+  for (const p of parts) map[p.type] = p.value;
+  return `${map.year}-${map.month}-${map.day}`;
+}
+
+/** Fecha ISO de "hoy" en la zona del negocio. */
+export function todayInTz(now: Date, tz: string): string {
+  return dayIsoInTz(now, tz);
+}
+
+/** Suma días a una fecha ISO (sin zona: es aritmética de calendario). */
+export function addDaysISO(dayISODate: string, days: number): string {
+  const ts = Date.parse(`${dayISODate}T00:00:00Z`);
+  if (Number.isNaN(ts)) return dayISODate;
+  return new Date(ts + days * 86_400_000).toISOString().slice(0, 10);
+}
+
+/**
+ * Expande los intervalos hábiles de UN día (hora de pared en tz) a slots UTC.
+ * Avanza `slot + buffer` por paso y solo emite el slot si CABE completo dentro
+ * del intervalo.
+ */
+export function expandWorkingDayToUtc(
+  dayISODate: string,
+  intervals: Interval[],
+  tz: string,
+  slotMinutes: number,
+  bufferMinutes: number
+): SlotUtc[] {
+  const out: SlotUtc[] = [];
+  const step = slotMinutes + Math.max(0, bufferMinutes);
+  if (slotMinutes <= 0 || step <= 0) return out;
+
+  for (const iv of intervals) {
+    const start = zonedWallClockToUtc(dayISODate, iv.start, tz);
+    const end = zonedWallClockToUtc(dayISODate, iv.end, tz);
+    if (!start || !end || end <= start) continue;
+
+    for (
+      let t = start.getTime(), guard = 0;
+      t + slotMinutes * 60_000 <= end.getTime() && guard < 500;
+      t += step * 60_000, guard++
+    ) {
+      out.push({
+        startUtc: new Date(t).toISOString(),
+        endUtc: new Date(t + slotMinutes * 60_000).toISOString(),
+      });
+    }
+  }
+  return out;
+}
+
+/** ¿Se solapan [aStart,aEnd) y [bStart,bEnd)? */
+export function overlaps(
+  aStart: string,
+  aEnd: string,
+  bStart: string,
+  bEnd: string
+): boolean {
+  return (
+    Date.parse(aStart) < Date.parse(bEnd) &&
+    Date.parse(bStart) < Date.parse(aEnd)
+  );
+}
+
+/** Etiqueta legible en la zona del negocio: "mié 5 ago, 10:00". */
+export function labelInTz(startUtc: string, tz: string): string {
+  const d = new Date(startUtc);
+  if (Number.isNaN(d.getTime())) return "";
+  const parts = new Intl.DateTimeFormat("es-MX", {
+    timeZone: tz,
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(d);
+  const map: Record<string, string> = {};
+  for (const p of parts) map[p.type] = p.value;
+  const weekday = (map.weekday ?? "").replace(/\.$/, "");
+  const month = (map.month ?? "").replace(/\.$/, "");
+  return `${weekday} ${map.day} ${month}, ${map.hour}:${map.minute}`;
+}
+
+/** Solo la hora en la zona del negocio: "10:00". */
+export function timeInTz(startUtc: string, tz: string): string {
+  const d = new Date(startUtc);
+  if (Number.isNaN(d.getTime())) return "";
+  return new Intl.DateTimeFormat("es-MX", {
+    timeZone: tz,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(d);
+}
+
+/**
+ * El día EN PALABRAS, con "hoy"/"mañana" cuando aplica: "hoy viernes 7 de
+ * agosto".
+ *
+ * Existe porque la etiqueta corta no basta: en producción del fork un lead
+ * contestó "10:30, de mañana" a una oferta de HOY y se agendó el día
+ * equivocado. Quien ofrece tiene que poder decir el día completo.
+ */
+export function dayLabelInTz(startUtc: string, tz: string, now?: Date): string {
+  const d = new Date(startUtc);
+  if (Number.isNaN(d.getTime())) return "";
+  const dayIso = dayIsoInTz(d, tz);
+  const todayIso = dayIsoInTz(now ?? new Date(), tz);
+
+  let prefijo = "";
+  if (dayIso === todayIso) prefijo = "hoy ";
+  else if (dayIso === addDaysISO(todayIso, 1)) prefijo = "mañana ";
+
+  const cuerpo = new Intl.DateTimeFormat("es-MX", {
+    timeZone: tz,
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  }).format(d);
+  return `${prefijo}${cuerpo}`;
+}
+
+/** Partes por separado para la tabla de Citas. */
+export function partsInTz(
+  startUtc: string,
+  tz: string
+): { date: string; time: string; weekday: string } {
+  const d = new Date(startUtc);
+  if (Number.isNaN(d.getTime())) return { date: "", time: "", weekday: "" };
+  const fmt = (opts: Intl.DateTimeFormatOptions) =>
+    new Intl.DateTimeFormat("es-MX", { timeZone: tz, ...opts }).format(d);
+  return {
+    date: fmt({ day: "numeric", month: "short", year: "numeric" }),
+    time: fmt({ hour: "2-digit", minute: "2-digit", hour12: false }),
+    weekday: fmt({ weekday: "long" }),
+  };
+}

--- a/src/server/agenda/agent.ts
+++ b/src/server/agenda/agent.ts
@@ -1,0 +1,122 @@
+import { computeAvailability } from "@/server/agenda/availability";
+import { getSettings } from "@/server/agenda/settings";
+import { spreadByDay } from "@/server/agenda/spread";
+import { replaceOffers } from "@/server/agenda/offers";
+import { BookingError, createSessionBooking } from "@/server/agenda/service";
+
+/**
+ * 015 — Lo que el agente incluido puede hacer con la agenda.
+ *
+ * Vive aquí y no en el pipeline para que el pipeline no aprenda de agendas: el
+ * turno pide "ofrece" o "reserva" y recibe el texto que hay que mandar.
+ *
+ * Regla que atraviesa las dos operaciones: el modelo NO redacta horarios. Pide
+ * ofrecer, y el motor pega las etiquetas reales. Si el modelo inventa un
+ * instante al reservar, el motor lo rechaza y se re-ofrece — nunca se agenda
+ * algo que el cliente no eligió.
+ */
+
+/** Cuántos huecos se le enseñan al cliente en un mensaje. */
+const SHOWN = 3;
+/** Cuántos se guardan como reservables: el catálogo es más ancho que el menú. */
+const OFFERED = 12;
+
+export type AgendaTurn = {
+  /** Lo que hay que enviarle al cliente. */
+  text: string;
+  /** false ⇒ el motor no pudo; el turno sigue, sin agendar. */
+  ok: boolean;
+};
+
+export async function offerSlots(input: {
+  organizationId: string;
+  conversationId: string;
+  intro?: string;
+}): Promise<AgendaTurn> {
+  const settings = await getSettings(input.organizationId);
+  const now = new Date();
+  const all = await computeAvailability(input.organizationId, {
+    settings,
+    now,
+  });
+  const spread = spreadByDay(all, {
+    timezone: settings.timezone,
+    limit: OFFERED,
+    perDay: 3,
+    now,
+  });
+
+  if (spread.length === 0) {
+    // Agenda llena no es un error: es una respuesta que el cliente entiende.
+    return {
+      ok: false,
+      text:
+        input.intro?.trim() ||
+        "Por ahora no me quedan horarios libres. Déjame confirmarlo con el equipo y te aviso.",
+    };
+  }
+
+  // Se REGISTRA todo el catálogo, no solo lo que se enseña: si el cliente pide
+  // otro día, el agente tiene alternativas legítimas que aceptar.
+  await replaceOffers(
+    input.organizationId,
+    input.conversationId,
+    spread.map((s) => ({ startUtc: s.startUtc, label: s.label }))
+  );
+
+  const shown = spread.slice(0, SHOWN);
+  const lista = shown.map((s) => `• ${s.dayLabel} a las ${s.time}`).join("\n");
+  const intro = input.intro?.trim() || "Tengo estos horarios disponibles:";
+  return { ok: true, text: `${intro}\n${lista}` };
+}
+
+export async function bookSlot(input: {
+  organizationId: string;
+  conversationId: string;
+  startUtc: string;
+  confirmation?: string;
+}): Promise<AgendaTurn> {
+  try {
+    const result = await createSessionBooking({
+      organizationId: input.organizationId,
+      conversationId: input.conversationId,
+      startUtc: input.startUtc,
+      source: "ai",
+      requireOffer: true,
+    });
+
+    const base =
+      input.confirmation?.trim() || `¡Listo! Te agendé para ${result.label}.`;
+    if (result.meetingLink) {
+      return { ok: true, text: `${base}\nEnlace: ${result.meetingLink}` };
+    }
+    if (result.linkPending) {
+      // La cita existe; el enlace no. No se promete lo que no se tiene.
+      return {
+        ok: true,
+        text: `${base}\nEn un momento te comparto el enlace por aquí.`,
+      };
+    }
+    return { ok: true, text: base };
+  } catch (err) {
+    if (!(err instanceof BookingError)) throw err;
+
+    // Se ocupó o el modelo inventó la hora: en ambos casos se re-ofrece con
+    // datos reales en vez de discutir con el cliente.
+    if (err.slots.length > 0) {
+      const lista = err.slots
+        .slice(0, SHOWN)
+        .map((s) => `• ${s.label}`)
+        .join("\n");
+      const disculpa =
+        err.code === "slot_taken"
+          ? "Se me acaba de ocupar ese horario, ¡perdón!"
+          : "Déjame confirmarte los horarios que tengo:";
+      return { ok: false, text: `${disculpa}\n${lista}` };
+    }
+    return {
+      ok: false,
+      text: "No pude agendarlo en este momento. Lo reviso con el equipo y te confirmo.",
+    };
+  }
+}

--- a/src/server/agenda/availability.ts
+++ b/src/server/agenda/availability.ts
@@ -1,0 +1,181 @@
+import { and, eq, gte, inArray, lte } from "drizzle-orm";
+import { getDb, schema } from "@/lib/db";
+import { scoped } from "@/lib/db/tenant";
+import {
+  addDaysISO,
+  eachDateInRange,
+  expandWorkingDayToUtc,
+  labelInTz,
+  overlaps,
+  todayInTz,
+  weekdayKeyOf,
+  zonedWallClockToUtc,
+  type SlotUtc,
+} from "@/lib/time/slots";
+import { getSettings, type CalendarSettings } from "@/server/agenda/settings";
+
+/**
+ * 015 — Motor de disponibilidad:
+ *   horario semanal del negocio − citas activas − bloqueos manuales.
+ *
+ * Limitación v1 documentada (Constitución VII): NO lee calendarios externos.
+ * Es una decisión, no un olvido: meter al proveedor en este camino acoplaría su
+ * latencia y sus caídas a la pantalla que más se usa. Los compromisos de fuera
+ * se reflejan con bloqueos manuales.
+ */
+
+export type AvailableSlot = SlotUtc & { label: string };
+
+/**
+ * PURA: expande el horario semanal a slots candidatos en UTC. Sin BD, sin
+ * reloj — se testea sola (tests/unit/availability.test.ts).
+ */
+export function buildCandidateSlots(
+  settings: CalendarSettings,
+  fromISO: string,
+  toISO: string
+): SlotUtc[] {
+  const tz = settings.timezone;
+  const candidates: SlotUtc[] = [];
+  for (const date of eachDateInRange(fromISO, toISO)) {
+    const weekday = weekdayKeyOf(date, tz);
+    if (!weekday) continue;
+    const intervals = settings.weeklyHours[weekday] ?? [];
+    if (intervals.length === 0) continue; // día cerrado
+    candidates.push(
+      ...expandWorkingDayToUtc(
+        date,
+        intervals,
+        tz,
+        settings.slotMinutes,
+        settings.bufferMinutes
+      )
+    );
+  }
+  return candidates;
+}
+
+/**
+ * PURA: descarta lo que ya pasó (con aviso mínimo) y lo que se solapa con algo
+ * ocupado, ordena y etiqueta.
+ */
+export function filterFreeSlots(
+  candidates: SlotUtc[],
+  busy: SlotUtc[],
+  opts: { now: Date; minNoticeHours: number; timezone: string }
+): AvailableSlot[] {
+  const minStartMs = opts.now.getTime() + opts.minNoticeHours * 3_600_000;
+  return candidates
+    .filter((c) => Date.parse(c.startUtc) >= minStartMs)
+    .filter(
+      (c) =>
+        !busy.some((b) => overlaps(c.startUtc, c.endUtc, b.startUtc, b.endUtc))
+    )
+    .sort((a, b) => Date.parse(a.startUtc) - Date.parse(b.startUtc))
+    .map((c) => ({ ...c, label: labelInTz(c.startUtc, opts.timezone) }));
+}
+
+export async function computeAvailability(
+  organizationId: string,
+  opts?: {
+    fromISO?: string;
+    toISO?: string;
+    excludeBookingId?: string;
+    now?: Date;
+    settings?: CalendarSettings;
+  }
+): Promise<AvailableSlot[]> {
+  const settings = opts?.settings ?? (await getSettings(organizationId));
+  const now = opts?.now ?? new Date();
+  const tz = settings.timezone;
+
+  const from = opts?.fromISO ?? todayInTz(now, tz);
+  const to = opts?.toISO ?? addDaysISO(from, settings.maxDaysAhead);
+
+  const candidates = buildCandidateSlots(settings, from, to);
+  if (candidates.length === 0) return [];
+
+  const busy = await getBusyIntervals(organizationId, {
+    fromUtc: zonedWallClockToUtc(from, "00:00", tz) ?? new Date(0),
+    toUtc:
+      zonedWallClockToUtc(addDaysISO(to, 1), "00:00", tz) ??
+      new Date(now.getTime() + 86_400_000 * 61),
+    excludeBookingId: opts?.excludeBookingId,
+  });
+
+  return filterFreeSlots(candidates, busy, {
+    now,
+    minNoticeHours: settings.minNoticeHours,
+    timezone: tz,
+  });
+}
+
+/**
+ * Re-valida que un instante concreto siga libre. Se llama AL CONFIRMAR, nunca
+ * al ofrecer. `excludeBookingId` permite reprogramar sin que la propia cita se
+ * bloquee a sí misma.
+ *
+ * Solo recalcula ±1 día alrededor del instante pedido.
+ *
+ * OJO: esto reduce la ventana de la carrera, no la cierra — entre este SELECT
+ * y el INSERT cabe otra confirmación. Quien cierra de verdad es el índice
+ * único parcial de `booking` (research D7); esto existe para dar una respuesta
+ * útil (con alternativas) en el caso normal.
+ */
+export async function findSlot(
+  organizationId: string,
+  whenISO: string,
+  opts?: { excludeBookingId?: string; now?: Date; settings?: CalendarSettings }
+): Promise<AvailableSlot | null> {
+  const target = Date.parse(whenISO);
+  if (Number.isNaN(target)) return null;
+
+  const settings = opts?.settings ?? (await getSettings(organizationId));
+  const dayInTz = todayInTz(new Date(target), settings.timezone);
+
+  const slots = await computeAvailability(organizationId, {
+    fromISO: addDaysISO(dayInTz, -1),
+    toISO: addDaysISO(dayInTz, 1),
+    excludeBookingId: opts?.excludeBookingId,
+    now: opts?.now,
+    settings,
+  });
+  return slots.find((s) => Date.parse(s.startUtc) === target) ?? null;
+}
+
+async function getBusyIntervals(
+  organizationId: string,
+  input: { fromUtc: Date; toUtc: Date; excludeBookingId?: string }
+): Promise<SlotUtc[]> {
+  const db = getDb();
+  const rows = await db
+    .select({
+      id: schema.booking.id,
+      scheduledAt: schema.booking.scheduledAt,
+      durationMinutes: schema.booking.durationMinutes,
+    })
+    .from(schema.booking)
+    .where(
+      scoped(
+        schema.booking.organizationId,
+        organizationId,
+        and(
+          // Canceladas y no-show liberan el hueco.
+          inArray(schema.booking.status, ["agendada", "realizada"]),
+          // Sandbox: una cita de prueba no consume la agenda real.
+          eq(schema.booking.isTest, false),
+          gte(schema.booking.scheduledAt, input.fromUtc),
+          lte(schema.booking.scheduledAt, input.toUtc)
+        )
+      )
+    );
+
+  return rows
+    .filter((r) => r.id !== input.excludeBookingId)
+    .map((r) => ({
+      startUtc: r.scheduledAt.toISOString(),
+      endUtc: new Date(
+        r.scheduledAt.getTime() + r.durationMinutes * 60_000
+      ).toISOString(),
+    }));
+}

--- a/src/server/agenda/connectors/enlace-fijo.ts
+++ b/src/server/agenda/connectors/enlace-fijo.ts
@@ -1,0 +1,31 @@
+import type { AgendaConnector, MeetingResult } from "@/server/agenda/connectors/types";
+
+/**
+ * 015 — El conector soberano: la sala de siempre.
+ *
+ * No habla con nadie. Es el default y la razón de que encender la agenda no
+ * exija credenciales de terceros — y, en términos constitucionales, el "camino
+ * sin dependencia externa" que hace admisibles a los demás (Principio II,
+ * 1.4.0).
+ */
+
+export type EnlaceFijoCreds = { meetingLink: string | null };
+
+export const enlaceFijoConnector: AgendaConnector<EnlaceFijoCreds> = {
+  id: "enlace-fijo",
+  requiresCredentials: false,
+
+  async createMeeting(creds): Promise<MeetingResult> {
+    // Sin sala configurada la cita se crea igual, sin link: nadie debe
+    // prometerle al cliente un enlace que no existe.
+    return { externalId: null, joinUrl: creds.meetingLink };
+  },
+
+  // La sala fija no se mueve ni se borra: es la misma todos los días.
+  async updateMeeting() {},
+  async deleteMeeting() {},
+
+  async testConnection() {
+    return { ok: true, detail: "El enlace fijo no requiere conexión" };
+  },
+};

--- a/src/server/agenda/connectors/google-credentials.ts
+++ b/src/server/agenda/connectors/google-credentials.ts
@@ -1,0 +1,141 @@
+import { getDb, schema } from "@/lib/db";
+import { newId } from "@/lib/db/ids";
+import { decryptSecret, encryptSecret } from "@/lib/crypto";
+import { scoped } from "@/lib/db/tenant";
+
+/**
+ * 015 — Credenciales de la app de Google Cloud del propio negocio.
+ *
+ * DOS secretos cifrados: el client secret y el refresh token que el dueño pega
+ * una sola vez. Mismo mecanismo AES-256-GCM que el resto.
+ */
+
+export type GoogleCreds = {
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+  calendarId: string;
+  status: "connected" | "error";
+};
+
+export async function getGoogleCredentials(
+  organizationId: string
+): Promise<GoogleCreds | null> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(schema.googleCredentials)
+    .where(scoped(schema.googleCredentials.organizationId, organizationId))
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    clientId: row.clientId,
+    clientSecret: decryptSecret({
+      cipher: row.clientSecretCipher,
+      iv: row.clientSecretIv,
+      tag: row.clientSecretTag,
+    }),
+    refreshToken: decryptSecret({
+      cipher: row.refreshTokenCipher,
+      iv: row.refreshTokenIv,
+      tag: row.refreshTokenTag,
+    }),
+    calendarId: row.calendarId,
+    status: row.status,
+  };
+}
+
+export async function saveGoogleCredentials(input: {
+  organizationId: string;
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+  calendarId?: string | null;
+}): Promise<void> {
+  const db = getDb();
+  const secret = encryptSecret(input.clientSecret);
+  const refresh = encryptSecret(input.refreshToken);
+  const values = {
+    clientId: input.clientId,
+    clientSecretCipher: secret.cipher,
+    clientSecretIv: secret.iv,
+    clientSecretTag: secret.tag,
+    refreshTokenCipher: refresh.cipher,
+    refreshTokenIv: refresh.iv,
+    refreshTokenTag: refresh.tag,
+    calendarId: input.calendarId?.trim() || "primary",
+    status: "connected" as const,
+  };
+  await db
+    .insert(schema.googleCredentials)
+    .values({
+      id: newId("googleCredentials"),
+      organizationId: input.organizationId,
+      ...values,
+    })
+    .onConflictDoUpdate({
+      target: [schema.googleCredentials.organizationId],
+      set: { ...values, updatedAt: new Date() },
+    });
+  clearGoogleTokenCache();
+}
+
+export async function deleteGoogleCredentials(
+  organizationId: string
+): Promise<void> {
+  const db = getDb();
+  await db
+    .delete(schema.googleCredentials)
+    .where(scoped(schema.googleCredentials.organizationId, organizationId));
+  clearGoogleTokenCache();
+}
+
+/** El estado `error` se escribe de verdad (ver zoom-credentials). */
+export async function markGoogleError(organizationId: string): Promise<void> {
+  const db = getDb();
+  await db
+    .update(schema.googleCredentials)
+    .set({ status: "error", updatedAt: new Date() })
+    .where(scoped(schema.googleCredentials.organizationId, organizationId));
+}
+
+export function secretLast4(secret: string): string {
+  return secret.slice(-4);
+}
+
+/* Caché del access token, por proceso. Google los emite de una hora. */
+
+type CachedToken = { token: string; expiresAtMs: number };
+
+const globalForGoogle = globalThis as unknown as {
+  __googleTokens?: Map<string, CachedToken>;
+};
+
+function tokenCache(): Map<string, CachedToken> {
+  if (!globalForGoogle.__googleTokens) globalForGoogle.__googleTokens = new Map();
+  return globalForGoogle.__googleTokens;
+}
+
+export function getCachedGoogleToken(key: string): string | null {
+  const hit = tokenCache().get(key);
+  if (!hit) return null;
+  if (hit.expiresAtMs <= Date.now()) {
+    tokenCache().delete(key);
+    return null;
+  }
+  return hit.token;
+}
+
+export function setCachedGoogleToken(
+  key: string,
+  token: string,
+  expiresInSeconds: number
+): void {
+  const ttl = Math.max(30, expiresInSeconds - 60) * 1000;
+  tokenCache().set(key, { token, expiresAtMs: Date.now() + ttl });
+}
+
+export function clearGoogleTokenCache(): void {
+  tokenCache().clear();
+}

--- a/src/server/agenda/connectors/google.ts
+++ b/src/server/agenda/connectors/google.ts
@@ -1,0 +1,240 @@
+import { getEnv } from "@/lib/env";
+import {
+  ConnectorError,
+  type AgendaConnector,
+  type MeetingRequest,
+  type MeetingResult,
+  type TestConnectionResult,
+} from "@/server/agenda/connectors/types";
+import {
+  getCachedGoogleToken,
+  setCachedGoogleToken,
+  type GoogleCreds,
+} from "@/server/agenda/connectors/google-credentials";
+
+/**
+ * 015 — Conector Google Calendar + Meet, por REST directo (sin SDK: la
+ * constitución no admite dependencias nuevas para esto).
+ *
+ * Cada cita se convierte en un evento del calendario del dueño con su enlace
+ * de Meet. Es el conector con un diferencial claro: la cita aparece donde el
+ * dueño ya mira su día.
+ *
+ * DOS cosas de Google que dan problemas y aquí están resueltas a propósito:
+ *
+ *  1. **La conferencia se crea de forma ASÍNCRONA.** La respuesta inmediata de
+ *     `events.insert` puede traer `conferenceData.createRequest.status =
+ *     "pending"` y ningún enlace. Por eso se re-lee el evento unas pocas veces
+ *     antes de rendirse; y si aun así no llegó, la cita se entrega con el
+ *     evento creado y el enlace pendiente (reintentable), nunca duplicando.
+ *  2. **El refresh token caduca a los 7 días si la app OAuth está en modo
+ *     prueba.** Eso no se puede arreglar desde aquí: se advierte en la guía de
+ *     conexión, y cuando pasa, el 401 marca la credencial como rota para que
+ *     el dueño se entere por la UI y no por un cliente sin enlace.
+ */
+
+export const GOOGLE_SCOPE = "https://www.googleapis.com/auth/calendar.events";
+
+/** Cuántas veces se re-lee el evento esperando el enlace de Meet. */
+const CONFERENCE_POLLS = 3;
+const POLL_DELAY_MS = 400;
+
+async function getAccessToken(creds: GoogleCreds): Promise<string> {
+  const key = `${creds.clientId}:${creds.calendarId}`;
+  const cached = getCachedGoogleToken(key);
+  if (cached) return cached;
+
+  let res: Response;
+  try {
+    res = await fetch(`${getEnv().GOOGLE_OAUTH_BASE_URL}/token`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: creds.clientId,
+        client_secret: creds.clientSecret,
+        refresh_token: creds.refreshToken,
+        grant_type: "refresh_token",
+      }).toString(),
+    });
+  } catch (err) {
+    throw new ConnectorError("google", `No se pudo contactar a Google: ${err}`);
+  }
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new ConnectorError(
+      "google",
+      `Google rechazó el refresh token: ${detail}. Si tu app OAuth sigue en modo prueba, Google lo revoca a los 7 días: publícala en producción y vuelve a conectar.`,
+      // `invalid_grant` llega como 400 y significa exactamente eso: hay que
+      // reconectar.
+      { status: res.status, isAuthError: res.status === 401 || res.status === 400 }
+    );
+  }
+
+  const data = (await res.json().catch(() => null)) as {
+    access_token?: string;
+    expires_in?: number;
+  } | null;
+  if (!data?.access_token) {
+    throw new ConnectorError("google", "Google no devolvió un token de acceso");
+  }
+  setCachedGoogleToken(key, data.access_token, data.expires_in ?? 3600);
+  return data.access_token;
+}
+
+async function googleFetch(
+  creds: GoogleCreds,
+  path: string,
+  init: RequestInit & { allow404?: boolean } = {}
+): Promise<unknown> {
+  const token = await getAccessToken(creds);
+  let res: Response;
+  try {
+    res = await fetch(`${getEnv().GOOGLE_CAL_BASE_URL}${path}`, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        ...(init.headers ?? {}),
+      },
+    });
+  } catch (err) {
+    throw new ConnectorError("google", `No se pudo contactar a Google: ${err}`);
+  }
+
+  if (res.status === 404 && init.allow404) return null;
+  if (res.status === 204) return null;
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new ConnectorError(
+      "google",
+      `Google respondió ${res.status}: ${detail}`,
+      { status: res.status }
+    );
+  }
+  return await res.json().catch(() => null);
+}
+
+type GoogleEvent = {
+  id?: string;
+  hangoutLink?: string;
+  conferenceData?: {
+    createRequest?: { status?: { statusCode?: string } };
+    entryPoints?: { entryPointType?: string; uri?: string }[];
+  };
+};
+
+/** El enlace de la videollamada, mire donde mire Google. */
+function meetLinkOf(event: GoogleEvent | null): string | null {
+  if (!event) return null;
+  const video = event.conferenceData?.entryPoints?.find(
+    (e) => e.entryPointType === "video"
+  );
+  return video?.uri ?? event.hangoutLink ?? null;
+}
+
+function eventsPath(creds: GoogleCreds, suffix = ""): string {
+  return `/calendars/${encodeURIComponent(creds.calendarId)}/events${suffix}`;
+}
+
+export const googleConnector: AgendaConnector<GoogleCreds> = {
+  id: "google",
+  requiresCredentials: true,
+
+  async createMeeting(creds, req: MeetingRequest): Promise<MeetingResult> {
+    const endUtc = new Date(
+      Date.parse(req.startUtc) + req.durationMinutes * 60_000
+    ).toISOString();
+
+    const created = (await googleFetch(
+      creds,
+      `${eventsPath(creds)}?conferenceDataVersion=1`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          summary: req.topic,
+          description: req.notes ?? undefined,
+          start: { dateTime: req.startUtc, timeZone: "UTC" },
+          end: { dateTime: endUtc, timeZone: "UTC" },
+          conferenceData: {
+            createRequest: {
+              // Google exige un id de petición propio; el instante lo hace
+              // único por cita sin necesitar aleatoriedad.
+              requestId: `vocero-${Date.parse(req.startUtc)}`,
+              conferenceSolutionKey: { type: "hangoutsMeet" },
+            },
+          },
+        }),
+      }
+    )) as GoogleEvent | null;
+
+    const eventId = created?.id ?? null;
+    if (!eventId) {
+      throw new ConnectorError("google", "Google no devolvió el evento creado");
+    }
+
+    let link = meetLinkOf(created);
+    // La conferencia se genera en segundo plano: la respuesta del insert suele
+    // venir `pending`. Se re-lee un par de veces antes de rendirse.
+    for (let i = 0; i < CONFERENCE_POLLS && !link; i++) {
+      await sleep(POLL_DELAY_MS);
+      const refreshed = (await googleFetch(
+        creds,
+        `${eventsPath(creds, `/${encodeURIComponent(eventId)}`)}`
+      ).catch(() => null)) as GoogleEvent | null;
+      link = meetLinkOf(refreshed);
+    }
+
+    // Con el evento creado y sin enlace, el motor deja la cita "sin enlace" y
+    // el operador reintenta: eso re-lee este mismo evento, no crea otro.
+    return { externalId: eventId, joinUrl: link };
+  },
+
+  async refreshMeeting(creds, externalId): Promise<MeetingResult> {
+    const event = (await googleFetch(
+      creds,
+      eventsPath(creds, `/${encodeURIComponent(externalId)}`)
+    )) as GoogleEvent | null;
+    return { externalId, joinUrl: meetLinkOf(event) };
+  },
+
+  async updateMeeting(creds, externalId, req): Promise<void> {
+    const endUtc = new Date(
+      Date.parse(req.startUtc) + req.durationMinutes * 60_000
+    ).toISOString();
+    await googleFetch(creds, eventsPath(creds, `/${encodeURIComponent(externalId)}`), {
+      method: "PATCH",
+      body: JSON.stringify({
+        start: { dateTime: req.startUtc, timeZone: "UTC" },
+        end: { dateTime: endUtc, timeZone: "UTC" },
+      }),
+    });
+  },
+
+  async deleteMeeting(creds, externalId): Promise<void> {
+    await googleFetch(creds, eventsPath(creds, `/${encodeURIComponent(externalId)}`), {
+      method: "DELETE",
+      allow404: true,
+    });
+  },
+
+  async testConnection(creds): Promise<TestConnectionResult> {
+    try {
+      const cal = (await googleFetch(
+        creds,
+        `/calendars/${encodeURIComponent(creds.calendarId)}`
+      )) as { summary?: string } | null;
+      return { ok: true, detail: cal?.summary };
+    } catch (err) {
+      return {
+        ok: false,
+        error:
+          err instanceof Error ? err.message : "No se pudo conectar con Google",
+      };
+    }
+  },
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/server/agenda/connectors/index.ts
+++ b/src/server/agenda/connectors/index.ts
@@ -8,6 +8,16 @@ import {
   type TestConnectionResult,
 } from "@/server/agenda/connectors/types";
 import { enlaceFijoConnector } from "@/server/agenda/connectors/enlace-fijo";
+import { zoomConnector } from "@/server/agenda/connectors/zoom";
+import {
+  getZoomCredentials,
+  markZoomError,
+} from "@/server/agenda/connectors/zoom-credentials";
+import { googleConnector } from "@/server/agenda/connectors/google";
+import {
+  getGoogleCredentials,
+  markGoogleError,
+} from "@/server/agenda/connectors/google-credentials";
 
 /**
  * 015 — El catálogo de conectores y la ÚNICA puerta por la que el motor habla
@@ -29,9 +39,12 @@ export type BoundConnector = {
   ): Promise<void>;
   deleteMeeting(externalId: string): Promise<void>;
   testConnection(): Promise<TestConnectionResult>;
+  /** Solo si el conector la implementa (enlaces asíncronos). */
+  refreshMeeting?: (externalId: string) => Promise<MeetingResult>;
 };
 
 function bind<C>(conn: AgendaConnector<C>, creds: C): BoundConnector {
+  const refresh = conn.refreshMeeting;
   return {
     id: conn.id,
     createMeeting: (req) => conn.createMeeting(creds, req),
@@ -39,6 +52,9 @@ function bind<C>(conn: AgendaConnector<C>, creds: C): BoundConnector {
       conn.updateMeeting(creds, externalId, req),
     deleteMeeting: (externalId) => conn.deleteMeeting(creds, externalId),
     testConnection: () => conn.testConnection(creds),
+    refreshMeeting: refresh
+      ? (externalId) => refresh.call(conn, creds, externalId)
+      : undefined,
   };
 }
 
@@ -59,13 +75,27 @@ export async function bindConnector(
     case "enlace-fijo":
       return bind(enlaceFijoConnector, { meetingLink: settings.meetingLink });
 
-    case "zoom":
-    case "google":
-      // Se registran en sus fases (US5 / US6).
-      throw new ConnectorError(
-        connectorId,
-        `El conector ${connectorId} no está disponible en esta instalación`
-      );
+    case "zoom": {
+      const creds = await getZoomCredentials(organizationId);
+      if (!creds) {
+        throw new ConnectorError(
+          "zoom",
+          "Zoom no está conectado: faltan las credenciales"
+        );
+      }
+      return bind(zoomConnector, creds);
+    }
+
+    case "google": {
+      const creds = await getGoogleCredentials(organizationId);
+      if (!creds) {
+        throw new ConnectorError(
+          "google",
+          "Google no está conectado: faltan las credenciales"
+        );
+      }
+      return bind(googleConnector, creds);
+    }
   }
 }
 
@@ -86,8 +116,10 @@ export async function markConnectorAuthError(
     case "enlace-fijo":
       return;
     case "zoom":
+      await markZoomError(organizationId);
+      return;
     case "google":
-      // Se implementa junto a su tabla de credenciales (US5 / US6).
+      await markGoogleError(organizationId);
       return;
   }
 }

--- a/src/server/agenda/connectors/index.ts
+++ b/src/server/agenda/connectors/index.ts
@@ -1,0 +1,93 @@
+import { type ConnectorId } from "@/lib/agenda-connectors";
+import type { CalendarSettings } from "@/server/agenda/settings";
+import {
+  ConnectorError,
+  type AgendaConnector,
+  type MeetingRequest,
+  type MeetingResult,
+  type TestConnectionResult,
+} from "@/server/agenda/connectors/types";
+import { enlaceFijoConnector } from "@/server/agenda/connectors/enlace-fijo";
+
+/**
+ * 015 — El catálogo de conectores y la ÚNICA puerta por la que el motor habla
+ * con un proveedor.
+ *
+ * El servicio de citas no conoce credenciales ni proveedores: pide "entrega
+ * esta reunión" y aquí se resuelve con qué y con qué llaves. Por eso agregar un
+ * conector en un fork no toca ni una línea del motor: se escribe su adaptador,
+ * su tabla de credenciales y una rama de este `switch`.
+ */
+
+/** Un conector con sus credenciales ya resueltas: el genérico queda borrado. */
+export type BoundConnector = {
+  id: ConnectorId;
+  createMeeting(req: MeetingRequest): Promise<MeetingResult>;
+  updateMeeting(
+    externalId: string,
+    req: Pick<MeetingRequest, "startUtc" | "durationMinutes" | "timezone">
+  ): Promise<void>;
+  deleteMeeting(externalId: string): Promise<void>;
+  testConnection(): Promise<TestConnectionResult>;
+};
+
+function bind<C>(conn: AgendaConnector<C>, creds: C): BoundConnector {
+  return {
+    id: conn.id,
+    createMeeting: (req) => conn.createMeeting(creds, req),
+    updateMeeting: (externalId, req) =>
+      conn.updateMeeting(creds, externalId, req),
+    deleteMeeting: (externalId) => conn.deleteMeeting(creds, externalId),
+    testConnection: () => conn.testConnection(creds),
+  };
+}
+
+/**
+ * Resuelve el conector pedido con las credenciales de esta organización.
+ *
+ * Lanza `ConnectorError` si el conector no está disponible o le faltan
+ * credenciales. El motor traduce esa excepción a "cita creada con enlace
+ * pendiente", que es honesto — en vez de entregar en silencio el enlace de
+ * otro conector.
+ */
+export async function bindConnector(
+  organizationId: string,
+  connectorId: ConnectorId,
+  settings: CalendarSettings
+): Promise<BoundConnector> {
+  switch (connectorId) {
+    case "enlace-fijo":
+      return bind(enlaceFijoConnector, { meetingLink: settings.meetingLink });
+
+    case "zoom":
+    case "google":
+      // Se registran en sus fases (US5 / US6).
+      throw new ConnectorError(
+        connectorId,
+        `El conector ${connectorId} no está disponible en esta instalación`
+      );
+  }
+}
+
+/**
+ * Marca la credencial del conector como rota tras un error de autenticación,
+ * para que Ajustes muestre la tarjeta de reconexión. `enlace-fijo` no tiene
+ * credenciales que marcar.
+ *
+ * Es lo que evita el fallo silencioso del fork, donde el estado `error` existe
+ * como enum y nadie lo escribe: el dueño se entera de que su conexión murió
+ * por el cliente que no recibió su enlace.
+ */
+export async function markConnectorAuthError(
+  organizationId: string,
+  connectorId: ConnectorId
+): Promise<void> {
+  switch (connectorId) {
+    case "enlace-fijo":
+      return;
+    case "zoom":
+    case "google":
+      // Se implementa junto a su tabla de credenciales (US5 / US6).
+      return;
+  }
+}

--- a/src/server/agenda/connectors/types.ts
+++ b/src/server/agenda/connectors/types.ts
@@ -1,0 +1,90 @@
+import type { ConnectorId } from "@/lib/agenda-connectors";
+
+/**
+ * 015 — El contrato público de un conector de agenda.
+ *
+ * Deliberadamente pequeño: CUATRO operaciones, medidas del uso real en
+ * producción de la integración de Zoom del fork de agencia — ni una más en
+ * meses de operación. Ver specs/015-motor-agenda-universal/contracts/conector.md.
+ *
+ * Lo que NO está aquí y es a propósito: leer disponibilidad ajena (free/busy).
+ * La disponibilidad se calcula 100% local, con una query y aritmética; meter al
+ * proveedor en ese camino acoplaría su latencia y sus caídas a la pantalla que
+ * más se usa. Los compromisos de fuera se reflejan con bloqueos manuales.
+ *
+ * Reglas que hace cumplir el MOTOR, no cada conector:
+ *  1. Los efectos corren DESPUÉS de escribir la verdad en el CRM y son
+ *     best-effort: una excepción de aquí jamás revierte ni bloquea la cita.
+ *  2. Una cita de prueba del Laboratorio NUNCA llega hasta aquí — la aserción
+ *     vive antes de la bifurcación por conector. Un conector no comprueba
+ *     `is_test`: no le toca.
+ */
+
+export type MeetingRequest = {
+  /** "Cita — <nombre del contacto>". */
+  topic: string;
+  /** Instante UTC ISO-8601 con Z. */
+  startUtc: string;
+  durationMinutes: number;
+  /** Zona IANA del negocio: el proveedor la usa para mostrarla a los suyos. */
+  timezone: string;
+  notes?: string;
+};
+
+export type MeetingResult = {
+  /** Id de la reunión/evento en el proveedor; null si no genera uno. */
+  externalId: string | null;
+  /** Lo que se le comparte al cliente; null si este conector no da link. */
+  joinUrl: string | null;
+};
+
+export type TestConnectionResult =
+  | { ok: true; detail?: string }
+  | { ok: false; error: string };
+
+export type AgendaConnector<Creds> = {
+  id: ConnectorId;
+  /** ¿Necesita credenciales guardadas para operar? */
+  requiresCredentials: boolean;
+
+  createMeeting(creds: Creds, req: MeetingRequest): Promise<MeetingResult>;
+
+  updateMeeting(
+    creds: Creds,
+    externalId: string,
+    req: Pick<MeetingRequest, "startUtc" | "durationMinutes" | "timezone">
+  ): Promise<void>;
+
+  /** Idempotente: un 404 del proveedor es éxito (ya no estaba). */
+  deleteMeeting(creds: Creds, externalId: string): Promise<void>;
+
+  testConnection(creds: Creds): Promise<TestConnectionResult>;
+};
+
+/**
+ * Error de un conector. `isAuthError` no es decorativo: cuando es true, el
+ * motor marca la credencial como rota y la UI muestra la tarjeta de
+ * reconexión. En el fork existe un helper igual que nadie consume y un estado
+ * `error` que nunca se escribe — el aviso no llega y el dueño se entera por
+ * el cliente que no recibió su link.
+ */
+export class ConnectorError extends Error {
+  readonly connectorId: ConnectorId;
+  readonly status: number | null;
+  readonly isAuthError: boolean;
+
+  constructor(
+    connectorId: ConnectorId,
+    message: string,
+    opts?: { status?: number | null; isAuthError?: boolean }
+  ) {
+    super(message);
+    this.name = "ConnectorError";
+    this.connectorId = connectorId;
+    this.status = opts?.status ?? null;
+    // Criterio estricto: SOLO 401. El helper del fork trata cualquier 400 como
+    // problema de credenciales, y un 400 de validación marcaría la conexión
+    // como rota sin estarlo.
+    this.isAuthError = opts?.isAuthError ?? opts?.status === 401;
+  }
+}

--- a/src/server/agenda/connectors/types.ts
+++ b/src/server/agenda/connectors/types.ts
@@ -59,6 +59,18 @@ export type AgendaConnector<Creds> = {
   deleteMeeting(creds: Creds, externalId: string): Promise<void>;
 
   testConnection(creds: Creds): Promise<TestConnectionResult>;
+
+  /**
+   * OPCIONAL: vuelve a leer una reunión ya creada.
+   *
+   * Existe por los proveedores que generan el enlace de forma asíncrona
+   * (Google crea la conferencia en segundo plano y su respuesta inmediata
+   * puede venir `pending`). Sin esto, "Reintentar enlace" sobre una cita que ya
+   * tiene evento crearía un DUPLICADO en el calendario del dueño.
+   *
+   * Un conector cuyo enlace llega de inmediato —Zoom— no la necesita.
+   */
+  refreshMeeting?(creds: Creds, externalId: string): Promise<MeetingResult>;
 };
 
 /**

--- a/src/server/agenda/connectors/zoom-credentials.ts
+++ b/src/server/agenda/connectors/zoom-credentials.ts
@@ -1,0 +1,144 @@
+import { getDb, schema } from "@/lib/db";
+import { newId } from "@/lib/db/ids";
+import { decryptSecret, encryptSecret } from "@/lib/crypto";
+import { scoped } from "@/lib/db/tenant";
+
+/**
+ * 015 — Credenciales de la app Server-to-Server de Zoom del propio negocio.
+ *
+ * Mismo mecanismo de cifrado que el token de WhatsApp: un segundo mecanismo
+ * sería un segundo mecanismo que auditar. Hacia fuera solo salen los últimos 4
+ * del secreto.
+ */
+
+export type ZoomCreds = {
+  accountId: string;
+  clientId: string;
+  clientSecret: string;
+  status: "connected" | "error";
+};
+
+export async function getZoomCredentials(
+  organizationId: string
+): Promise<ZoomCreds | null> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(schema.zoomCredentials)
+    .where(scoped(schema.zoomCredentials.organizationId, organizationId))
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    accountId: row.accountId,
+    clientId: row.clientId,
+    clientSecret: decryptSecret({
+      cipher: row.secretCipher,
+      iv: row.secretIv,
+      tag: row.secretTag,
+    }),
+    status: row.status,
+  };
+}
+
+export async function saveZoomCredentials(input: {
+  organizationId: string;
+  accountId: string;
+  clientId: string;
+  clientSecret: string;
+}): Promise<void> {
+  const db = getDb();
+  const enc = encryptSecret(input.clientSecret);
+  const values = {
+    accountId: input.accountId,
+    clientId: input.clientId,
+    secretCipher: enc.cipher,
+    secretIv: enc.iv,
+    secretTag: enc.tag,
+    status: "connected" as const,
+  };
+  await db
+    .insert(schema.zoomCredentials)
+    .values({
+      id: newId("zoomCredentials"),
+      organizationId: input.organizationId,
+      ...values,
+    })
+    .onConflictDoUpdate({
+      target: [schema.zoomCredentials.organizationId],
+      set: { ...values, updatedAt: new Date() },
+    });
+  // El token cacheado se emitió con las credenciales viejas.
+  clearZoomTokenCache();
+}
+
+export async function deleteZoomCredentials(
+  organizationId: string
+): Promise<void> {
+  const db = getDb();
+  await db
+    .delete(schema.zoomCredentials)
+    .where(scoped(schema.zoomCredentials.organizationId, organizationId));
+  clearZoomTokenCache();
+}
+
+/**
+ * Marca la conexión como rota. Se ESCRIBE de verdad, en el momento en que el
+ * proveedor rechaza la autenticación: si nadie lo escribiera, el dueño se
+ * enteraría por el cliente que no recibió su enlace.
+ */
+export async function markZoomError(organizationId: string): Promise<void> {
+  const db = getDb();
+  await db
+    .update(schema.zoomCredentials)
+    .set({ status: "error", updatedAt: new Date() })
+    .where(scoped(schema.zoomCredentials.organizationId, organizationId));
+}
+
+/** Últimos 4 del secreto, para la UI. Jamás el secreto. */
+export function secretLast4(secret: string): string {
+  return secret.slice(-4);
+}
+
+/* --------------------------------------------------------------------------
+ * Caché del token de acceso, por proceso.
+ *
+ * Zoom emite un token de vida corta por cada llamada al endpoint de OAuth;
+ * pedir uno nuevo en cada cita es una llamada de red de más y un límite de tasa
+ * que se acerca. Se renueva 60 s antes de expirar, y se invalida al cambiar o
+ * borrar las credenciales.
+ * ------------------------------------------------------------------------ */
+
+type CachedToken = { token: string; expiresAtMs: number };
+
+const globalForZoom = globalThis as unknown as {
+  __zoomTokens?: Map<string, CachedToken>;
+};
+
+function tokenCache(): Map<string, CachedToken> {
+  if (!globalForZoom.__zoomTokens) globalForZoom.__zoomTokens = new Map();
+  return globalForZoom.__zoomTokens;
+}
+
+export function getCachedZoomToken(key: string): string | null {
+  const hit = tokenCache().get(key);
+  if (!hit) return null;
+  if (hit.expiresAtMs <= Date.now()) {
+    tokenCache().delete(key);
+    return null;
+  }
+  return hit.token;
+}
+
+export function setCachedZoomToken(
+  key: string,
+  token: string,
+  expiresInSeconds: number
+): void {
+  const ttl = Math.max(30, expiresInSeconds - 60) * 1000;
+  tokenCache().set(key, { token, expiresAtMs: Date.now() + ttl });
+}
+
+export function clearZoomTokenCache(): void {
+  tokenCache().clear();
+}

--- a/src/server/agenda/connectors/zoom.ts
+++ b/src/server/agenda/connectors/zoom.ts
@@ -1,0 +1,176 @@
+import { getEnv } from "@/lib/env";
+import {
+  ConnectorError,
+  type AgendaConnector,
+  type MeetingRequest,
+  type MeetingResult,
+  type TestConnectionResult,
+} from "@/server/agenda/connectors/types";
+import {
+  getCachedZoomToken,
+  setCachedZoomToken,
+  type ZoomCreds,
+} from "@/server/agenda/connectors/zoom-credentials";
+
+/**
+ * 015 — Conector Zoom (Server-to-Server OAuth).
+ *
+ * Es el conector de referencia: su forma exacta lleva meses en producción en un
+ * CRM real, y el contrato de conectores se midió de este uso.
+ *
+ * Frontera única de salida hacia Zoom: fuera de este archivo, nadie sabe que
+ * Zoom existe.
+ */
+
+/**
+ * Los CUATRO scopes granulares que hacen falta. `user:read:user` es el que se
+ * olvida —lo usa la prueba de conexión— y sin él conectar falla aunque las
+ * credenciales sirvan para crear reuniones.
+ */
+export const ZOOM_SCOPES = [
+  "meeting:write:meeting",
+  "meeting:update:meeting",
+  "meeting:delete:meeting",
+  "user:read:user",
+] as const;
+
+async function getAccessToken(creds: ZoomCreds): Promise<string> {
+  const key = `${creds.accountId}:${creds.clientId}`;
+  const cached = getCachedZoomToken(key);
+  if (cached) return cached;
+
+  const base = getEnv().ZOOM_OAUTH_BASE_URL;
+  const url = `${base}/oauth/token?grant_type=account_credentials&account_id=${encodeURIComponent(
+    creds.accountId
+  )}`;
+  const basic = Buffer.from(`${creds.clientId}:${creds.clientSecret}`).toString(
+    "base64"
+  );
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: { Authorization: `Basic ${basic}` },
+    });
+  } catch (err) {
+    throw new ConnectorError("zoom", `No se pudo contactar a Zoom: ${err}`);
+  }
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new ConnectorError("zoom", `Zoom rechazó las credenciales: ${detail}`, {
+      status: res.status,
+      // El endpoint de token responde 400 cuando las credenciales no sirven:
+      // aquí un 400 SÍ es un problema de autenticación, a diferencia del resto
+      // de la API, donde suele ser una validación del cuerpo.
+      isAuthError: res.status === 401 || res.status === 400,
+    });
+  }
+
+  const data = (await res.json().catch(() => null)) as {
+    access_token?: string;
+    expires_in?: number;
+  } | null;
+  if (!data?.access_token) {
+    throw new ConnectorError("zoom", "Zoom no devolvió un token de acceso");
+  }
+  setCachedZoomToken(key, data.access_token, data.expires_in ?? 3600);
+  return data.access_token;
+}
+
+async function zoomFetch(
+  creds: ZoomCreds,
+  path: string,
+  init: RequestInit & { allow404?: boolean } = {}
+): Promise<unknown> {
+  const token = await getAccessToken(creds);
+  const url = `${getEnv().ZOOM_BASE_URL}${path}`;
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        ...(init.headers ?? {}),
+      },
+    });
+  } catch (err) {
+    throw new ConnectorError("zoom", `No se pudo contactar a Zoom: ${err}`);
+  }
+
+  // Idempotencia: borrar algo que ya no está es objetivo cumplido.
+  if (res.status === 404 && init.allow404) return null;
+  if (res.status === 204) return null;
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new ConnectorError("zoom", `Zoom respondió ${res.status}: ${detail}`, {
+      status: res.status,
+    });
+  }
+  return await res.json().catch(() => null);
+}
+
+export const zoomConnector: AgendaConnector<ZoomCreds> = {
+  id: "zoom",
+  requiresCredentials: true,
+
+  async createMeeting(creds, req: MeetingRequest): Promise<MeetingResult> {
+    const data = (await zoomFetch(creds, "/users/me/meetings", {
+      method: "POST",
+      body: JSON.stringify({
+        topic: req.topic,
+        type: 2, // reunión programada
+        // Zoom rechaza los milisegundos en start_time.
+        start_time: req.startUtc.replace(/\.\d{3}Z$/, "Z"),
+        duration: req.durationMinutes,
+        timezone: req.timezone,
+        agenda: req.notes ?? undefined,
+        settings: { join_before_host: true, waiting_room: false },
+      }),
+    })) as { id?: number | string; join_url?: string } | null;
+
+    if (!data?.id || !data.join_url) {
+      throw new ConnectorError("zoom", "Zoom no devolvió la reunión creada");
+    }
+    return { externalId: String(data.id), joinUrl: data.join_url };
+  },
+
+  async updateMeeting(creds, externalId, req): Promise<void> {
+    // Solo la hora: el mismo id conserva el mismo join_url, que es lo que el
+    // cliente ya tiene guardado.
+    await zoomFetch(creds, `/meetings/${encodeURIComponent(externalId)}`, {
+      method: "PATCH",
+      body: JSON.stringify({
+        start_time: req.startUtc.replace(/\.\d{3}Z$/, "Z"),
+        duration: req.durationMinutes,
+        timezone: req.timezone,
+      }),
+    });
+  },
+
+  async deleteMeeting(creds, externalId): Promise<void> {
+    await zoomFetch(creds, `/meetings/${encodeURIComponent(externalId)}`, {
+      method: "DELETE",
+      allow404: true,
+    });
+  },
+
+  async testConnection(creds): Promise<TestConnectionResult> {
+    try {
+      const me = (await zoomFetch(creds, "/users/me")) as {
+        email?: string;
+      } | null;
+      return { ok: true, detail: me?.email };
+    } catch (err) {
+      return {
+        ok: false,
+        error:
+          err instanceof Error ? err.message : "No se pudo conectar con Zoom",
+      };
+    }
+  },
+};

--- a/src/server/agenda/flag.ts
+++ b/src/server/agenda/flag.ts
@@ -1,5 +1,3 @@
-import { getEnv } from "@/lib/env";
-
 /**
  * 015 — Si esta instancia tiene agenda o no.
  *
@@ -30,8 +28,17 @@ export function parseAgendaFlag(raw: string | undefined): boolean {
   return ON_VALUES.has((raw ?? "").trim().toLowerCase());
 }
 
+/**
+ * Se lee de `process.env` directo, no por `getEnv()`, igual que
+ * `isMockEnabled()` e `isAiConfigured()`: preguntar si una feature existe no
+ * puede depender de que TODO el entorno valide. Con `getEnv()`, un turno del
+ * agente reventaba —en vez de degradar— solo por consultar la bandera.
+ *
+ * `AGENDA` sí está declarada en el esquema de `lib/env.ts`: ahí vive su
+ * documentación y su tipo. Lo que no pasa por el validador es esta consulta.
+ */
 export function agendaEnabled(): boolean {
-  return parseAgendaFlag(getEnv().AGENDA);
+  return parseAgendaFlag(process.env.AGENDA);
 }
 
 /**

--- a/src/server/agenda/flag.ts
+++ b/src/server/agenda/flag.ts
@@ -1,0 +1,44 @@
+import { getEnv } from "@/lib/env";
+
+/**
+ * 015 — Si esta instancia tiene agenda o no.
+ *
+ * Misma decisión que los canales opcionales (ADR-001): el código del motor
+ * viaja siempre en main, y lo que decide si EXISTE para el usuario es una
+ * variable de despliegue. Una instancia normal (sin `AGENDA`) no ve la agenda
+ * por ningún lado: ni pantalla de Citas, ni pestaña de Ajustes, ni rutas, ni
+ * instrucciones de agendar en el prompt del agente — ni se le piden
+ * credenciales de nadie.
+ *
+ * Se hace así, y no con una rama, porque una rama tiene que mantenerse
+ * compatible con main Y con las demás features opcionales, y su cadena de
+ * migraciones diverge sin arreglo posible. La prueba está en el repo: la rama
+ * `004-motor-agenda` quedó irrescatable en 26 días.
+ *
+ * La migración se aplica siempre: unas tablas vacías son inertes, y a cambio
+ * todas las instancias comparten la misma estructura.
+ *
+ * No se llama `CHANNELS` porque agendar no es un canal: mezclar las dos
+ * taxonomías haría que el contrato de capacidades por canal dejara de
+ * significar lo que dice.
+ */
+
+/** Valores que cuentan como "encendida". Cualquier otra cosa, apagada. */
+const ON_VALUES = new Set(["on", "1", "true", "si", "sí", "yes"]);
+
+export function parseAgendaFlag(raw: string | undefined): boolean {
+  return ON_VALUES.has((raw ?? "").trim().toLowerCase());
+}
+
+export function agendaEnabled(): boolean {
+  return parseAgendaFlag(getEnv().AGENDA);
+}
+
+/**
+ * Respuesta para una superficie de agenda apagada. 404 y no 403 a propósito:
+ * si la agenda no está encendida, ese endpoint no existe en esta instancia —
+ * no hay nada que revelar sobre él.
+ */
+export function agendaDisabledResponse(): Response {
+  return new Response(null, { status: 404 });
+}

--- a/src/server/agenda/http.ts
+++ b/src/server/agenda/http.ts
@@ -1,0 +1,61 @@
+import { BookingError, type BookingResult } from "@/server/agenda/service";
+
+/**
+ * 015 — La traducción entre el dominio y HTTP, en un solo sitio.
+ *
+ * Vive aquí y no dentro de los `route.ts` por dos razones: Next solo admite
+ * handlers como exports de una ruta (así que no serían testeables), y porque
+ * los códigos y la FORMA del error son contrato observable, no un detalle.
+ *
+ * Las dos lecciones que costaron caro en producción y que este módulo fija:
+ *  - Crear responde **201**, no 200. Un cliente que validaba `=== 200` dejó a
+ *    todos los leads sin agendar durante horas, y los mocks no lo vieron
+ *    porque respondían 200.
+ *  - El error va ANIDADO (`{"error":{"code":…}}`) con `slots` como HERMANO. Un
+ *    mock con la forma plana escondió el camino de re-oferta durante semanas:
+ *    todo 409 se leía como conflicto genérico y las alternativas nunca se
+ *    ofrecían.
+ */
+
+export type BookingPayload = {
+  bookingId: string;
+  meetingLink: string | null;
+  linkPending: boolean;
+  label: string;
+};
+
+export function bookingPayload(result: BookingResult): BookingPayload {
+  return {
+    bookingId: result.booking.id,
+    meetingLink: result.meetingLink,
+    /**
+     * true ⇒ la cita EXISTE pero el proveedor aún no entregó el enlace.
+     * Confirma la cita y di que el enlace llega luego; no prometas uno que no
+     * tienes.
+     */
+    linkPending: result.linkPending,
+    label: result.label,
+  };
+}
+
+export function bookingErrorStatus(code: BookingError["code"]): number {
+  switch (code) {
+    case "not_found":
+      return 404;
+    case "invalid":
+      return 422;
+    case "slot_taken":
+    case "slot_not_offered":
+      return 409;
+  }
+}
+
+/** Traduce un `BookingError` al sobre estándar. Cualquier otro error se relanza. */
+export function bookingErrorResponse(err: unknown): Response {
+  if (!(err instanceof BookingError)) throw err;
+  const code = err.code === "invalid" ? "invalid_body" : err.code;
+  return Response.json(
+    { error: { code, message: err.message }, slots: err.slots },
+    { status: bookingErrorStatus(err.code) }
+  );
+}

--- a/src/server/agenda/offers.ts
+++ b/src/server/agenda/offers.ts
@@ -1,0 +1,111 @@
+import { asc, eq } from "drizzle-orm";
+import { getDb, schema } from "@/lib/db";
+import { newId } from "@/lib/db/ids";
+import { scoped } from "@/lib/db/tenant";
+
+/**
+ * 015 — Memoria de lo ofrecido a una conversación (requisito INNEGOCIABLE).
+ *
+ * Sin fila aquí no hay reserva: es lo que impide que un modelo alucine un
+ * horario que nunca se le ofreció al cliente. La oferta se reemplaza completa
+ * en cada ronda (la vigente es siempre la última) y se limpia al reservar.
+ */
+
+export type OfferedSlot = { startUtc: string; label: string };
+
+/** Reemplaza TODA la oferta de la conversación, en una transacción. */
+export async function replaceOffers(
+  organizationId: string,
+  conversationId: string,
+  slots: OfferedSlot[]
+): Promise<void> {
+  const db = getDb();
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(schema.offeredSlot)
+      .where(
+        scoped(
+          schema.offeredSlot.organizationId,
+          organizationId,
+          eq(schema.offeredSlot.conversationId, conversationId)
+        )
+      );
+    if (slots.length === 0) return;
+    await tx.insert(schema.offeredSlot).values(
+      slots.map((s) => ({
+        id: newId("offeredSlot"),
+        organizationId,
+        conversationId,
+        startUtc: new Date(s.startUtc),
+        label: s.label,
+      }))
+    );
+  });
+}
+
+export async function getOffers(
+  organizationId: string,
+  conversationId: string
+): Promise<OfferedSlot[]> {
+  const db = getDb();
+  const rows = await db
+    .select({
+      startUtc: schema.offeredSlot.startUtc,
+      label: schema.offeredSlot.label,
+    })
+    .from(schema.offeredSlot)
+    .where(
+      scoped(
+        schema.offeredSlot.organizationId,
+        organizationId,
+        eq(schema.offeredSlot.conversationId, conversationId)
+      )
+    )
+    .orderBy(asc(schema.offeredSlot.startUtc));
+
+  return rows.map((r) => ({
+    startUtc: r.startUtc.toISOString(),
+    label: r.label,
+  }));
+}
+
+export async function clearOffers(
+  organizationId: string,
+  conversationId: string
+): Promise<void> {
+  const db = getDb();
+  await db
+    .delete(schema.offeredSlot)
+    .where(
+      scoped(
+        schema.offeredSlot.organizationId,
+        organizationId,
+        eq(schema.offeredSlot.conversationId, conversationId)
+      )
+    );
+}
+
+/**
+ * ¿El instante pedido está entre los ofrecidos? Comparación por **epoch
+ * exacto**: nada de tolerancias ni de comparar texto. Un ISO con otro offset
+ * pero el mismo instante SÍ vale; un minuto de diferencia NO.
+ *
+ * La tolerancia sería la puerta por donde entra la alucinación: un modelo
+ * inventa "el martes a las 10" con facilidad, y comparar exacto convierte eso
+ * en un rechazo con la lista de lo que sí se ofreció.
+ */
+export function findOffered(
+  offers: OfferedSlot[],
+  whenISO: string
+): OfferedSlot | null {
+  const target = Date.parse(whenISO);
+  if (Number.isNaN(target)) return null;
+  return offers.find((o) => Date.parse(o.startUtc) === target) ?? null;
+}
+
+/** Igualdad de instante, expuesta para tests. */
+export function sameInstant(a: string, b: string): boolean {
+  const x = Date.parse(a);
+  const y = Date.parse(b);
+  return !Number.isNaN(x) && !Number.isNaN(y) && x === y;
+}

--- a/src/server/agenda/queries.ts
+++ b/src/server/agenda/queries.ts
@@ -1,0 +1,72 @@
+import { desc, eq } from "drizzle-orm";
+import { getDb, schema } from "@/lib/db";
+import { scoped } from "@/lib/db/tenant";
+import { partsInTz } from "@/lib/time/slots";
+import { getSettings } from "@/server/agenda/settings";
+
+/** 015 — Listado de citas para la UI, con la hora en la zona del negocio. */
+
+export type BookingListItem = {
+  id: string;
+  kind: "session" | "block";
+  status: "agendada" | "realizada" | "no_show" | "cancelada";
+  source: "manual" | "ai";
+  scheduledAtUtc: string;
+  durationMinutes: number;
+  date: string;
+  time: string;
+  weekday: string;
+  contact: { id: string; name: string } | null;
+  conversationId: string | null;
+  /** Con qué conector nació la entrega de esta cita. */
+  connector: string | null;
+  meetingLink: string | null;
+  /** El proveedor falló al crear la reunión: se puede reintentar. */
+  linkPending: boolean;
+  isTest: boolean;
+  notes: string | null;
+};
+
+export async function listBookings(
+  organizationId: string
+): Promise<BookingListItem[]> {
+  const db = getDb();
+  const settings = await getSettings(organizationId);
+
+  const rows = await db
+    .select({
+      booking: schema.booking,
+      contactId: schema.contact.id,
+      contactName: schema.contact.name,
+    })
+    .from(schema.booking)
+    .leftJoin(schema.contact, eq(schema.booking.contactId, schema.contact.id))
+    .where(scoped(schema.booking.organizationId, organizationId))
+    .orderBy(desc(schema.booking.scheduledAt))
+    .limit(200);
+
+  return rows.map((r) => {
+    const scheduledAtUtc = r.booking.scheduledAt.toISOString();
+    const parts = partsInTz(scheduledAtUtc, settings.timezone);
+    return {
+      id: r.booking.id,
+      kind: r.booking.kind,
+      status: r.booking.status,
+      source: r.booking.source,
+      scheduledAtUtc,
+      durationMinutes: r.booking.durationMinutes,
+      date: parts.date,
+      time: parts.time,
+      weekday: parts.weekday,
+      contact: r.contactId
+        ? { id: r.contactId, name: r.contactName ?? "" }
+        : null,
+      conversationId: r.booking.conversationId,
+      connector: r.booking.connector,
+      meetingLink: r.booking.meetingLink,
+      linkPending: r.booking.linkPending,
+      isTest: r.booking.isTest,
+      notes: r.booking.notes,
+    };
+  });
+}

--- a/src/server/agenda/service.ts
+++ b/src/server/agenda/service.ts
@@ -1,0 +1,769 @@
+import { and, asc, eq, gte, inArray } from "drizzle-orm";
+import { getDb, schema } from "@/lib/db";
+import { newId } from "@/lib/db/ids";
+import { scoped } from "@/lib/db/tenant";
+import { labelInTz } from "@/lib/time/slots";
+import type { ConnectorId } from "@/lib/agenda-connectors";
+import {
+  computeAvailability,
+  findSlot,
+  type AvailableSlot,
+} from "@/server/agenda/availability";
+import { getSettings, type CalendarSettings } from "@/server/agenda/settings";
+import {
+  clearOffers,
+  findOffered,
+  getOffers,
+  replaceOffers,
+  type OfferedSlot,
+} from "@/server/agenda/offers";
+import {
+  bindConnector,
+  markConnectorAuthError,
+} from "@/server/agenda/connectors";
+import { ConnectorError } from "@/server/agenda/connectors/types";
+import { moveLeadToStage } from "@/server/leads/stage-history";
+import { publish } from "@/server/events/bus";
+
+/**
+ * 015 — Ciclo de vida de la cita y las dos reglas INNEGOCIABLES:
+ *
+ *  1. Quien conduce la conversación (agente in-process o cerebro externo) solo
+ *     puede reservar un instante que ya se ofreció a ESA conversación
+ *     (`offered_slot`, comparación por epoch exacto).
+ *  2. Al confirmar se re-valida el hueco y la base lo cierra con su índice
+ *     único parcial; si se ocupó, se responde `slot_taken` con alternativas
+ *     frescas y NO se crea nada. Nunca se confirma una reserva que no se creó.
+ *
+ * Y una regla de honestidad: la entrega de la reunión (el conector) corre
+ * DESPUÉS de escribir la verdad del CRM y es best-effort. Si el proveedor está
+ * caído, la cita se crea igual con el enlace pendiente — un tercero no puede
+ * costarnos la conversión, ni hacernos prometer un enlace que no existe.
+ */
+
+export type BookingErrorCode =
+  | "slot_taken"
+  | "slot_not_offered"
+  | "not_found"
+  | "invalid";
+
+export class BookingError extends Error {
+  code: BookingErrorCode;
+  /**
+   * Horarios para re-ofrecer. En `slot_taken` son alternativas frescas YA
+   * registradas como la nueva oferta de la conversación; en `slot_not_offered`
+   * es lo que sí se había ofrecido.
+   */
+  slots: OfferedSlot[];
+
+  constructor(
+    code: BookingErrorCode,
+    message: string,
+    slots: OfferedSlot[] = []
+  ) {
+    super(message);
+    this.name = "BookingError";
+    this.code = code;
+    this.slots = slots;
+  }
+}
+
+type BookingRow = typeof schema.booking.$inferSelect;
+
+export type BookingResult = {
+  booking: BookingRow;
+  meetingLink: string | null;
+  linkPending: boolean;
+  label: string;
+};
+
+/** Cuántas alternativas se devuelven cuando el hueco se ocupó. */
+const FRESH_ALTERNATIVES = 3;
+
+export async function createSessionBooking(input: {
+  organizationId: string;
+  startUtc: string;
+  source: "manual" | "ai";
+  /** Obligatoria en el camino conversacional; de ella sale el contacto. */
+  conversationId?: string | null;
+  /** Camino manual del operador. */
+  contactId?: string | null;
+  notes?: string | null;
+  /**
+   * true ⇒ exige que el instante figure entre los ofrecidos a la conversación
+   * (agente/bot). El operador elige de la disponibilidad que está viendo, así
+   * que reserva sin oferta previa.
+   */
+  requireOffer: boolean;
+  now?: Date;
+}): Promise<BookingResult> {
+  const db = getDb();
+  const settings = await getSettings(input.organizationId);
+
+  if (Number.isNaN(Date.parse(input.startUtc))) {
+    throw new BookingError("invalid", "Instante inválido");
+  }
+
+  // Contexto de la conversación: contacto y si es del Laboratorio.
+  let isTest = false;
+  let contactId = input.contactId ?? null;
+  let contactName = "";
+  if (input.conversationId) {
+    const rows = await db
+      .select({
+        contactId: schema.conversation.contactId,
+        isTest: schema.conversation.isTest,
+      })
+      .from(schema.conversation)
+      .where(
+        scoped(
+          schema.conversation.organizationId,
+          input.organizationId,
+          eq(schema.conversation.id, input.conversationId)
+        )
+      )
+      .limit(1);
+    const conv = rows[0];
+    if (!conv) throw new BookingError("not_found", "Conversación no encontrada");
+    isTest = conv.isTest;
+    contactId = contactId ?? conv.contactId;
+  }
+
+  if (!contactId) {
+    throw new BookingError("invalid", "La cita necesita un contacto");
+  }
+  contactName = await getContactName(input.organizationId, contactId);
+
+  // REGLA 1: solo se reserva lo que se ofreció.
+  if (input.requireOffer) {
+    if (!input.conversationId) {
+      throw new BookingError(
+        "invalid",
+        "Se necesita la conversación para validar la oferta"
+      );
+    }
+    const offers = await getOffers(input.organizationId, input.conversationId);
+    if (!findOffered(offers, input.startUtc)) {
+      throw new BookingError(
+        "slot_not_offered",
+        "Ese horario no se ofreció en esta conversación",
+        offers
+      );
+    }
+  }
+
+  // REGLA 2 (primera mitad): el hueco debe seguir libre AHORA.
+  const slot = await findSlot(input.organizationId, input.startUtc, {
+    now: input.now,
+    settings,
+  });
+  if (!slot) {
+    throw new BookingError(
+      "slot_taken",
+      "Ese horario ya no está disponible",
+      await refreshOffer(input.organizationId, input.conversationId, {
+        now: input.now,
+      })
+    );
+  }
+
+  const leadRows = await db
+    .select({ id: schema.lead.id })
+    .from(schema.lead)
+    .where(
+      scoped(
+        schema.lead.organizationId,
+        input.organizationId,
+        eq(schema.lead.contactId, contactId)
+      )
+    )
+    .limit(1);
+
+  let booking: BookingRow;
+  try {
+    const inserted = await db
+      .insert(schema.booking)
+      .values({
+        id: newId("booking"),
+        organizationId: input.organizationId,
+        kind: "session",
+        source: input.source === "ai" ? "ai" : "manual",
+        contactId,
+        conversationId: input.conversationId ?? null,
+        leadId: leadRows[0]?.id ?? null,
+        scheduledAt: new Date(slot.startUtc),
+        durationMinutes: settings.slotMinutes,
+        // Copia histórica: si el negocio cambia de conector, esta cita conserva
+        // el que le tocó y sigue hablando con él al moverse o cancelarse.
+        connector: settings.connector,
+        isTest,
+        notes: input.notes ?? null,
+      })
+      .returning();
+    booking = inserted[0]!;
+  } catch (err) {
+    // REGLA 2 (segunda mitad): la llave única cierra la carrera exacta. Dos
+    // confirmaciones simultáneas del mismo instante — la perdedora sale por
+    // aquí, sin cita creada.
+    if (isUniqueViolation(err)) {
+      throw new BookingError(
+        "slot_taken",
+        "Ese horario acaba de ocuparse",
+        await refreshOffer(input.organizationId, input.conversationId, {
+          now: input.now,
+        })
+      );
+    }
+    throw err;
+  }
+
+  // La oferta cumplió su propósito.
+  if (input.conversationId) {
+    await clearOffers(input.organizationId, input.conversationId).catch(
+      (err) => {
+        console.warn(`[agenda] no pude limpiar la oferta: ${err}`);
+      }
+    );
+  }
+
+  // Efectos secundarios: ninguno puede revertir la cita.
+  const delivered = await deliverMeeting(booking, settings, contactName);
+  await advanceLeadStage(
+    input.organizationId,
+    contactId,
+    input.source === "ai" ? "bot" : "dueno"
+  ).catch((err) => {
+    console.warn(`[agenda] avance de etapa falló: ${err}`);
+  });
+
+  publish(input.organizationId, {
+    type: "booking.updated",
+    data: { bookingId: delivered.id },
+  });
+
+  return {
+    booking: delivered,
+    meetingLink: delivered.meetingLink,
+    linkPending: delivered.linkPending,
+    label: labelInTz(slot.startUtc, settings.timezone),
+  };
+}
+
+export async function createBlock(input: {
+  organizationId: string;
+  startUtc: string;
+  durationMinutes: number;
+  notes?: string | null;
+}): Promise<BookingRow> {
+  if (Number.isNaN(Date.parse(input.startUtc))) {
+    throw new BookingError("invalid", "Instante inválido");
+  }
+  const db = getDb();
+  try {
+    const inserted = await db
+      .insert(schema.booking)
+      .values({
+        id: newId("booking"),
+        organizationId: input.organizationId,
+        kind: "block",
+        source: "manual",
+        scheduledAt: new Date(input.startUtc),
+        durationMinutes: input.durationMinutes,
+        notes: input.notes ?? null,
+      })
+      .returning();
+    const block = inserted[0]!;
+    publish(input.organizationId, {
+      type: "booking.updated",
+      data: { bookingId: block.id },
+    });
+    return block;
+  } catch (err) {
+    if (isUniqueViolation(err)) {
+      throw new BookingError("slot_taken", "Ese horario ya está ocupado");
+    }
+    throw err;
+  }
+}
+
+export async function rescheduleBooking(input: {
+  organizationId: string;
+  bookingId: string;
+  startUtc: string;
+  now?: Date;
+}): Promise<BookingResult> {
+  const db = getDb();
+  const booking = await getOwnBooking(input.organizationId, input.bookingId);
+  if (booking.status === "cancelada") {
+    throw new BookingError("invalid", "La cita está cancelada");
+  }
+
+  const settings = await getSettings(input.organizationId);
+  // excludeBookingId: la propia cita no debe bloquearse a sí misma.
+  const slot = await findSlot(input.organizationId, input.startUtc, {
+    excludeBookingId: booking.id,
+    now: input.now,
+    settings,
+  });
+  if (!slot) {
+    throw new BookingError("slot_taken", "Ese horario ya no está disponible");
+  }
+
+  let next: BookingRow;
+  try {
+    const updated = await db
+      .update(schema.booking)
+      .set({ scheduledAt: new Date(slot.startUtc), updatedAt: new Date() })
+      .where(eq(schema.booking.id, booking.id))
+      .returning();
+    next = updated[0]!;
+  } catch (err) {
+    if (isUniqueViolation(err)) {
+      throw new BookingError("slot_taken", "Ese horario acaba de ocuparse");
+    }
+    throw err;
+  }
+
+  // Mover la reunión en el proveedor conserva el enlace: es la MISMA reunión,
+  // en otra hora. Un fallo aquí no deshace nada — el enlace anterior sigue
+  // sirviendo en la práctica.
+  await withConnector(next, settings, async (conn, externalRef) => {
+    await conn.updateMeeting(externalRef, {
+      startUtc: slot.startUtc,
+      durationMinutes: next.durationMinutes,
+      timezone: settings.timezone,
+    });
+  });
+
+  publish(input.organizationId, {
+    type: "booking.updated",
+    data: { bookingId: next.id },
+  });
+  return {
+    booking: next,
+    meetingLink: next.meetingLink,
+    linkPending: next.linkPending,
+    label: labelInTz(slot.startUtc, settings.timezone),
+  };
+}
+
+/**
+ * Reprograma la PRÓXIMA cita activa de la conversación. Es el camino del
+ * agente: mover una cita no debería obligar a pausar la IA y pasarle el
+ * problema a un humano.
+ */
+export async function rescheduleForConversation(input: {
+  organizationId: string;
+  conversationId: string;
+  startUtc: string;
+  now?: Date;
+}): Promise<BookingResult> {
+  const db = getDb();
+  const now = input.now ?? new Date();
+
+  const convRows = await db
+    .select({ contactId: schema.conversation.contactId })
+    .from(schema.conversation)
+    .where(
+      scoped(
+        schema.conversation.organizationId,
+        input.organizationId,
+        eq(schema.conversation.id, input.conversationId)
+      )
+    )
+    .limit(1);
+  const conv = convRows[0];
+  if (!conv) throw new BookingError("not_found", "Conversación no encontrada");
+
+  // Mismas reglas que al crear: el instante nuevo tiene que haberse ofrecido.
+  const offers = await getOffers(input.organizationId, input.conversationId);
+  if (!findOffered(offers, input.startUtc)) {
+    throw new BookingError(
+      "slot_not_offered",
+      "Ese horario no se ofreció en esta conversación",
+      offers
+    );
+  }
+
+  const rows = await db
+    .select()
+    .from(schema.booking)
+    .where(
+      scoped(
+        schema.booking.organizationId,
+        input.organizationId,
+        and(
+          eq(schema.booking.contactId, conv.contactId),
+          eq(schema.booking.kind, "session"),
+          eq(schema.booking.status, "agendada"),
+          gte(schema.booking.scheduledAt, now)
+        )
+      )
+    )
+    .orderBy(asc(schema.booking.scheduledAt))
+    .limit(1);
+
+  const target = rows[0];
+  if (!target) {
+    throw new BookingError("not_found", "No hay una cita activa que mover");
+  }
+
+  const result = await rescheduleBooking({
+    organizationId: input.organizationId,
+    bookingId: target.id,
+    startUtc: input.startUtc,
+    now: input.now,
+  });
+  await clearOffers(input.organizationId, input.conversationId).catch(() => {});
+  return result;
+}
+
+/** Idempotente: cancelar una cita ya cancelada no falla ni cambia nada. */
+export async function cancelBooking(input: {
+  organizationId: string;
+  bookingId: string;
+}): Promise<void> {
+  const db = getDb();
+  const booking = await getOwnBooking(input.organizationId, input.bookingId);
+  if (booking.status === "cancelada") return;
+
+  await db
+    .update(schema.booking)
+    .set({ status: "cancelada", updatedAt: new Date() })
+    .where(eq(schema.booking.id, booking.id));
+
+  const settings = await getSettings(input.organizationId);
+  await withConnector(booking, settings, async (conn, externalRef) => {
+    await conn.deleteMeeting(externalRef);
+  });
+
+  publish(input.organizationId, {
+    type: "booking.updated",
+    data: { bookingId: booking.id },
+  });
+}
+
+export async function markBookingStatus(input: {
+  organizationId: string;
+  bookingId: string;
+  status: "realizada" | "no_show";
+}): Promise<void> {
+  const db = getDb();
+  const booking = await getOwnBooking(input.organizationId, input.bookingId);
+  try {
+    await db
+      .update(schema.booking)
+      .set({ status: input.status, updatedAt: new Date() })
+      .where(eq(schema.booking.id, booking.id));
+  } catch (err) {
+    // Reactivar a `realizada` un instante que otra cita ya ocupa.
+    if (isUniqueViolation(err)) {
+      throw new BookingError("slot_taken", "Ese horario ya está ocupado");
+    }
+    throw err;
+  }
+  publish(input.organizationId, {
+    type: "booking.updated",
+    data: { bookingId: booking.id },
+  });
+}
+
+/**
+ * Reintenta la entrega de una cita que quedó sin enlace porque el proveedor
+ * falló. Habla con el conector con el que NACIÓ la cita, no con el activo.
+ *
+ * Sin esto, un hipo del proveedor sería una pérdida silenciosa que nadie
+ * repara — que es exactamente lo que pasa hoy en el fork.
+ */
+export async function retryMeetingLink(input: {
+  organizationId: string;
+  bookingId: string;
+}): Promise<BookingResult> {
+  const booking = await getOwnBooking(input.organizationId, input.bookingId);
+  if (!booking.linkPending) {
+    throw new BookingError("invalid", "Esta cita no tiene un enlace pendiente");
+  }
+  const settings = await getSettings(input.organizationId);
+  const contactName = booking.contactId
+    ? await getContactName(input.organizationId, booking.contactId)
+    : "";
+  const delivered = await deliverMeeting(booking, settings, contactName);
+
+  publish(input.organizationId, {
+    type: "booking.updated",
+    data: { bookingId: delivered.id },
+  });
+  return {
+    booking: delivered,
+    meetingLink: delivered.meetingLink,
+    linkPending: delivered.linkPending,
+    label: labelInTz(delivered.scheduledAt.toISOString(), settings.timezone),
+  };
+}
+
+/**
+ * Crea la reunión en el proveedor y la guarda en la cita.
+ *
+ * SANDBOX: una cita del Laboratorio jamás llega a un conector. La aserción va
+ * aquí, ANTES de resolver cuál es, para que valga igual para todos — hoy y
+ * para el que agregue un fork mañana.
+ */
+async function deliverMeeting(
+  booking: BookingRow,
+  settings: CalendarSettings,
+  contactName: string
+): Promise<BookingRow> {
+  if (booking.isTest) return booking;
+  const connectorId = (booking.connector ?? settings.connector) as ConnectorId;
+
+  try {
+    const conn = await bindConnector(
+      booking.organizationId,
+      connectorId,
+      settings
+    );
+    const meeting = await conn.createMeeting({
+      topic: contactName ? `Cita — ${contactName}` : "Cita",
+      startUtc: booking.scheduledAt.toISOString(),
+      durationMinutes: booking.durationMinutes,
+      timezone: settings.timezone,
+      notes: booking.notes ?? undefined,
+    });
+    return await persistDelivery(booking.id, {
+      externalRef: meeting.externalId,
+      meetingLink: meeting.joinUrl,
+      linkPending: false,
+    });
+  } catch (err) {
+    console.warn(
+      `[agenda] el conector ${connectorId} no pudo entregar la reunión: ${err}`
+    );
+    if (err instanceof ConnectorError && err.isAuthError) {
+      await markConnectorAuthError(booking.organizationId, connectorId).catch(
+        () => {}
+      );
+    }
+    // La cita ya existe y se queda: el enlace es lo único que falta.
+    return await persistDelivery(booking.id, {
+      externalRef: null,
+      meetingLink: null,
+      linkPending: true,
+    });
+  }
+}
+
+async function persistDelivery(
+  bookingId: string,
+  values: {
+    externalRef: string | null;
+    meetingLink: string | null;
+    linkPending: boolean;
+  }
+): Promise<BookingRow> {
+  const db = getDb();
+  const rows = await db
+    .update(schema.booking)
+    .set({ ...values, updatedAt: new Date() })
+    .where(eq(schema.booking.id, bookingId))
+    .returning();
+  return rows[0]!;
+}
+
+/**
+ * Corre un efecto sobre el proveedor de una cita ya creada (mover, borrar).
+ * Best-effort y con el mismo guardarraíl de sandbox. Sin `external_ref` no hay
+ * nada que mover: el conector no generó reunión (p. ej. el enlace fijo).
+ */
+async function withConnector(
+  booking: BookingRow,
+  settings: CalendarSettings,
+  run: (
+    conn: Awaited<ReturnType<typeof bindConnector>>,
+    externalRef: string
+  ) => Promise<void>
+): Promise<void> {
+  if (booking.isTest || !booking.externalRef) return;
+  const connectorId = (booking.connector ?? settings.connector) as ConnectorId;
+  try {
+    const conn = await bindConnector(
+      booking.organizationId,
+      connectorId,
+      settings
+    );
+    await run(conn, booking.externalRef);
+  } catch (err) {
+    console.warn(`[agenda] efecto en ${connectorId} falló: ${err}`);
+    if (err instanceof ConnectorError && err.isAuthError) {
+      await markConnectorAuthError(booking.organizationId, connectorId).catch(
+        () => {}
+      );
+    }
+  }
+}
+
+/**
+ * Alternativas frescas para re-ofrecer. Si hay conversación, quedan
+ * REGISTRADAS como su nueva oferta: el cliente puede aceptar una de inmediato
+ * y la validación seguirá siendo válida.
+ */
+async function refreshOffer(
+  organizationId: string,
+  conversationId: string | null | undefined,
+  opts: { now?: Date }
+): Promise<OfferedSlot[]> {
+  let fresh: AvailableSlot[] = [];
+  try {
+    fresh = (await computeAvailability(organizationId, { now: opts.now })).slice(
+      0,
+      FRESH_ALTERNATIVES
+    );
+  } catch (err) {
+    console.warn(`[agenda] no pude calcular alternativas: ${err}`);
+    return [];
+  }
+  const offers: OfferedSlot[] = fresh.map((s) => ({
+    startUtc: s.startUtc,
+    label: s.label,
+  }));
+  if (conversationId && offers.length > 0) {
+    await replaceOffers(organizationId, conversationId, offers).catch((err) => {
+      console.warn(`[agenda] no pude registrar la nueva oferta: ${err}`);
+    });
+  }
+  return offers;
+}
+
+async function getOwnBooking(
+  organizationId: string,
+  bookingId: string
+): Promise<BookingRow> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(schema.booking)
+    .where(
+      scoped(
+        schema.booking.organizationId,
+        organizationId,
+        eq(schema.booking.id, bookingId)
+      )
+    )
+    .limit(1);
+  if (!rows[0]) throw new BookingError("not_found", "Cita no encontrada");
+  return rows[0];
+}
+
+async function getContactName(
+  organizationId: string,
+  contactId: string
+): Promise<string> {
+  const db = getDb();
+  const rows = await db
+    .select({ name: schema.contact.name })
+    .from(schema.contact)
+    .where(
+      scoped(
+        schema.contact.organizationId,
+        organizationId,
+        eq(schema.contact.id, contactId)
+      )
+    )
+    .limit(1);
+  return rows[0]?.name ?? "";
+}
+
+/**
+ * El lead avanza a la siguiente etapa abierta al agendar — solo hacia adelante,
+ * nunca retrocede.
+ *
+ * Pasa por `moveLeadToStage`, la única puerta que puede escribir `stage_id`:
+ * mover el lead y registrar el movimiento en la bitácora son la misma
+ * operación. Escribir el UPDATE aquí no truena, solo hace que las gráficas
+ * mientan meses después — y hay un test de vigilancia que lo impide.
+ */
+async function advanceLeadStage(
+  organizationId: string,
+  contactId: string,
+  source: "bot" | "dueno"
+): Promise<void> {
+  const db = getDb();
+  const leads = await db
+    .select({ id: schema.lead.id, stageId: schema.lead.stageId })
+    .from(schema.lead)
+    .where(
+      scoped(
+        schema.lead.organizationId,
+        organizationId,
+        eq(schema.lead.contactId, contactId)
+      )
+    )
+    .limit(1);
+  const lead = leads[0];
+  if (!lead) return;
+
+  const stages = await db
+    .select({
+      id: schema.pipelineStage.id,
+      position: schema.pipelineStage.position,
+      kind: schema.pipelineStage.kind,
+    })
+    .from(schema.pipelineStage)
+    .where(scoped(schema.pipelineStage.organizationId, organizationId))
+    .orderBy(asc(schema.pipelineStage.position));
+
+  const currentIdx = stages.findIndex((s) => s.id === lead.stageId);
+  if (currentIdx < 0) return;
+  const nextOpen = stages.find((s, i) => i > currentIdx && s.kind === "open");
+  if (!nextOpen) return; // ya está en la última etapa abierta (o en un ancla)
+
+  await moveLeadToStage({
+    organizationId,
+    leadId: lead.id,
+    toStageId: nextOpen.id,
+    source,
+    extra: { lastActivityAt: new Date() },
+  });
+}
+
+/** Citas que ocupan agenda de verdad. */
+export const ACTIVE_STATUSES = ["agendada", "realizada"] as const;
+
+/** ¿Hay alguna cita activa para este contacto? Lo usa el agente. */
+export async function hasActiveBooking(
+  organizationId: string,
+  contactId: string,
+  now = new Date()
+): Promise<boolean> {
+  const db = getDb();
+  const rows = await db
+    .select({ id: schema.booking.id })
+    .from(schema.booking)
+    .where(
+      scoped(
+        schema.booking.organizationId,
+        organizationId,
+        and(
+          eq(schema.booking.contactId, contactId),
+          eq(schema.booking.kind, "session"),
+          inArray(schema.booking.status, [...ACTIVE_STATUSES]),
+          gte(schema.booking.scheduledAt, now)
+        )
+      )
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+/** 23505 = unique_violation de Postgres. */
+function isUniqueViolation(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const code = (err as { code?: unknown }).code;
+  if (code === "23505") return true;
+  // Drizzle envuelve el error del driver: el código real viaja en `cause`.
+  const cause = (err as { cause?: unknown }).cause;
+  return (
+    typeof cause === "object" &&
+    cause !== null &&
+    (cause as { code?: unknown }).code === "23505"
+  );
+}

--- a/src/server/agenda/service.ts
+++ b/src/server/agenda/service.ts
@@ -3,7 +3,7 @@ import { getDb, schema } from "@/lib/db";
 import { newId } from "@/lib/db/ids";
 import { scoped } from "@/lib/db/tenant";
 import { labelInTz } from "@/lib/time/slots";
-import type { ConnectorId } from "@/lib/agenda-connectors";
+import { CONNECTOR_META, type ConnectorId } from "@/lib/agenda-connectors";
 import {
   computeAvailability,
   findSlot,
@@ -522,17 +522,28 @@ async function deliverMeeting(
       connectorId,
       settings
     );
-    const meeting = await conn.createMeeting({
-      topic: contactName ? `Cita — ${contactName}` : "Cita",
-      startUtc: booking.scheduledAt.toISOString(),
-      durationMinutes: booking.durationMinutes,
-      timezone: settings.timezone,
-      notes: booking.notes ?? undefined,
-    });
+
+    // Si la cita YA tiene reunión, esto es un reintento: se vuelve a leer, no
+    // se crea otra. Sin esta rama, reintentar el enlace de un evento de Google
+    // dejaría al dueño con dos citas en su calendario.
+    const meeting =
+      booking.externalRef && conn.refreshMeeting
+        ? await conn.refreshMeeting(booking.externalRef)
+        : await conn.createMeeting({
+            topic: contactName ? `Cita — ${contactName}` : "Cita",
+            startUtc: booking.scheduledAt.toISOString(),
+            durationMinutes: booking.durationMinutes,
+            timezone: settings.timezone,
+            notes: booking.notes ?? undefined,
+          });
+
     return await persistDelivery(booking.id, {
-      externalRef: meeting.externalId,
+      externalRef: meeting.externalId ?? booking.externalRef,
       meetingLink: meeting.joinUrl,
-      linkPending: false,
+      // Un conector que promete enlace por cita y no lo trajo todavía deja la
+      // cita "sin enlace" — reintentable. `enlace-fijo` sin sala configurada,
+      // en cambio, no tiene nada pendiente: simplemente no hay enlace.
+      linkPending: CONNECTOR_META[connectorId].perBookingLink && !meeting.joinUrl,
     });
   } catch (err) {
     console.warn(
@@ -543,9 +554,11 @@ async function deliverMeeting(
         () => {}
       );
     }
-    // La cita ya existe y se queda: el enlace es lo único que falta.
+    // La cita ya existe y se queda: el enlace es lo único que falta. Se
+    // conserva la referencia externa si ya la había, para que el reintento
+    // sepa que no debe crear otra reunión.
     return await persistDelivery(booking.id, {
-      externalRef: null,
+      externalRef: booking.externalRef,
       meetingLink: null,
       linkPending: true,
     });

--- a/src/server/agenda/settings.ts
+++ b/src/server/agenda/settings.ts
@@ -1,0 +1,202 @@
+import { getDb, schema } from "@/lib/db";
+import { newId } from "@/lib/db/ids";
+import { scoped } from "@/lib/db/tenant";
+import {
+  DEFAULT_CONNECTOR,
+  isConnectorId,
+  type ConnectorId,
+} from "@/lib/agenda-connectors";
+import {
+  isValidInterval,
+  isValidTimeZone,
+  WEEKDAYS,
+  type Interval,
+  type WeekdayKey,
+} from "@/lib/time/slots";
+
+/**
+ * 015 — La configuración de la agenda del negocio (una por organización):
+ * lectura con defaults y upsert normalizado.
+ */
+
+export type WeeklyHours = Partial<Record<WeekdayKey, Interval[]>>;
+
+export const DEFAULT_TIMEZONE = "America/Mexico_City";
+
+/** L-V 09:00-18:00 — se ajusta en Ajustes → Agenda. */
+export const DEFAULT_WEEKLY_HOURS: WeeklyHours = {
+  mon: [{ start: "09:00", end: "18:00" }],
+  tue: [{ start: "09:00", end: "18:00" }],
+  wed: [{ start: "09:00", end: "18:00" }],
+  thu: [{ start: "09:00", end: "18:00" }],
+  fri: [{ start: "09:00", end: "18:00" }],
+};
+
+export type CalendarSettings = {
+  weeklyHours: WeeklyHours;
+  slotMinutes: number;
+  bufferMinutes: number;
+  minNoticeHours: number;
+  maxDaysAhead: number;
+  timezone: string;
+  /** Cómo se entrega la reunión. */
+  connector: ConnectorId;
+  /** Sala fija del conector `enlace-fijo`; null ⇒ citas sin link. */
+  meetingLink: string | null;
+};
+
+/** Lo que ve una instancia recién encendida: útil sin configurar nada. */
+export const DEFAULT_CALENDAR_SETTINGS: CalendarSettings = {
+  weeklyHours: DEFAULT_WEEKLY_HOURS,
+  slotMinutes: 30,
+  bufferMinutes: 0,
+  minNoticeHours: 2,
+  maxDaysAhead: 7,
+  timezone: DEFAULT_TIMEZONE,
+  connector: DEFAULT_CONNECTOR,
+  meetingLink: null,
+};
+
+export const LIMITS = {
+  slotMinutes: { min: 10, max: 240 },
+  bufferMinutes: { min: 0, max: 120 },
+  minNoticeHours: { min: 0, max: 72 },
+  maxDaysAhead: { min: 1, max: 60 },
+} as const;
+
+export async function getSettings(
+  organizationId: string
+): Promise<CalendarSettings> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(schema.calendarSettings)
+    .where(scoped(schema.calendarSettings.organizationId, organizationId))
+    .limit(1);
+
+  const row = rows[0];
+  // Sin fila: la instancia recién encendida ya es usable.
+  if (!row) return DEFAULT_CALENDAR_SETTINGS;
+
+  return {
+    weeklyHours: normalizeWeeklyHours(row.weeklyHours as WeeklyHours),
+    slotMinutes: row.slotMinutes,
+    bufferMinutes: row.bufferMinutes,
+    minNoticeHours: row.minNoticeHours,
+    maxDaysAhead: row.maxDaysAhead,
+    timezone: row.timezone,
+    // Un conector que ya no existe en el código (p. ej. venías de un fork) no
+    // puede dejar la agenda inservible: se degrada al soberano.
+    connector: isConnectorId(row.connector) ? row.connector : DEFAULT_CONNECTOR,
+    meetingLink: row.meetingLink,
+  };
+}
+
+export class CalendarSettingsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CalendarSettingsError";
+  }
+}
+
+export async function upsertSettings(
+  organizationId: string,
+  input: Partial<CalendarSettings>
+): Promise<CalendarSettings> {
+  const current = await getSettings(organizationId);
+
+  const timezone = input.timezone ?? current.timezone;
+  // Una zona desconocida rompería el motor entero: se rechaza al guardar.
+  if (!isValidTimeZone(timezone)) {
+    throw new CalendarSettingsError(`Zona horaria desconocida: ${timezone}`);
+  }
+
+  const connector = input.connector ?? current.connector;
+  if (!isConnectorId(connector)) {
+    throw new CalendarSettingsError(`Conector desconocido: ${connector}`);
+  }
+
+  const next: CalendarSettings = {
+    weeklyHours: normalizeWeeklyHours(input.weeklyHours ?? current.weeklyHours),
+    slotMinutes: clampInt(
+      input.slotMinutes ?? current.slotMinutes,
+      LIMITS.slotMinutes.min,
+      LIMITS.slotMinutes.max
+    ),
+    bufferMinutes: clampInt(
+      input.bufferMinutes ?? current.bufferMinutes,
+      LIMITS.bufferMinutes.min,
+      LIMITS.bufferMinutes.max
+    ),
+    minNoticeHours: clampInt(
+      input.minNoticeHours ?? current.minNoticeHours,
+      LIMITS.minNoticeHours.min,
+      LIMITS.minNoticeHours.max
+    ),
+    maxDaysAhead: clampInt(
+      input.maxDaysAhead ?? current.maxDaysAhead,
+      LIMITS.maxDaysAhead.min,
+      LIMITS.maxDaysAhead.max
+    ),
+    timezone,
+    connector,
+    meetingLink: normalizeLink(
+      input.meetingLink !== undefined ? input.meetingLink : current.meetingLink
+    ),
+  };
+
+  const db = getDb();
+  const values = {
+    weeklyHours: next.weeklyHours,
+    slotMinutes: next.slotMinutes,
+    bufferMinutes: next.bufferMinutes,
+    minNoticeHours: next.minNoticeHours,
+    maxDaysAhead: next.maxDaysAhead,
+    timezone: next.timezone,
+    connector: next.connector,
+    meetingLink: next.meetingLink,
+  };
+  await db
+    .insert(schema.calendarSettings)
+    .values({
+      id: newId("calendarSettings"),
+      organizationId,
+      ...values,
+    })
+    .onConflictDoUpdate({
+      target: schema.calendarSettings.organizationId,
+      set: { ...values, updatedAt: new Date() },
+    });
+
+  return next;
+}
+
+/**
+ * Descarta intervalos inválidos y días vacíos (día cerrado) y ordena por hora
+ * de inicio. Se prefiere limpiar a rechazar: un día mal escrito no debe tumbar
+ * el guardado completo del horario.
+ */
+export function normalizeWeeklyHours(input: WeeklyHours): WeeklyHours {
+  const out: WeeklyHours = {};
+  if (typeof input !== "object" || input === null) return out;
+  for (const day of WEEKDAYS) {
+    const intervals = input[day];
+    if (!Array.isArray(intervals)) continue;
+    const valid = intervals
+      .filter(isValidInterval)
+      .sort((a, b) => a.start.localeCompare(b.start));
+    if (valid.length > 0) out[day] = valid;
+  }
+  return out;
+}
+
+/** Cadena vacía o espacios ⇒ null (el campo es opcional de verdad). */
+function normalizeLink(link: string | null | undefined): string | null {
+  const trimmed = (link ?? "").trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function clampInt(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, Math.round(value)));
+}

--- a/src/server/agenda/settings.ts
+++ b/src/server/agenda/settings.ts
@@ -99,9 +99,22 @@ export class CalendarSettingsError extends Error {
   }
 }
 
+/**
+ * Lo que llega de fuera, antes de normalizar: el horario y el conector vienen
+ * sueltos porque su validación vive AQUÍ. Si el tipo estricto se exigiera en la
+ * ruta, cada llamador tendría que hacer un cast — y un cast es justamente la
+ * comprobación que no ocurre.
+ */
+export type CalendarSettingsInput = Partial<
+  Omit<CalendarSettings, "weeklyHours" | "connector">
+> & {
+  weeklyHours?: unknown;
+  connector?: string;
+};
+
 export async function upsertSettings(
   organizationId: string,
-  input: Partial<CalendarSettings>
+  input: CalendarSettingsInput
 ): Promise<CalendarSettings> {
   const current = await getSettings(organizationId);
 
@@ -117,7 +130,9 @@ export async function upsertSettings(
   }
 
   const next: CalendarSettings = {
-    weeklyHours: normalizeWeeklyHours(input.weeklyHours ?? current.weeklyHours),
+    weeklyHours: normalizeWeeklyHours(
+      input.weeklyHours !== undefined ? input.weeklyHours : current.weeklyHours
+    ),
     slotMinutes: clampInt(
       input.slotMinutes ?? current.slotMinutes,
       LIMITS.slotMinutes.min,
@@ -176,11 +191,12 @@ export async function upsertSettings(
  * de inicio. Se prefiere limpiar a rechazar: un día mal escrito no debe tumbar
  * el guardado completo del horario.
  */
-export function normalizeWeeklyHours(input: WeeklyHours): WeeklyHours {
+export function normalizeWeeklyHours(input: unknown): WeeklyHours {
   const out: WeeklyHours = {};
   if (typeof input !== "object" || input === null) return out;
+  const source = input as Record<string, unknown>;
   for (const day of WEEKDAYS) {
-    const intervals = input[day];
+    const intervals = source[day];
     if (!Array.isArray(intervals)) continue;
     const valid = intervals
       .filter(isValidInterval)

--- a/src/server/agenda/spread.ts
+++ b/src/server/agenda/spread.ts
@@ -1,0 +1,62 @@
+import { dayIsoInTz, dayLabelInTz, timeInTz } from "@/lib/time/slots";
+import type { AvailableSlot } from "@/server/agenda/availability";
+
+/**
+ * 015 — Reparto de huecos entre días distintos.
+ *
+ * Los N huecos más próximos casi siempre caen todos HOY, y entonces quien
+ * conduce la conversación no tiene nada que ofrecer cuando el lead dice "¿y
+ * el jueves?". Esto toma `perDay` por día hasta completar `limit`, de modo que
+ * la oferta cubra varios días.
+ *
+ * El catálogo reservable es MÁS ANCHO que el menú que se muestra: se ofrecen
+ * (y se registran) hasta `limit`, aunque el agente enseñe tres. Guardar solo lo
+ * enseñado dejaba al agente sin alternativas legítimas que aceptar.
+ */
+
+export type SpreadSlot = AvailableSlot & {
+  /** Día del slot en la zona del negocio (YYYY-MM-DD). */
+  dayIso: string;
+  /** El día EN PALABRAS: "hoy miércoles 5 de agosto". */
+  dayLabel: string;
+  /** Solo la hora: "10:00". */
+  time: string;
+};
+
+export function spreadByDay(
+  slots: AvailableSlot[],
+  opts: { timezone: string; limit: number; perDay: number; now?: Date }
+): SpreadSlot[] {
+  const { timezone, limit, perDay } = opts;
+  const now = opts.now ?? new Date();
+  if (limit <= 0 || perDay <= 0) return [];
+
+  const byDay = new Map<string, AvailableSlot[]>();
+  for (const slot of slots) {
+    const dayIso = dayIsoInTz(new Date(slot.startUtc), timezone);
+    const bucket = byDay.get(dayIso);
+    if (bucket) bucket.push(slot);
+    else byDay.set(dayIso, [slot]);
+  }
+
+  // Los días ya vienen ordenados porque `slots` viene ordenado; el Map
+  // conserva el orden de inserción.
+  const out: SpreadSlot[] = [];
+  for (const [dayIso, daySlots] of byDay) {
+    for (const slot of daySlots.slice(0, perDay)) {
+      if (out.length >= limit) return out;
+      out.push({
+        ...slot,
+        dayIso,
+        dayLabel: dayLabelInTz(slot.startUtc, timezone, now),
+        time: timeInTz(slot.startUtc, timezone),
+      });
+    }
+  }
+  return out;
+}
+
+/** Los días (YYYY-MM-DD) que tienen algo que ofrecer. Los ausentes NO. */
+export function daysWithAgenda(slots: SpreadSlot[]): string[] {
+  return [...new Set(slots.map((s) => s.dayIso))];
+}

--- a/src/server/ai/actions.ts
+++ b/src/server/ai/actions.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
  * El servidor valida cada acción contra sus allowlists (etapas de la org);
  * lo que no valida se degrada, nunca se ejecuta a ciegas.
  */
-export const AgentAction = z.discriminatedUnion("action", [
+const baseActions = [
   z.object({ action: z.literal("none") }),
   z.object({ action: z.literal("reply"), text: z.string().min(1) }),
   z.object({
@@ -23,7 +23,41 @@ export const AgentAction = z.discriminatedUnion("action", [
     reason: z.string().optional(),
     farewell: z.string().optional(),
   }),
+] as const;
+
+/**
+ * 015 — Las dos acciones de agenda. Solo se registran si esta instancia tiene
+ * la bandera encendida: donde no hay agenda, el modelo ni siquiera puede
+ * nombrarlas.
+ *
+ * `reply` es una introducción opcional, NO la lista de horarios: los horarios
+ * los pega el motor con las etiquetas reales. Y `startUtc` tiene que ser
+ * exactamente uno de los que el sistema ofreció — si no, el motor lo rechaza y
+ * se re-ofrece.
+ */
+const agendaActions = [
+  z.object({
+    action: z.literal("offer_slots"),
+    reply: z.string().optional(),
+  }),
+  z.object({
+    action: z.literal("book_slot"),
+    startUtc: z.string().min(1),
+    reply: z.string().optional(),
+  }),
+] as const;
+
+export const AgentAction = z.discriminatedUnion("action", [
+  ...baseActions,
+  ...agendaActions,
 ]);
+
+/** El esquema que se le exige al modelo en ESTE turno. */
+export function agentActionSchema(agenda: boolean) {
+  return agenda
+    ? AgentAction
+    : z.discriminatedUnion("action", [...baseActions]);
+}
 
 export type AgentActionType = z.infer<typeof AgentAction>;
 
@@ -41,9 +75,13 @@ export function resolveStage(
   return stages.find((s) => s.name.toLowerCase() === lower) ?? null;
 }
 
-/** Degrada una move_stage sin etapa válida (FR-021 / contrato ai.md). */
+/** Degrada una acción que no se pudo ejecutar (FR-021 / contrato ai.md). */
 export function degradeAction(action: AgentActionType): AgentActionType {
-  if (action.action === "move_stage") {
+  if (
+    action.action === "move_stage" ||
+    action.action === "offer_slots" ||
+    action.action === "book_slot"
+  ) {
     return action.reply
       ? { action: "reply", text: action.reply }
       : { action: "none" };

--- a/src/server/ai/pipeline.ts
+++ b/src/server/ai/pipeline.ts
@@ -8,9 +8,16 @@ import { chatJson, type ChatMessage } from "@/lib/ai";
 import { publish } from "@/server/events/bus";
 import { isWindowOpen } from "@/server/inbox/window";
 import { SendError, sendText } from "@/server/inbox/send";
-import { AgentAction, degradeAction, resolveStage, type AgentActionType } from "@/server/ai/actions";
+import {
+  agentActionSchema,
+  degradeAction,
+  resolveStage,
+  type AgentActionType,
+} from "@/server/ai/actions";
 import { matchesHandoffIntent } from "@/server/ai/handoff";
 import { buildAgentSystemPrompt } from "@/server/ai/prompts";
+import { agendaEnabled } from "@/server/agenda/flag";
+import { bookSlot, offerSlots } from "@/server/agenda/agent";
 
 /**
  * Turno del agente (FR-021..FR-025).
@@ -144,10 +151,11 @@ export async function runAgentTurn(conversationId: string): Promise<void> {
     .where(eq(schema.pipelineStage.organizationId, organizationId))
     .orderBy(asc(schema.pipelineStage.position));
 
+  const agenda = agendaEnabled();
   const messages: ChatMessage[] = [
     {
       role: "system",
-      content: buildAgentSystemPrompt({ profile, kb, stages }),
+      content: buildAgentSystemPrompt({ profile, kb, stages, agenda }),
     },
     ...history
       .filter((m) => m.text)
@@ -157,7 +165,7 @@ export async function runAgentTurn(conversationId: string): Promise<void> {
       })),
   ];
 
-  const result = await chatJson(AgentAction, messages);
+  const result = await chatJson(agentActionSchema(agenda), messages);
   if (!result.ok) {
     if (result.error === "not_configured") return;
     // Fallo persistente del proveedor o salida imposible → escalar (FR-022).
@@ -167,6 +175,41 @@ export async function runAgentTurn(conversationId: string): Promise<void> {
   }
 
   let action: AgentActionType = result.data;
+
+  // 015 — Agenda. Un fallo del motor degrada el turno (el agente responde sin
+  // agendar), nunca lo tumba: quedarse callado es peor que no agendar.
+  if (action.action === "offer_slots" || action.action === "book_slot") {
+    if (!agenda) {
+      action = degradeAction(action);
+    } else {
+      try {
+        const turn =
+          action.action === "offer_slots"
+            ? await offerSlots({
+                organizationId,
+                conversationId,
+                intro: action.reply,
+              })
+            : await bookSlot({
+                organizationId,
+                conversationId,
+                startUtc: action.startUtc,
+                confirmation: action.reply,
+              });
+        await deliverReply(conversation, turn.text);
+        if (turn.ok) {
+          publish(organizationId, {
+            type: "conversation.updated",
+            data: { conversation: { id: conversationId } },
+          });
+        }
+        return;
+      } catch (err) {
+        console.error(`[agente] el motor de agenda falló: ${err}`);
+        action = degradeAction(action);
+      }
+    }
+  }
 
   if (action.action === "move_stage") {
     const stage = resolveStage(action.stage, stages);

--- a/src/server/ai/prompts.ts
+++ b/src/server/ai/prompts.ts
@@ -26,9 +26,27 @@ export function buildAgentSystemPrompt(input: {
   profile: AgentProfile;
   kb: KbEntry[];
   stages: { name: string }[];
+  /**
+   * 015 — ¿esta instancia tiene agenda? Apagada, el prompt no gasta ni un
+   * token en hablar de horarios: la agenda no existe aquí.
+   */
+  agenda?: boolean;
 }): string {
   const { profile } = input;
   const stageNames = input.stages.map((s) => s.name).join(" | ");
+  const agendaLines = input.agenda
+    ? [
+        '- {"action":"offer_slots","reply":"..."} — ofrecer horarios para agendar (reply es solo la frase de entrada; los horarios los pone el sistema).',
+        '- {"action":"book_slot","startUtc":"<uno de los horarios que el sistema ofreció, en ISO UTC>","reply":"..."} — agendar el horario que el cliente eligió.',
+      ]
+    : [];
+  const agendaRules = input.agenda
+    ? [
+        "- NUNCA escribas tú los horarios ni los inventes: usa offer_slots y el sistema pega los reales.",
+        "- book_slot solo acepta un horario que el sistema ofreció antes en ESTA conversación. Si el cliente pide otro, vuelve a ofrecer con offer_slots.",
+        "- Si el cliente quiere CANCELAR una cita → handoff: esa decisión no es tuya.",
+      ]
+    : [];
   return [
     `Eres "${profile.name}", el asistente de WhatsApp de este negocio. Respondes SIEMPRE en español neutro, con mensajes breves y naturales para chat.`,
     profile.tone ? `Tono: ${profile.tone}` : null,
@@ -46,10 +64,12 @@ export function buildAgentSystemPrompt(input: {
       '- {"action":"update_lead","note":"...","reply":"..."} — guardar una nota del lead (reply opcional).',
       '- {"action":"move_stage","stage":"<nombre exacto de etapa>","reply":"..."} — mover el lead (reply opcional).',
       '- {"action":"handoff","reason":"...","farewell":"..."} — escalar a un humano (farewell opcional para despedirte).',
+      ...agendaLines,
       "Reglas duras:",
       "- Si el cliente pide hablar con una persona/humano/asesor → handoff.",
       "- Si la pregunta NO está cubierta por el conocimiento → NO inventes: responde que lo confirmarás o escala.",
       "- Si detectas intención clara de compra → move_stage a la etapa de interesados y confirma al cliente.",
+      ...agendaRules,
       "- JSON puro, sin markdown ni texto adicional.",
     ].join("\n"),
   ]

--- a/src/server/dev/google-mock-state.ts
+++ b/src/server/dev/google-mock-state.ts
@@ -1,0 +1,66 @@
+/**
+ * 015 — Estado del mock de Google Calendar (solo entorno de pruebas).
+ *
+ * Imita la parte que más cuesta creer hasta que se ve: la conferencia de Meet
+ * NO viene en la respuesta de crear el evento. Aquí el primer `GET` del evento
+ * todavía la da como pendiente y el siguiente ya trae el enlace — así el
+ * self-test ejercita el camino real, no uno cómodo.
+ */
+
+export type MockEvent = {
+  id: string;
+  summary: string;
+  start: string;
+  end: string;
+  /** Cuántas veces se ha leído: la conferencia "termina" tras la primera. */
+  reads: number;
+  meetLink: string | null;
+  updates: number;
+};
+
+type MockState = {
+  events: Map<string, MockEvent>;
+  deleted: string[];
+  nextId: number;
+  /** Lecturas que tarda la conferencia en estar lista. */
+  conferenceDelayReads: number;
+};
+
+const globalForMock = globalThis as unknown as { __googleMock?: MockState };
+
+export function googleMockState(): MockState {
+  if (!globalForMock.__googleMock) {
+    globalForMock.__googleMock = {
+      events: new Map(),
+      deleted: [],
+      nextId: 1,
+      conferenceDelayReads: 1,
+    };
+  }
+  return globalForMock.__googleMock;
+}
+
+export function resetGoogleMock(): void {
+  const s = googleMockState();
+  s.events.clear();
+  s.deleted.length = 0;
+  s.nextId = 1;
+  s.conferenceDelayReads = 1;
+}
+
+export function googleMockSnapshot() {
+  const s = googleMockState();
+  return {
+    events: [...s.events.values()],
+    deleted: [...s.deleted],
+  };
+}
+
+/**
+ * Camino infeliz determinista: un refresh token terminado en `-invalid` hace
+ * que Google responda `invalid_grant` — exactamente lo que pasa cuando la app
+ * OAuth sigue en modo prueba y caducó a los 7 días.
+ */
+export function mockRefreshTokenIsBad(body: string): boolean {
+  return new URLSearchParams(body).get("refresh_token")?.endsWith("-invalid") ?? true;
+}

--- a/src/server/dev/zoom-mock-state.ts
+++ b/src/server/dev/zoom-mock-state.ts
@@ -1,0 +1,61 @@
+/**
+ * 015 — Estado del mock de Zoom (solo entorno de pruebas).
+ *
+ * Existe para que el self-test pueda AFIRMAR sobre lo que el CRM le mandó al
+ * proveedor —no solo que la petición no falló—: qué reunión se creó, que
+ * moverla usó el mismo id, y que cancelarla la borró. Y para que el sandbox
+ * del Laboratorio se pueda verificar por ausencia: tras una corrida de prueba,
+ * este estado tiene que estar VACÍO.
+ */
+
+export type MockMeeting = {
+  id: string;
+  topic: string;
+  startTime: string;
+  duration: number;
+  timezone: string;
+  joinUrl: string;
+  updates: number;
+};
+
+type MockState = {
+  meetings: Map<string, MockMeeting>;
+  deleted: string[];
+  nextId: number;
+};
+
+const globalForMock = globalThis as unknown as { __zoomMock?: MockState };
+
+export function zoomMockState(): MockState {
+  if (!globalForMock.__zoomMock) {
+    globalForMock.__zoomMock = { meetings: new Map(), deleted: [], nextId: 1 };
+  }
+  return globalForMock.__zoomMock;
+}
+
+export function resetZoomMock(): void {
+  const s = zoomMockState();
+  s.meetings.clear();
+  s.deleted.length = 0;
+  s.nextId = 1;
+}
+
+export function zoomMockSnapshot() {
+  const s = zoomMockState();
+  return {
+    meetings: [...s.meetings.values()],
+    deleted: [...s.deleted],
+  };
+}
+
+/**
+ * El camino infeliz, determinista: un secreto terminado en `-invalid` hace que
+ * el mock rechace la autenticación. Sin esto, el self-test solo podría probar
+ * que todo sale bien — y lo que hay que probar es que cuando el proveedor
+ * falla, la cita se crea igual.
+ */
+export function mockCredentialsAreBad(authHeader: string | null): boolean {
+  if (!authHeader?.startsWith("Basic ")) return true;
+  const decoded = Buffer.from(authHeader.slice(6), "base64").toString("utf8");
+  return decoded.endsWith("-invalid");
+}

--- a/src/server/events/bus.ts
+++ b/src/server/events/bus.ts
@@ -19,6 +19,8 @@ export type SseEvent =
       };
     }
   | { type: "conversation.updated"; data: { conversation: unknown } }
+  /** 015 — algo cambió en la agenda: la pantalla de Citas se refresca sola. */
+  | { type: "booking.updated"; data: { bookingId: string } }
   | {
       type: "lab.run";
       data: {

--- a/src/server/lab/runner.ts
+++ b/src/server/lab/runner.ts
@@ -247,8 +247,15 @@ async function upsertTestContact(
       name: persona.contactName,
       archivedAt: new Date(),
     })
+    // Ídem que en el alta manual: desde 014 el índice único incluye `channel`,
+    // y un ON CONFLICT que no lo nombra no corresponde a ningún índice. Sin
+    // esto, TODA corrida del Laboratorio muere antes de la primera persona.
     .onConflictDoNothing({
-      target: [schema.contact.organizationId, schema.contact.waIdentity],
+      target: [
+        schema.contact.organizationId,
+        schema.contact.channel,
+        schema.contact.waIdentity,
+      ],
     })
     .returning();
   if (inserted[0]) return inserted[0].id;

--- a/tests/e2e/us-agenda.md
+++ b/tests/e2e/us-agenda.md
@@ -1,0 +1,84 @@
+# E2E — Motor de agenda universal (015)
+
+Guion de comportamiento observable. Automatizado en la sección `015` de
+`scripts/e2e-selftest.mjs`: con la app viva y los mocks encendidos,
+`pnpm test:e2e` lo conduce y sale distinto de cero si algo falla.
+
+**Preparación**: app en `localhost` con `WA_MOCK_ENABLED=true`,
+`META_GRAPH_BASE_URL` → wa-mock, `ZOOM_BASE_URL`/`ZOOM_OAUTH_BASE_URL` →
+zoom-mock, `BOT_API_KEY` y la BD migrada. La bandera `AGENDA` decide qué mitad
+del guion corre: ambas se ejercitan en la matriz de CI.
+
+---
+
+## US1 — La instancia decide si la agenda existe
+
+Con `AGENDA` ausente:
+
+1. `GET /api/calendar/settings`, `/api/calendar/availability` y `/api/bookings`
+   responden **404**.
+2. `GET /api/bot/availability` responde **404** — antes incluso de mirar la
+   llave: el endpoint no existe aquí.
+3. La pantalla `/bookings` responde 404 y la navegación no la menciona.
+
+Con `AGENDA=on`, las mismas rutas responden con normalidad.
+
+## US2 — El negocio define cuándo atiende
+
+1. Una instancia recién encendida devuelve **defaults usables** (cita de 30
+   min, conector `enlace-fijo`) con 200, no un 404.
+2. Se guarda un horario y una sala fija; la disponibilidad devuelve huecos.
+3. Cada hueco trae el **día en palabras** además de la hora — la etiqueta corta
+   ya agendó una cita el día equivocado en producción.
+4. Una zona horaria inventada se rechaza con **422** en vez de guardarse y
+   romper el motor después.
+
+## US3 — Las dos garantías
+
+1. **Solo se reserva lo que se ofreció**: un instante libre y válido, pero
+   nunca ofrecido a esa conversación, se rechaza con `409 slot_not_offered` y
+   la respuesta trae lo que sí se ofreció.
+2. **Camino feliz**: reservar un hueco ofrecido responde **201 Created** (no
+   200), con etiqueta y enlace; el hueco desaparece de la disponibilidad y la
+   cita aparece en Citas marcada como agendada por la IA.
+3. **La carrera**: un segundo intento sobre el mismo instante responde `409`
+   con el sobre **anidado** y `slots` como **hermano**; en la base queda **una
+   sola cita activa** en ese instante.
+4. Las alternativas del `409` ya son la oferta vigente: reservar una de ellas
+   responde 201 de inmediato.
+5. **Reprogramar** por la superficie del bot responde **200**, no 201.
+
+## US4 — El operador
+
+1. Cancelar dos veces no falla (idempotente).
+2. Reintentar el enlace de una cita que ya lo tiene responde 422.
+3. **El proveedor caído no cuesta la conversión**: con el conector externo sin
+   credenciales, reservar responde **201 igualmente**, con
+   `linkPending: true` y `meetingLink: null`, y la cita se ve como "sin enlace"
+   en Citas.
+
+## US5 — Conector Zoom
+
+1. Unas credenciales que el proveedor rechaza responden 422 y **no se
+   guardan**: la conexión sigue sin existir.
+2. Unas válidas se guardan y hacia el navegador solo salen sus **últimos 4** —
+   el secreto no aparece en la respuesta.
+3. Agendar crea la reunión: el proveedor la recibe con su tema y su hora, y el
+   enlace vuelve en la respuesta.
+4. Cancelar la cita **borra** la reunión en el proveedor.
+
+## US6 — Conector Google
+
+Cubierto por la suite de contrato (`tests/unit/connectors.test.ts`), que fija
+lo que su mock reproduce: el enlace de Meet **no** viene en la respuesta de
+crear el evento —la conferencia es asíncrona—, el conector re-lee, y si sigue
+pendiente entrega el evento sin enlace en vez de fallar. Reintentar re-lee ese
+mismo evento: **nunca** crea uno duplicado en el calendario del dueño.
+
+## Sandbox del Laboratorio
+
+1. Una conversación de prueba **puede** agendar (201) y la cita queda marcada
+   como de prueba.
+2. Con un conector externo activo, el estado del mock queda **vacío**: el
+   proveedor jamás se entera de una cita de prueba. Se verifica por ausencia, y
+   vale igual para crear, reprogramar y cancelar.

--- a/tests/unit/agenda-contract.test.ts
+++ b/tests/unit/agenda-contract.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  bookingErrorResponse,
+  bookingErrorStatus,
+  bookingPayload,
+} from "@/server/agenda/http";
+import { BookingError } from "@/server/agenda/service";
+import { agendaDisabledResponse } from "@/server/agenda/flag";
+
+/**
+ * 015 — El CONTRATO observable de la agenda, fijado en un test.
+ *
+ * No es purismo REST: los dos fallos que esto previene ocurrieron en
+ * producción y ninguno lo detectaron los mocks, porque los mocks respondían
+ * otra cosa que el servidor real. Aquí el cliente y el servidor miran la misma
+ * definición.
+ */
+
+const result = {
+  booking: { id: "bk_123" },
+  meetingLink: "https://meet.ejemplo.com/sala",
+  linkPending: false,
+  label: "mié 5 ago, 09:00",
+} as never;
+
+describe("cuerpo de una reserva creada", () => {
+  it("lleva el id, el enlace, si el enlace está pendiente y la etiqueta", () => {
+    expect(bookingPayload(result)).toEqual({
+      bookingId: "bk_123",
+      meetingLink: "https://meet.ejemplo.com/sala",
+      linkPending: false,
+      label: "mié 5 ago, 09:00",
+    });
+  });
+
+  it("`linkPending` viaja SIEMPRE: es lo que decide si se promete el enlace", () => {
+    const pendiente = bookingPayload({
+      ...(result as object),
+      meetingLink: null,
+      linkPending: true,
+    } as never);
+    expect(pendiente.meetingLink).toBeNull();
+    expect(pendiente.linkPending).toBe(true);
+  });
+});
+
+describe("códigos de estado", () => {
+  it("los conflictos de hueco son 409, no 400", () => {
+    expect(bookingErrorStatus("slot_taken")).toBe(409);
+    expect(bookingErrorStatus("slot_not_offered")).toBe(409);
+  });
+
+  it("no encontrado es 404 y payload inválido 422", () => {
+    expect(bookingErrorStatus("not_found")).toBe(404);
+    expect(bookingErrorStatus("invalid")).toBe(422);
+  });
+});
+
+describe("forma del error", () => {
+  it("el sobre va ANIDADO y `slots` es HERMANO de `error`", async () => {
+    const slots = [{ startUtc: "2026-08-05T15:30:00.000Z", label: "mié 5 ago, 09:30" }];
+    const res = bookingErrorResponse(
+      new BookingError("slot_taken", "Ese horario acaba de ocuparse", slots)
+    );
+    expect(res.status).toBe(409);
+
+    const body = (await res.json()) as {
+      error: { code: string; message: string };
+      slots: { label: string }[];
+    };
+    // Anidado: un mock con la forma plana `{code}` hizo que todo 409 se leyera
+    // como conflicto genérico y el camino de re-oferta nunca se activara.
+    expect(body.error.code).toBe("slot_taken");
+    expect(body.error.message).toContain("ocuparse");
+    // Hermano: es lo que el cliente usa para re-ofrecer sin otra ida y vuelta.
+    expect(body.slots).toHaveLength(1);
+    expect(body.slots[0]!.label).toBe("mié 5 ago, 09:30");
+  });
+
+  it("`invalid` sale como `invalid_body`, el código que ya usa el resto de la API", async () => {
+    const res = bookingErrorResponse(new BookingError("invalid", "Instante inválido"));
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("invalid_body");
+  });
+
+  it("un error que no es del dominio se relanza en vez de disfrazarse de 409", () => {
+    expect(() => bookingErrorResponse(new Error("se cayó la base"))).toThrow(
+      "se cayó la base"
+    );
+  });
+});
+
+describe("la agenda apagada", () => {
+  it("responde 404 sin cuerpo: ese endpoint no existe en esta instancia", () => {
+    const res = agendaDisabledResponse();
+    // 404 y no 403: un 403 confirmaría que la agenda existe pero está vedada.
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/unit/agenda-flag.test.ts
+++ b/tests/unit/agenda-flag.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { parseAgendaFlag } from "@/server/agenda/flag";
+
+/**
+ * 015 — La bandera de la agenda. El caso que importa es el DEFAULT: una
+ * instancia que no la pidió no debe acabar con la agenda encendida por un
+ * despiste de configuración.
+ */
+
+describe("parseAgendaFlag", () => {
+  it("sin variable, la agenda no existe", () => {
+    expect(parseAgendaFlag(undefined)).toBe(false);
+    expect(parseAgendaFlag("")).toBe(false);
+    expect(parseAgendaFlag("   ")).toBe(false);
+  });
+
+  it("`on` la enciende, con espacios y mayúsculas de por medio", () => {
+    expect(parseAgendaFlag("on")).toBe(true);
+    expect(parseAgendaFlag("ON")).toBe(true);
+    expect(parseAgendaFlag("  On  ")).toBe(true);
+  });
+
+  it("acepta las otras formas de decir que sí", () => {
+    expect(parseAgendaFlag("1")).toBe(true);
+    expect(parseAgendaFlag("true")).toBe(true);
+    expect(parseAgendaFlag("TRUE")).toBe(true);
+    expect(parseAgendaFlag("si")).toBe(true);
+    expect(parseAgendaFlag("sí")).toBe(true);
+    expect(parseAgendaFlag("yes")).toBe(true);
+  });
+
+  it("cualquier otra cosa deja la agenda apagada, incluido `off` y `false`", () => {
+    expect(parseAgendaFlag("off")).toBe(false);
+    expect(parseAgendaFlag("false")).toBe(false);
+    expect(parseAgendaFlag("0")).toBe(false);
+    expect(parseAgendaFlag("no")).toBe(false);
+    expect(parseAgendaFlag("agenda")).toBe(false);
+    // Un typo no enciende nada: apagada es el estado seguro.
+    expect(parseAgendaFlag("onn")).toBe(false);
+  });
+});

--- a/tests/unit/agenda-sandbox.test.ts
+++ b/tests/unit/agenda-sandbox.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * 015 — El sandbox del Laboratorio en la agenda.
+ *
+ * Una cita de una conversación de prueba se registra, pero JAMÁS llega a un
+ * conector: nadie crea una reunión de Zoom ni un evento en el calendario del
+ * dueño por una simulación.
+ *
+ * Se prueba aquí y no en el arnés E2E por una razón concreta: las
+ * conversaciones del Laboratorio no son alcanzables desde la API pública (a
+ * propósito), así que no hay forma de conducirlas desde fuera. Este test sí
+ * puede afirmar lo que importa —que el conector no se llama— en vez de
+ * observarlo por ausencia.
+ *
+ * En el fork del que salió este motor la protección es ASIMÉTRICA: existe al
+ * crear y está cableada a `false` al reprogramar y cancelar. Ahí no rompe nada
+ * de milagro; aquí se comprueban las tres.
+ */
+
+const settings = {
+  weeklyHours: { wed: [{ start: "09:00", end: "18:00" }] },
+  slotMinutes: 30,
+  bufferMinutes: 0,
+  minNoticeHours: 0,
+  maxDaysAhead: 7,
+  timezone: "America/Mexico_City",
+  connector: "zoom" as const,
+  meetingLink: null,
+};
+
+const SLOT = "2026-08-05T15:00:00.000Z";
+
+const createMeeting = vi.fn(async () => ({
+  externalId: "zoom_1",
+  joinUrl: "https://zoom.test/j/1",
+}));
+const updateMeeting = vi.fn(async () => {});
+const deleteMeeting = vi.fn(async () => {});
+const bindConnector = vi.fn(async () => ({
+  id: "zoom",
+  createMeeting,
+  updateMeeting,
+  deleteMeeting,
+  testConnection: async () => ({ ok: true }),
+}));
+
+vi.mock("@/server/agenda/settings", () => ({ getSettings: async () => settings }));
+vi.mock("@/server/agenda/availability", () => ({
+  findSlot: async () => ({ startUtc: SLOT, endUtc: "…", label: "mié 5 ago, 09:00" }),
+  computeAvailability: async () => [],
+}));
+vi.mock("@/server/agenda/offers", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/server/agenda/offers")>();
+  return {
+    ...original,
+    getOffers: async () => [{ startUtc: SLOT, label: "mié 5 ago, 09:00" }],
+    replaceOffers: async () => {},
+    clearOffers: async () => {},
+  };
+});
+vi.mock("@/server/agenda/connectors", () => ({
+  bindConnector,
+  markConnectorAuthError: async () => {},
+}));
+vi.mock("@/server/leads/stage-history", () => ({
+  moveLeadToStage: async () => ({ ok: true }),
+}));
+vi.mock("@/server/events/bus", () => ({ publish: () => {} }));
+
+const selectRows: unknown[][] = [];
+let lastInsert: Record<string, unknown> | null = null;
+/** La fila que devuelve un `update(...).returning()`. */
+let updatedRow: Record<string, unknown> = {};
+
+function chain(rows: unknown[]) {
+  const c: Record<string, unknown> = {};
+  for (const m of ["from", "where", "orderBy", "leftJoin"]) c[m] = () => c;
+  c.limit = () => Promise.resolve(rows);
+  return c;
+}
+
+vi.mock("@/lib/db", () => ({
+  getDb: () => ({
+    select: () => chain(selectRows.shift() ?? []),
+    insert: () => ({
+      values: (v: Record<string, unknown>) => ({
+        returning: () => {
+          lastInsert = v;
+          return Promise.resolve([
+            { ...v, scheduledAt: new Date(SLOT), externalRef: null, linkPending: false },
+          ]);
+        },
+      }),
+    }),
+    update: () => ({
+      set: (v: Record<string, unknown>) => ({
+        where: () => ({
+          returning: () => Promise.resolve([{ ...updatedRow, ...v }]),
+        }),
+      }),
+    }),
+  }),
+  schema: {
+    booking: {},
+    conversation: { organizationId: "organizationId", id: "id" },
+    contact: { organizationId: "organizationId", id: "id", name: "name" },
+    lead: { organizationId: "organizationId", contactId: "contactId" },
+    pipelineStage: { organizationId: "organizationId" },
+    offeredSlot: {},
+  },
+}));
+
+const CITA_DE_PRUEBA = {
+  id: "bk_test",
+  organizationId: "org_1",
+  scheduledAt: new Date(SLOT),
+  durationMinutes: 30,
+  status: "agendada",
+  isTest: true,
+  connector: "zoom",
+  // Aunque tuviera reunión, no debe tocarse: es de prueba.
+  externalRef: "zoom_viejo",
+  meetingLink: null,
+  linkPending: false,
+  notes: null,
+  contactId: "ct_1",
+};
+
+describe("una cita del Laboratorio jamás llega al proveedor", () => {
+  beforeEach(() => {
+    selectRows.length = 0;
+    lastInsert = null;
+    updatedRow = { ...CITA_DE_PRUEBA };
+    createMeeting.mockClear();
+    updateMeeting.mockClear();
+    deleteMeeting.mockClear();
+    bindConnector.mockClear();
+  });
+
+  it("al CREAR: la cita se registra como de prueba y no se crea reunión", async () => {
+    const { createSessionBooking } = await import("@/server/agenda/service");
+    selectRows.push([{ contactId: "ct_1", isTest: true }]); // la conversación
+    selectRows.push([{ name: "Persona simulada" }]); // el contacto
+    selectRows.push([]); // sin lead
+
+    const result = await createSessionBooking({
+      organizationId: "org_1",
+      conversationId: "cv_lab",
+      startUtc: SLOT,
+      source: "ai",
+      requireOffer: true,
+    });
+
+    expect(lastInsert?.isTest).toBe(true);
+    expect(result.booking.isTest).toBe(true);
+    // Lo que importa: ni siquiera se resolvió el conector.
+    expect(bindConnector).not.toHaveBeenCalled();
+    expect(createMeeting).not.toHaveBeenCalled();
+  });
+
+  it("al REPROGRAMAR: no se mueve nada en el proveedor", async () => {
+    const { rescheduleBooking } = await import("@/server/agenda/service");
+    selectRows.push([CITA_DE_PRUEBA]);
+
+    await rescheduleBooking({
+      organizationId: "org_1",
+      bookingId: "bk_test",
+      startUtc: SLOT,
+    });
+
+    expect(updateMeeting).not.toHaveBeenCalled();
+    expect(bindConnector).not.toHaveBeenCalled();
+  });
+
+  it("al CANCELAR: no se borra nada en el proveedor", async () => {
+    const { cancelBooking } = await import("@/server/agenda/service");
+    selectRows.push([CITA_DE_PRUEBA]);
+
+    await cancelBooking({ organizationId: "org_1", bookingId: "bk_test" });
+
+    expect(deleteMeeting).not.toHaveBeenCalled();
+    expect(bindConnector).not.toHaveBeenCalled();
+  });
+
+  it("una cita REAL sí llega al proveedor (el guardarraíl no apaga todo)", async () => {
+    const { createSessionBooking } = await import("@/server/agenda/service");
+    selectRows.push([{ contactId: "ct_1", isTest: false }]);
+    selectRows.push([{ name: "Cliente real" }]);
+    selectRows.push([]);
+
+    await createSessionBooking({
+      organizationId: "org_1",
+      conversationId: "cv_real",
+      startUtc: SLOT,
+      source: "ai",
+      requireOffer: true,
+    });
+
+    expect(createMeeting).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/availability.test.ts
+++ b/tests/unit/availability.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCandidateSlots,
+  filterFreeSlots,
+} from "@/server/agenda/availability";
+import {
+  DEFAULT_CALENDAR_SETTINGS,
+  normalizeWeeklyHours,
+  type CalendarSettings,
+} from "@/server/agenda/settings";
+import { daysWithAgenda, spreadByDay } from "@/server/agenda/spread";
+
+/** 015 — El motor: horario − ocupado, con aviso mínimo. Sin BD ni reloj real. */
+
+const MX = "America/Mexico_City";
+
+function settings(over: Partial<CalendarSettings> = {}): CalendarSettings {
+  return { ...DEFAULT_CALENDAR_SETTINGS, ...over };
+}
+
+describe("buildCandidateSlots", () => {
+  it("solo genera slots en los días con horario (L-V por defecto)", () => {
+    // 2026-08-08 es sábado; 2026-08-10 lunes.
+    const slots = buildCandidateSlots(settings(), "2026-08-08", "2026-08-10");
+    const días = new Set(slots.map((s) => s.startUtc.slice(0, 10)));
+    expect(días.has("2026-08-08")).toBe(false); // sábado cerrado
+    expect(días.has("2026-08-09")).toBe(false); // domingo cerrado
+    expect(días.size).toBeGreaterThan(0); // el lunes sí
+  });
+
+  it("respeta la duración configurada", () => {
+    const cortos = buildCandidateSlots(
+      settings({ slotMinutes: 30 }),
+      "2026-08-05",
+      "2026-08-05"
+    );
+    const largos = buildCandidateSlots(
+      settings({ slotMinutes: 60 }),
+      "2026-08-05",
+      "2026-08-05"
+    );
+    // 09:00-18:00 ⇒ 18 slots de 30 min, 9 de 60.
+    expect(cortos).toHaveLength(18);
+    expect(largos).toHaveLength(9);
+  });
+
+  it("un horario vacío no genera nada (negocio sin configurar días)", () => {
+    expect(
+      buildCandidateSlots(
+        settings({ weeklyHours: {} }),
+        "2026-08-03",
+        "2026-08-07"
+      )
+    ).toEqual([]);
+  });
+});
+
+describe("filterFreeSlots", () => {
+  const tz = MX;
+  const candidates = buildCandidateSlots(
+    settings(),
+    "2026-08-05",
+    "2026-08-05"
+  );
+
+  it("descarta lo que no cumple el aviso mínimo", () => {
+    // "Ahora" son las 09:00 locales del mismo día, con 2 h de aviso ⇒ el
+    // primer hueco ofrecible es a las 11:00 locales (17:00Z).
+    const now = new Date("2026-08-05T15:00:00.000Z");
+    const free = filterFreeSlots(candidates, [], {
+      now,
+      minNoticeHours: 2,
+      timezone: tz,
+    });
+    expect(free[0]!.startUtc).toBe("2026-08-05T17:00:00.000Z");
+  });
+
+  it("sin aviso mínimo ofrece desde el instante actual", () => {
+    const now = new Date("2026-08-05T15:00:00.000Z");
+    const free = filterFreeSlots(candidates, [], {
+      now,
+      minNoticeHours: 0,
+      timezone: tz,
+    });
+    expect(free[0]!.startUtc).toBe("2026-08-05T15:00:00.000Z");
+  });
+
+  it("una cita ocupada retira su hueco y solo ese", () => {
+    const now = new Date("2026-08-05T00:00:00.000Z");
+    const ocupado = [
+      {
+        startUtc: "2026-08-05T16:00:00.000Z",
+        endUtc: "2026-08-05T16:30:00.000Z",
+      },
+    ];
+    const libres = filterFreeSlots(candidates, ocupado, {
+      now,
+      minNoticeHours: 0,
+      timezone: tz,
+    });
+    const inicios = libres.map((s) => s.startUtc);
+    expect(inicios).not.toContain("2026-08-05T16:00:00.000Z");
+    expect(inicios).toContain("2026-08-05T16:30:00.000Z");
+    expect(inicios).toContain("2026-08-05T15:30:00.000Z");
+  });
+
+  it("un bloqueo largo retira todos los huecos que toca", () => {
+    const now = new Date("2026-08-05T00:00:00.000Z");
+    const bloqueo = [
+      {
+        startUtc: "2026-08-05T15:00:00.000Z",
+        endUtc: "2026-08-05T17:00:00.000Z", // 2 h ⇒ 4 slots de 30
+      },
+    ];
+    const libres = filterFreeSlots(candidates, bloqueo, {
+      now,
+      minNoticeHours: 0,
+      timezone: tz,
+    });
+    expect(libres).toHaveLength(candidates.length - 4);
+  });
+
+  it("devuelve los huecos ordenados y etiquetados", () => {
+    const now = new Date("2026-08-05T00:00:00.000Z");
+    const libres = filterFreeSlots([...candidates].reverse(), [], {
+      now,
+      minNoticeHours: 0,
+      timezone: tz,
+    });
+    const tiempos = libres.map((s) => Date.parse(s.startUtc));
+    expect([...tiempos].sort((a, b) => a - b)).toEqual(tiempos);
+    expect(libres[0]!.label).toContain("09:00");
+  });
+
+  it("agenda llena ⇒ lista vacía, no error", () => {
+    const now = new Date("2026-08-05T00:00:00.000Z");
+    const todo = candidates.map((c) => ({
+      startUtc: c.startUtc,
+      endUtc: c.endUtc,
+    }));
+    expect(
+      filterFreeSlots(candidates, todo, {
+        now,
+        minNoticeHours: 0,
+        timezone: tz,
+      })
+    ).toEqual([]);
+  });
+});
+
+/**
+ * Sin reparto, los primeros huecos se los come el día de hoy y quien ofrece se
+ * queda sin nada que decir cuando el lead pide otro día.
+ */
+describe("spreadByDay", () => {
+  // 14:00Z son las 08:00 en México: "hoy" es el miércoles 5, no la víspera.
+  // (Con 00:00Z el día local del negocio sería todavía el 4 — el motor decide
+  // el día en la zona del negocio, no en la del servidor.)
+  const now = new Date("2026-08-05T14:00:00.000Z");
+  // Mié 5 a vie 7 de agosto, 09:00-18:00, citas de 30 ⇒ 18 huecos por día.
+  const libres = filterFreeSlots(
+    buildCandidateSlots(settings(), "2026-08-05", "2026-08-07"),
+    [],
+    { now, minNoticeHours: 0, timezone: MX }
+  );
+
+  it("toma como mucho `perDay` de cada día, en vez de los N más próximos", () => {
+    const spread = spreadByDay(libres, {
+      timezone: MX,
+      limit: 12,
+      perDay: 3,
+      now,
+    });
+    expect(spread).toHaveLength(9); // 3 días × 3
+    expect(daysWithAgenda(spread)).toEqual([
+      "2026-08-05",
+      "2026-08-06",
+      "2026-08-07",
+    ]);
+  });
+
+  it("el límite corta el total sin romper el reparto", () => {
+    const spread = spreadByDay(libres, {
+      timezone: MX,
+      limit: 4,
+      perDay: 3,
+      now,
+    });
+    expect(spread).toHaveLength(4);
+    // 3 del primer día + 1 del segundo: el límite no se come la variedad.
+    expect(daysWithAgenda(spread)).toEqual(["2026-08-05", "2026-08-06"]);
+  });
+
+  it("cada hueco viaja con su día EN PALABRAS y su hora", () => {
+    const spread = spreadByDay(libres, {
+      timezone: MX,
+      limit: 3,
+      perDay: 1,
+      now,
+    });
+    expect(spread[0]!.dayLabel).toMatch(/^hoy /);
+    expect(spread[1]!.dayLabel).toMatch(/^mañana /);
+    expect(spread[0]!.time).toBe("09:00");
+  });
+
+  it("sin huecos no inventa días", () => {
+    expect(
+      spreadByDay([], { timezone: MX, limit: 12, perDay: 3, now })
+    ).toEqual([]);
+  });
+});
+
+describe("normalizeWeeklyHours", () => {
+  it("descarta intervalos inválidos sin tumbar el resto del horario", () => {
+    const out = normalizeWeeklyHours({
+      mon: [
+        { start: "09:00", end: "18:00" },
+        { start: "20:00", end: "19:00" }, // fin antes del inicio
+        { start: "9:00", end: "18:00" }, // formato inválido
+      ],
+      tue: [],
+    });
+    expect(out.mon).toEqual([{ start: "09:00", end: "18:00" }]);
+    expect(out.tue).toBeUndefined(); // día sin franjas válidas = cerrado
+  });
+
+  it("ordena las franjas por hora de inicio", () => {
+    const out = normalizeWeeklyHours({
+      wed: [
+        { start: "16:00", end: "18:00" },
+        { start: "09:00", end: "13:00" },
+      ],
+    });
+    expect(out.wed?.[0]?.start).toBe("09:00");
+  });
+});

--- a/tests/unit/booking-race.test.ts
+++ b/tests/unit/booking-race.test.ts
@@ -1,0 +1,244 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * 015 — La carrera del hueco (FR-006).
+ *
+ * Dos confirmaciones simultáneas del mismo instante pasan las dos la
+ * re-validación —entre leer y escribir cabe la otra— y es la BASE quien las
+ * separa, con el índice único parcial. Lo que se fija aquí es la traducción de
+ * ese choque: `23505` ⇒ `slot_taken` CON alternativas frescas, y jamás una
+ * cita creada.
+ *
+ * La carrera de verdad, con dos peticiones concurrentes contra la app viva, la
+ * corre el arnés E2E: esto asegura que cuando ocurra, la respuesta sea útil.
+ */
+
+const settings = {
+  weeklyHours: { wed: [{ start: "09:00", end: "18:00" }] },
+  slotMinutes: 30,
+  bufferMinutes: 0,
+  minNoticeHours: 0,
+  maxDaysAhead: 7,
+  timezone: "America/Mexico_City",
+  connector: "enlace-fijo" as const,
+  meetingLink: "https://meet.ejemplo.com/sala",
+};
+
+const SLOT = "2026-08-05T15:00:00.000Z";
+
+const ALTERNATIVES = [
+  { startUtc: "2026-08-05T15:30:00.000Z", endUtc: "…", label: "mié 5 ago, 09:30" },
+  { startUtc: "2026-08-05T16:00:00.000Z", endUtc: "…", label: "mié 5 ago, 10:00" },
+];
+
+const replaceOffers = vi.fn(async () => {});
+const clearOffers = vi.fn(async () => {});
+const moveLeadToStage = vi.fn(async () => ({ ok: true as const }));
+const createMeeting = vi.fn(async () => ({
+  externalId: null,
+  joinUrl: settings.meetingLink,
+}));
+
+vi.mock("@/server/agenda/settings", () => ({
+  getSettings: async () => settings,
+}));
+
+vi.mock("@/server/agenda/availability", () => ({
+  // El hueco se ve libre al re-validar: la otra confirmación aún no escribía.
+  findSlot: async () => ({ startUtc: SLOT, endUtc: "…", label: "mié 5 ago, 09:00" }),
+  computeAvailability: async () => ALTERNATIVES,
+}));
+
+vi.mock("@/server/agenda/offers", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/server/agenda/offers")>();
+  return {
+    ...original,
+    getOffers: async () => [{ startUtc: SLOT, label: "mié 5 ago, 09:00" }],
+    replaceOffers,
+    clearOffers,
+  };
+});
+
+vi.mock("@/server/agenda/connectors", () => ({
+  bindConnector: async () => ({
+    id: "enlace-fijo",
+    createMeeting,
+    updateMeeting: async () => {},
+    deleteMeeting: async () => {},
+    testConnection: async () => ({ ok: true }),
+  }),
+  markConnectorAuthError: async () => {},
+}));
+
+vi.mock("@/server/leads/stage-history", () => ({ moveLeadToStage }));
+vi.mock("@/server/events/bus", () => ({ publish: () => {} }));
+
+/** Cola de resultados para cada `select(...).limit(n)` en orden de llamada. */
+const selectRows: unknown[][] = [];
+/** Si tiene algo, el INSERT lo lanza en vez de insertar. */
+let insertThrows: unknown = null;
+const inserted: unknown[] = [];
+
+function chain(rows: unknown[]) {
+  const c: Record<string, unknown> = {};
+  for (const m of ["from", "where", "orderBy", "leftJoin", "innerJoin"]) {
+    c[m] = () => c;
+  }
+  c.limit = () => Promise.resolve(rows);
+  return c;
+}
+
+vi.mock("@/lib/db", () => ({
+  getDb: () => ({
+    select: () => chain(selectRows.shift() ?? []),
+    insert: () => ({
+      values: (v: unknown) => ({
+        returning: () => {
+          if (insertThrows) return Promise.reject(insertThrows);
+          inserted.push(v);
+          return Promise.resolve([
+            {
+              ...(v as object),
+              scheduledAt: new Date(SLOT),
+              meetingLink: null,
+              linkPending: false,
+              isTest: false,
+              externalRef: null,
+            },
+          ]);
+        },
+      }),
+    }),
+    update: () => ({
+      set: (v: unknown) => ({
+        where: () => ({
+          returning: () =>
+            Promise.resolve([
+              {
+                id: "bk_1",
+                organizationId: "org_1",
+                scheduledAt: new Date(SLOT),
+                durationMinutes: 30,
+                isTest: false,
+                connector: "enlace-fijo",
+                notes: null,
+                contactId: "ct_1",
+                ...(v as object),
+              },
+            ]),
+        }),
+      }),
+    }),
+  }),
+  schema: {
+    booking: {},
+    conversation: { organizationId: "organizationId", id: "id" },
+    contact: { organizationId: "organizationId", id: "id", name: "name" },
+    lead: { organizationId: "organizationId", contactId: "contactId" },
+    pipelineStage: { organizationId: "organizationId" },
+    offeredSlot: {},
+  },
+}));
+
+function primeLookups() {
+  // 1) la conversación, 2) el nombre del contacto, 3) el lead
+  selectRows.push([{ contactId: "ct_1", isTest: false }]);
+  selectRows.push([{ name: "Ana" }]);
+  selectRows.push([{ id: "ld_1" }]);
+}
+
+describe("la carrera del hueco", () => {
+  beforeEach(() => {
+    selectRows.length = 0;
+    inserted.length = 0;
+    insertThrows = null;
+    replaceOffers.mockClear();
+    clearOffers.mockClear();
+  });
+
+  it("un 23505 se traduce a slot_taken con alternativas frescas, sin crear la cita", async () => {
+    const { createSessionBooking, BookingError } = await import(
+      "@/server/agenda/service"
+    );
+    primeLookups();
+    insertThrows = { code: "23505" };
+
+    const promise = createSessionBooking({
+      organizationId: "org_1",
+      conversationId: "cv_1",
+      startUtc: SLOT,
+      source: "ai",
+      requireOffer: true,
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(BookingError);
+    await promise.catch((err) => {
+      expect(err.code).toBe("slot_taken");
+      // Con alternativas concretas: sin ellas, la conversación se queda sin
+      // salida y el cliente sin cita.
+      expect(err.slots).toHaveLength(2);
+      expect(err.slots[0].label).toBe("mié 5 ago, 09:30");
+    });
+
+    // Y quedan REGISTRADAS como la nueva oferta: el cliente puede aceptar una
+    // de inmediato y la validación seguirá siendo válida.
+    expect(replaceOffers).toHaveBeenCalledOnce();
+    expect(inserted).toHaveLength(0);
+  });
+
+  it("el 23505 también se reconoce cuando el driver lo envuelve en `cause`", async () => {
+    const { createSessionBooking } = await import("@/server/agenda/service");
+    primeLookups();
+    insertThrows = Object.assign(new Error("insert falló"), {
+      cause: { code: "23505" },
+    });
+
+    await expect(
+      createSessionBooking({
+        organizationId: "org_1",
+        conversationId: "cv_1",
+        startUtc: SLOT,
+        source: "ai",
+        requireOffer: true,
+      })
+    ).rejects.toMatchObject({ code: "slot_taken" });
+  });
+
+  it("un error que NO es la carrera se propaga tal cual, sin disfrazarse de slot_taken", async () => {
+    const { createSessionBooking } = await import("@/server/agenda/service");
+    primeLookups();
+    insertThrows = { code: "23503", message: "foreign key" };
+
+    await expect(
+      createSessionBooking({
+        organizationId: "org_1",
+        conversationId: "cv_1",
+        startUtc: SLOT,
+        source: "ai",
+        requireOffer: true,
+      })
+    ).rejects.toMatchObject({ code: "23503" });
+  });
+
+  it("un instante que nunca se ofreció se rechaza ANTES de tocar la base", async () => {
+    const { createSessionBooking } = await import("@/server/agenda/service");
+    primeLookups();
+
+    const promise = createSessionBooking({
+      organizationId: "org_1",
+      conversationId: "cv_1",
+      // Libre y válido, pero jamás ofrecido en esta conversación.
+      startUtc: "2026-08-05T20:00:00.000Z",
+      source: "ai",
+      requireOffer: true,
+    });
+
+    await expect(promise).rejects.toMatchObject({ code: "slot_not_offered" });
+    await promise.catch((err) => {
+      // Se devuelve lo que SÍ se ofreció, para que se re-ofrezca en vez de
+      // inventar.
+      expect(err.slots[0].startUtc).toBe(SLOT);
+    });
+    expect(inserted).toHaveLength(0);
+  });
+});

--- a/tests/unit/conflict-targets.test.ts
+++ b/tests/unit/conflict-targets.test.ts
@@ -1,0 +1,59 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Vigilancia: un `ON CONFLICT` sobre `contact` tiene que nombrar EXACTAMENTE
+ * las columnas del índice único.
+ *
+ * Existe por un fallo real: la feature 014 cambió el índice de
+ * `(organization_id, wa_identity)` a `(organization_id, channel, wa_identity)`
+ * y dejó dos `onConflictDoNothing` apuntando al índice viejo. Postgres no falla
+ * al compilar ni al arrancar: falla en la petición, con
+ * "no unique or exclusion constraint matching the ON CONFLICT specification".
+ *
+ * El resultado fue que el Laboratorio y el alta manual de contactos quedaron
+ * rotos en `main` sin que ninguna prueba lo notara — porque ninguna los
+ * ejercitaba contra una base real. Este test es más barato que volver a
+ * descubrirlo en producción.
+ */
+
+const CONTACT_INDEX_COLUMNS = ["organizationId", "channel", "waIdentity"];
+
+function tsFilesUnder(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...tsFilesUnder(full));
+    else if (/\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+describe("ON CONFLICT sobre contact", () => {
+  it("nombra las tres columnas del índice único, en todos los sitios", () => {
+    const offenders: string[] = [];
+
+    for (const file of tsFilesUnder(join(process.cwd(), "src"))) {
+      const source = readFileSync(file, "utf8");
+      if (!source.includes("schema.contact.waIdentity")) continue;
+
+      // Solo interesan los `target: [...]` de un onConflict.
+      const targets = source.matchAll(/target:\s*\[([^\]]*)\]/g);
+      for (const match of targets) {
+        const body = match[1] ?? "";
+        if (!body.includes("schema.contact.waIdentity")) continue;
+        const faltantes = CONTACT_INDEX_COLUMNS.filter(
+          (col) => !body.includes(`schema.contact.${col}`)
+        );
+        if (faltantes.length > 0) {
+          offenders.push(
+            `${file.replace(process.cwd(), "")} — le falta: ${faltantes.join(", ")}`
+          );
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/unit/connectors.test.ts
+++ b/tests/unit/connectors.test.ts
@@ -1,0 +1,329 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CONNECTOR_META, CONNECTOR_ORDER } from "@/lib/agenda-connectors";
+import { enlaceFijoConnector } from "@/server/agenda/connectors/enlace-fijo";
+import { zoomConnector, ZOOM_SCOPES } from "@/server/agenda/connectors/zoom";
+import { googleConnector } from "@/server/agenda/connectors/google";
+import { ConnectorError } from "@/server/agenda/connectors/types";
+import { clearZoomTokenCache } from "@/server/agenda/connectors/zoom-credentials";
+import { clearGoogleTokenCache } from "@/server/agenda/connectors/google-credentials";
+
+/**
+ * 015 — La suite de contrato de conectores.
+ *
+ * Es la misma para todos a propósito: agregar un conector en un fork significa
+ * pasar ESTAS pruebas, no inventarse las suyas. Lo que se fija aquí son las
+ * cuatro operaciones y las dos reglas que el motor da por hechas: borrar es
+ * idempotente, y mover conserva el enlace.
+ */
+
+vi.mock("@/lib/env", () => ({
+  getEnv: () => ({
+    ZOOM_BASE_URL: "https://zoom.test/v2",
+    ZOOM_OAUTH_BASE_URL: "https://oauth.zoom.test",
+    GOOGLE_CAL_BASE_URL: "https://cal.google.test/v3",
+    GOOGLE_OAUTH_BASE_URL: "https://oauth.google.test",
+  }),
+}));
+
+const REQ = {
+  topic: "Cita — Ana",
+  startUtc: "2026-08-05T15:00:00.000Z",
+  durationMinutes: 30,
+  timezone: "America/Mexico_City",
+};
+
+describe("el catálogo", () => {
+  it("todo conector declarado tiene su ficha para la pantalla", () => {
+    for (const id of CONNECTOR_ORDER) {
+      const meta = CONNECTOR_META[id];
+      expect(meta.label.length).toBeGreaterThan(0);
+      expect(meta.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("existe al menos un conector SIN dependencias externas", () => {
+    // Es la condición constitucional: el camino soberano tiene que existir,
+    // o los conectores externos no serían opcionales de verdad.
+    expect(CONNECTOR_ORDER.some((id) => !CONNECTOR_META[id].external)).toBe(true);
+  });
+
+  it("el default no habla con nadie", () => {
+    expect(CONNECTOR_META["enlace-fijo"].external).toBe(false);
+    expect(enlaceFijoConnector.requiresCredentials).toBe(false);
+  });
+});
+
+describe("enlace-fijo", () => {
+  it("entrega la sala configurada, sin id externo", async () => {
+    const out = await enlaceFijoConnector.createMeeting(
+      { meetingLink: "https://meet.ejemplo.com/sala" },
+      REQ
+    );
+    expect(out).toEqual({
+      externalId: null,
+      joinUrl: "https://meet.ejemplo.com/sala",
+    });
+  });
+
+  it("sin sala configurada entrega null en vez de fallar", async () => {
+    // La cita se crea igual: nadie promete un enlace que no existe.
+    const out = await enlaceFijoConnector.createMeeting({ meetingLink: null }, REQ);
+    expect(out.joinUrl).toBeNull();
+  });
+
+  it("mover y borrar no hacen nada, y no lanzan", async () => {
+    await expect(
+      enlaceFijoConnector.updateMeeting({ meetingLink: null }, "x", REQ)
+    ).resolves.toBeUndefined();
+    await expect(
+      enlaceFijoConnector.deleteMeeting({ meetingLink: null }, "x")
+    ).resolves.toBeUndefined();
+  });
+
+  it("siempre está conectado: no hay nada que conectar", async () => {
+    await expect(
+      enlaceFijoConnector.testConnection({ meetingLink: null })
+    ).resolves.toMatchObject({ ok: true });
+  });
+});
+
+describe("zoom", () => {
+  const creds = {
+    accountId: "acc_1",
+    clientId: "cli_1",
+    clientSecret: "sec_1",
+    status: "connected" as const,
+  };
+  const calls: { url: string; method: string; body?: unknown }[] = [];
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    clearZoomTokenCache();
+    calls.length = 0;
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({
+        url,
+        method: init?.method ?? "GET",
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      });
+      if (url.includes("/oauth/token")) {
+        return Response.json({ access_token: "tk", expires_in: 3600 });
+      }
+      if (url.endsWith("/users/me/meetings")) {
+        return Response.json({ id: 91234, join_url: "https://zoom.test/j/91234" });
+      }
+      if (url.endsWith("/users/me")) {
+        return Response.json({ email: "dueño@negocio.test" });
+      }
+      return new Response(null, { status: 204 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("la guía de scopes incluye el de leer usuario, que usa la prueba de conexión", () => {
+    // El tropiezo real: documentar solo los de reunión hace que conectar falle
+    // con credenciales que en realidad sirven.
+    expect(ZOOM_SCOPES).toContain("user:read:user");
+    expect(ZOOM_SCOPES).toContain("meeting:write:meeting");
+  });
+
+  it("crear manda la reunión programada y devuelve id + enlace", async () => {
+    const out = await zoomConnector.createMeeting(creds, REQ);
+    expect(out).toEqual({
+      externalId: "91234",
+      joinUrl: "https://zoom.test/j/91234",
+    });
+
+    const create = calls.find((c) => c.url.endsWith("/users/me/meetings"));
+    const body = create?.body as Record<string, unknown>;
+    expect(body.type).toBe(2);
+    expect(body.topic).toBe("Cita — Ana");
+    expect(body.timezone).toBe("America/Mexico_City");
+    // Zoom rechaza los milisegundos.
+    expect(body.start_time).toBe("2026-08-05T15:00:00Z");
+  });
+
+  it("el token se pide una vez y se reutiliza", async () => {
+    await zoomConnector.createMeeting(creds, REQ);
+    await zoomConnector.createMeeting(creds, REQ);
+    const tokenCalls = calls.filter((c) => c.url.includes("/oauth/token"));
+    expect(tokenCalls).toHaveLength(1);
+  });
+
+  it("mover usa el MISMO id y solo manda la hora: el enlace no cambia", async () => {
+    await zoomConnector.updateMeeting(creds, "91234", {
+      startUtc: "2026-08-06T16:00:00.000Z",
+      durationMinutes: 45,
+      timezone: "America/Mexico_City",
+    });
+    const patch = calls.find((c) => c.method === "PATCH");
+    expect(patch?.url).toContain("/meetings/91234");
+    const body = patch?.body as Record<string, unknown>;
+    expect(body.start_time).toBe("2026-08-06T16:00:00Z");
+    expect(body.duration).toBe(45);
+    // No re-manda el tema ni los ajustes: solo se movió de hora.
+    expect(body.topic).toBeUndefined();
+  });
+
+  it("borrar algo que ya no está es ÉXITO, no error (idempotencia)", async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes("/oauth/token")) {
+        return Response.json({ access_token: "tk", expires_in: 3600 });
+      }
+      return new Response(null, { status: 404 });
+    });
+    await expect(
+      zoomConnector.deleteMeeting(creds, "ya-borrada")
+    ).resolves.toBeUndefined();
+  });
+
+  it("probar la conexión pega a users/me", async () => {
+    const out = await zoomConnector.testConnection(creds);
+    expect(out).toMatchObject({ ok: true, detail: "dueño@negocio.test" });
+  });
+
+  it("credenciales rechazadas → error de AUTENTICACIÓN, para marcar la conexión rota", async () => {
+    fetchMock.mockImplementation(async () =>
+      Response.json({ error: "invalid_client" }, { status: 400 })
+    );
+    await expect(zoomConnector.createMeeting(creds, REQ)).rejects.toSatisfy(
+      (err: unknown) =>
+        err instanceof ConnectorError && err.isAuthError && err.connectorId === "zoom"
+    );
+  });
+
+  it("un 400 de la API (no del token) NO se confunde con credenciales rotas", async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes("/oauth/token")) {
+        return Response.json({ access_token: "tk", expires_in: 3600 });
+      }
+      return Response.json({ message: "start_time inválido" }, { status: 400 });
+    });
+    await expect(zoomConnector.createMeeting(creds, REQ)).rejects.toSatisfy(
+      (err: unknown) => err instanceof ConnectorError && !err.isAuthError
+    );
+  });
+
+  it("probar la conexión nunca lanza: devuelve el fallo como dato", async () => {
+    fetchMock.mockImplementation(async () => {
+      throw new Error("sin red");
+    });
+    const out = await zoomConnector.testConnection(creds);
+    expect(out.ok).toBe(false);
+  });
+});
+
+describe("google", () => {
+  const creds = {
+    clientId: "cli_1",
+    clientSecret: "sec_1",
+    refreshToken: "ref_1",
+    calendarId: "primary",
+    status: "connected" as const,
+  };
+  const calls: { url: string; method: string }[] = [];
+  let fetchMock: ReturnType<typeof vi.fn>;
+  /** Lecturas del evento antes de que la conferencia esté lista. */
+  let pendingReads = 0;
+
+  beforeEach(() => {
+    clearGoogleTokenCache();
+    calls.length = 0;
+    pendingReads = 0;
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      calls.push({ url, method });
+
+      if (url.endsWith("/token")) {
+        return Response.json({ access_token: "tk", expires_in: 3600 });
+      }
+      if (method === "POST") {
+        // Como Google de verdad: el evento nace SIN enlace de Meet.
+        return Response.json({
+          id: "evt_1",
+          conferenceData: { createRequest: { status: { statusCode: "pending" } } },
+        });
+      }
+      if (method === "GET") {
+        if (pendingReads > 0) {
+          pendingReads -= 1;
+          return Response.json({
+            id: "evt_1",
+            conferenceData: {
+              createRequest: { status: { statusCode: "pending" } },
+            },
+          });
+        }
+        return Response.json({
+          id: "evt_1",
+          summary: "Calendario de prueba",
+          conferenceData: {
+            entryPoints: [
+              { entryPointType: "video", uri: "https://meet.google.test/abc" },
+            ],
+          },
+        });
+      }
+      return new Response(null, { status: 204 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("crear re-lee el evento hasta que aparece el enlace de Meet", async () => {
+    // La conferencia es ASÍNCRONA: quedarse con la respuesta del insert
+    // dejaría todas las citas sin enlace.
+    pendingReads = 1;
+    const out = await googleConnector.createMeeting(creds, REQ);
+    expect(out.externalId).toBe("evt_1");
+    expect(out.joinUrl).toBe("https://meet.google.test/abc");
+    expect(calls.filter((c) => c.method === "GET").length).toBeGreaterThan(1);
+  });
+
+  it("si la conferencia sigue pendiente, devuelve el evento SIN enlace en vez de fallar", async () => {
+    // El motor lo traduce a "cita sin enlace, reintentable": la cita no se
+    // pierde por una demora del proveedor.
+    pendingReads = 99;
+    const out = await googleConnector.createMeeting(creds, REQ);
+    expect(out.externalId).toBe("evt_1");
+    expect(out.joinUrl).toBeNull();
+  });
+
+  it("refrescar lee el MISMO evento: reintentar no duplica la cita en el calendario", async () => {
+    const out = await googleConnector.refreshMeeting!(creds, "evt_1");
+    expect(out.externalId).toBe("evt_1");
+    expect(out.joinUrl).toBe("https://meet.google.test/abc");
+    // Ni un solo POST a events: el del token no cuenta.
+    expect(
+      calls.some((c) => c.method === "POST" && c.url.includes("/events"))
+    ).toBe(false);
+  });
+
+  it("borrar tolera el 404 (idempotencia)", async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.endsWith("/token")) {
+        return Response.json({ access_token: "tk", expires_in: 3600 });
+      }
+      return new Response(null, { status: 404 });
+    });
+    await expect(
+      googleConnector.deleteMeeting(creds, "evt_borrado")
+    ).resolves.toBeUndefined();
+  });
+
+  it("un refresh token revocado es error de AUTENTICACIÓN y lo explica", async () => {
+    fetchMock.mockImplementation(async () =>
+      Response.json({ error: "invalid_grant" }, { status: 400 })
+    );
+    await expect(googleConnector.createMeeting(creds, REQ)).rejects.toSatisfy(
+      (err: unknown) =>
+        err instanceof ConnectorError &&
+        err.isAuthError &&
+        // El mensaje nombra la causa más común: la app OAuth en modo prueba.
+        /modo prueba/.test(err.message)
+    );
+  });
+});

--- a/tests/unit/offers.test.ts
+++ b/tests/unit/offers.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  findOffered,
+  sameInstant,
+  type OfferedSlot,
+} from "@/server/agenda/offers";
+
+/**
+ * 015 — La regla INNEGOCIABLE: solo se reserva lo que se ofreció, comparando
+ * por instante EXACTO. Estos tests fijan lo que un LLM no puede saltarse.
+ */
+
+const OFFERS: OfferedSlot[] = [
+  { startUtc: "2026-08-05T15:00:00.000Z", label: "mié 5 ago, 09:00" },
+  { startUtc: "2026-08-05T15:30:00.000Z", label: "mié 5 ago, 09:30" },
+  { startUtc: "2026-08-06T16:00:00.000Z", label: "jue 6 ago, 10:00" },
+];
+
+describe("findOffered", () => {
+  it("acepta un instante ofrecido", () => {
+    expect(findOffered(OFFERS, "2026-08-05T15:30:00.000Z")?.label).toBe(
+      "mié 5 ago, 09:30"
+    );
+  });
+
+  it("acepta el MISMO instante escrito con otro offset", () => {
+    // 09:00 en México es el mismo instante que 15:00Z: es el mismo hueco.
+    expect(findOffered(OFFERS, "2026-08-05T09:00:00.000-06:00")).not.toBeNull();
+  });
+
+  it("rechaza un instante que no se ofreció, aunque sea cercano", () => {
+    // Un minuto de diferencia NO es el hueco ofrecido.
+    expect(findOffered(OFFERS, "2026-08-05T15:31:00.000Z")).toBeNull();
+    // Un horario perfectamente válido pero nunca ofrecido tampoco vale.
+    expect(findOffered(OFFERS, "2026-08-05T18:00:00.000Z")).toBeNull();
+  });
+
+  it("rechaza basura sin lanzar (el modelo alucinó el formato)", () => {
+    expect(findOffered(OFFERS, "el martes a las 10")).toBeNull();
+    expect(findOffered(OFFERS, "")).toBeNull();
+  });
+
+  it("sin oferta previa no hay nada reservable", () => {
+    expect(findOffered([], "2026-08-05T15:00:00.000Z")).toBeNull();
+  });
+});
+
+describe("sameInstant", () => {
+  it("compara instantes, no cadenas", () => {
+    expect(
+      sameInstant("2026-08-05T15:00:00.000Z", "2026-08-05T09:00:00-06:00")
+    ).toBe(true);
+    expect(
+      sameInstant("2026-08-05T15:00:00.000Z", "2026-08-05T15:00:01.000Z")
+    ).toBe(false);
+  });
+
+  it("una fecha inválida nunca es igual a nada", () => {
+    expect(sameInstant("nope", "2026-08-05T15:00:00.000Z")).toBe(false);
+  });
+});

--- a/tests/unit/slots.test.ts
+++ b/tests/unit/slots.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+import {
+  dayLabelInTz,
+  eachDateInRange,
+  expandWorkingDayToUtc,
+  isValidTimeZone,
+  labelInTz,
+  overlaps,
+  partsInTz,
+  timeInTz,
+  todayInTz,
+  weekdayKeyOf,
+  zonedWallClockToUtc,
+} from "@/lib/time/slots";
+
+/**
+ * 015 — Los bordes que rompen un motor de agenda: DST, franjas partidas y
+ * días cerrados. Sin luxon: si `Intl` fallara, estos tests lo gritan.
+ */
+
+const MX = "America/Mexico_City";
+const NY = "America/New_York";
+const MADRID = "Europe/Madrid";
+
+describe("zonedWallClockToUtc — hora de pared → instante", () => {
+  it("México no tiene DST desde 2022: 09:00 son las 15:00Z todo el año", () => {
+    expect(zonedWallClockToUtc("2026-08-05", "09:00", MX)?.toISOString()).toBe(
+      "2026-08-05T15:00:00.000Z"
+    );
+    expect(zonedWallClockToUtc("2026-01-14", "09:00", MX)?.toISOString()).toBe(
+      "2026-01-14T15:00:00.000Z"
+    );
+  });
+
+  it("Nueva York: la misma hora local cambia de instante al entrar el DST", () => {
+    // El DST arranca el 2026-03-08.
+    expect(zonedWallClockToUtc("2026-03-07", "09:00", NY)?.toISOString()).toBe(
+      "2026-03-07T14:00:00.000Z"
+    );
+    expect(zonedWallClockToUtc("2026-03-09", "09:00", NY)?.toISOString()).toBe(
+      "2026-03-09T13:00:00.000Z"
+    );
+  });
+
+  it("Madrid: idem en el cambio europeo (2026-03-29)", () => {
+    expect(
+      zonedWallClockToUtc("2026-03-28", "09:00", MADRID)?.toISOString()
+    ).toBe("2026-03-28T08:00:00.000Z");
+    expect(
+      zonedWallClockToUtc("2026-03-30", "09:00", MADRID)?.toISOString()
+    ).toBe("2026-03-30T07:00:00.000Z");
+  });
+
+  it("una hora inexistente (salto de primavera) devuelve un instante real, no lanza", () => {
+    // 02:30 del 2026-03-08 en NY no existe: el reloj salta de 02:00 a 03:00.
+    const d = zonedWallClockToUtc("2026-03-08", "02:30", NY);
+    expect(d).not.toBeNull();
+    expect(Number.isNaN(d!.getTime())).toBe(false);
+  });
+
+  it("rechaza formatos inválidos en vez de inventar una fecha", () => {
+    expect(zonedWallClockToUtc("2026-8-5", "09:00", MX)).toBeNull();
+    expect(zonedWallClockToUtc("2026-08-05", "9:00", MX)).toBeNull();
+    expect(zonedWallClockToUtc("2026-08-05", "25:00", MX)).toBeNull();
+  });
+});
+
+describe("weekdayKeyOf / todayInTz", () => {
+  it("da el día de la semana en la zona del negocio", () => {
+    expect(weekdayKeyOf("2026-08-05", MX)).toBe("wed");
+    expect(weekdayKeyOf("2026-03-29", MADRID)).toBe("sun");
+  });
+
+  it("el día 'de hoy' depende de la zona, no del servidor", () => {
+    // 03:00Z del 6 de agosto sigue siendo 5 de agosto en México (UTC-6).
+    const instant = new Date("2026-08-06T03:00:00.000Z");
+    expect(todayInTz(instant, MX)).toBe("2026-08-05");
+    expect(todayInTz(instant, MADRID)).toBe("2026-08-06");
+  });
+});
+
+describe("expandWorkingDayToUtc", () => {
+  it("genera slots de la duración pedida dentro de la franja", () => {
+    const slots = expandWorkingDayToUtc(
+      "2026-08-05",
+      [{ start: "09:00", end: "11:00" }],
+      MX,
+      30,
+      0
+    );
+    expect(slots).toHaveLength(4);
+    expect(slots[0]!.startUtc).toBe("2026-08-05T15:00:00.000Z");
+    expect(slots[0]!.endUtc).toBe("2026-08-05T15:30:00.000Z");
+    expect(slots[3]!.startUtc).toBe("2026-08-05T16:30:00.000Z");
+  });
+
+  it("el respiro separa los slots sin desbordar la franja", () => {
+    const slots = expandWorkingDayToUtc(
+      "2026-08-05",
+      [{ start: "09:00", end: "11:00" }],
+      MX,
+      30,
+      15
+    );
+    // 09:00, 09:45, 10:30 (10:30+30 = 11:00, cabe justo)
+    expect(slots.map((s) => s.startUtc)).toEqual([
+      "2026-08-05T15:00:00.000Z",
+      "2026-08-05T15:45:00.000Z",
+      "2026-08-05T16:30:00.000Z",
+    ]);
+  });
+
+  it("una franja partida no genera nada en el hueco del medio", () => {
+    const slots = expandWorkingDayToUtc(
+      "2026-08-05",
+      [
+        { start: "09:00", end: "13:00" },
+        { start: "16:00", end: "18:00" },
+      ],
+      MX,
+      60,
+      0
+    );
+    const horas = slots.map((s) => s.startUtc.slice(11, 16));
+    expect(horas).toEqual([
+      "15:00",
+      "16:00",
+      "17:00",
+      "18:00",
+      "22:00",
+      "23:00",
+    ]);
+  });
+
+  it("un día sin franjas (cerrado) no genera slots", () => {
+    expect(expandWorkingDayToUtc("2026-08-09", [], MX, 30, 0)).toEqual([]);
+  });
+
+  it("no emite un slot que no cabe completo en la franja", () => {
+    const slots = expandWorkingDayToUtc(
+      "2026-08-05",
+      [{ start: "09:00", end: "09:45" }],
+      MX,
+      30,
+      0
+    );
+    expect(slots).toHaveLength(1);
+  });
+});
+
+describe("eachDateInRange", () => {
+  it("incluye ambos extremos", () => {
+    expect(eachDateInRange("2026-08-03", "2026-08-06")).toEqual([
+      "2026-08-03",
+      "2026-08-04",
+      "2026-08-05",
+      "2026-08-06",
+    ]);
+  });
+
+  it("rango invertido → vacío (no cuelga)", () => {
+    expect(eachDateInRange("2026-08-06", "2026-08-03")).toEqual([]);
+  });
+});
+
+describe("overlaps", () => {
+  const a = ["2026-08-05T15:00:00.000Z", "2026-08-05T15:30:00.000Z"] as const;
+
+  it("solape parcial cuenta como ocupado", () => {
+    expect(
+      overlaps(
+        a[0],
+        a[1],
+        "2026-08-05T15:15:00.000Z",
+        "2026-08-05T15:45:00.000Z"
+      )
+    ).toBe(true);
+  });
+
+  it("intervalos contiguos NO se solapan", () => {
+    expect(
+      overlaps(
+        a[0],
+        a[1],
+        "2026-08-05T15:30:00.000Z",
+        "2026-08-05T16:00:00.000Z"
+      )
+    ).toBe(false);
+  });
+});
+
+describe("etiquetas para el cliente", () => {
+  it("labelInTz muestra la hora local del negocio", () => {
+    const label = labelInTz("2026-08-05T15:00:00.000Z", MX);
+    expect(label).toContain("09:00");
+    expect(label).toContain("5");
+    // Mismo instante, otra zona ⇒ otra hora.
+    expect(labelInTz("2026-08-05T15:00:00.000Z", MADRID)).toContain("17:00");
+  });
+
+  it("partsInTz separa fecha, hora y día", () => {
+    const parts = partsInTz("2026-08-05T15:00:00.000Z", MX);
+    expect(parts.time).toBe("09:00");
+    expect(parts.date).toContain("2026");
+    expect(parts.weekday.length).toBeGreaterThan(0);
+  });
+
+  it("timeInTz da solo la hora local", () => {
+    expect(timeInTz("2026-08-05T15:00:00.000Z", MX)).toBe("09:00");
+  });
+
+  it("un instante inválido degrada a vacío en vez de lanzar", () => {
+    expect(labelInTz("no-es-fecha", MX)).toBe("");
+    expect(timeInTz("no-es-fecha", MX)).toBe("");
+    expect(dayLabelInTz("no-es-fecha", MX)).toBe("");
+    expect(partsInTz("no-es-fecha", MX).time).toBe("");
+  });
+});
+
+/**
+ * El día en palabras es lo que evita el fallo caro: un lead contestó
+ * "10:30, de mañana" a una oferta de HOY y se agendó el día equivocado.
+ */
+describe("dayLabelInTz — el día EN PALABRAS", () => {
+  const now = new Date("2026-08-05T15:00:00.000Z"); // miércoles 5, 09:00 en MX
+
+  it("marca 'hoy' cuando el slot cae en el día en curso del negocio", () => {
+    const label = dayLabelInTz("2026-08-05T20:00:00.000Z", MX, now);
+    expect(label).toMatch(/^hoy /);
+    expect(label).toContain("miércoles");
+    expect(label).toContain("5");
+    expect(label).toContain("agosto");
+  });
+
+  it("marca 'mañana' en el día siguiente", () => {
+    const label = dayLabelInTz("2026-08-06T16:00:00.000Z", MX, now);
+    expect(label).toMatch(/^mañana /);
+    expect(label).toContain("jueves");
+  });
+
+  it("un día más lejano va sin prefijo, pero SIEMPRE con el día nombrado", () => {
+    const label = dayLabelInTz("2026-08-10T16:00:00.000Z", MX, now);
+    expect(label).not.toMatch(/^(hoy|mañana) /);
+    expect(label).toContain("lunes");
+    expect(label).toContain("10");
+  });
+
+  it("'hoy' se decide en la zona del negocio, no en la del servidor", () => {
+    // 03:00Z del 6 sigue siendo 5 de agosto en México.
+    const instant = "2026-08-06T03:00:00.000Z";
+    expect(dayLabelInTz(instant, MX, now)).toMatch(/^hoy /);
+    expect(dayLabelInTz(instant, MADRID, now)).toMatch(/^mañana /);
+  });
+});
+
+describe("isValidTimeZone", () => {
+  it("acepta zonas IANA reales y rechaza inventadas", () => {
+    expect(isValidTimeZone(MX)).toBe(true);
+    expect(isValidTimeZone("Europe/Madrid")).toBe(true);
+    expect(isValidTimeZone("Marte/Olympus")).toBe(false);
+  });
+});


### PR DESCRIPTION
Motor de agendamiento con huecos reales en el core, **apagado por defecto**, y
una capa de conectores para que la reunión se entregue donde el negocio ya
vive: su sala de siempre, Zoom, o Google Calendar + Meet.

Ciclo SDD completo en [`specs/015-motor-agenda-universal/`](specs/015-motor-agenda-universal/)
(spec, plan, research, data-model, 2 contratos, quickstart, checklist, tasks).

## Qué entra

**La bandera.** `AGENDA=on`, hermana de `CHANNELS` y con los mismos criterios
de ADR-001: apagada no existe nada — rutas en 404, sin navegación, sin pestaña
de Ajustes, y **cero tokens** de prompt del agente gastados en hablar de
horarios. La migración se aplica siempre: unas tablas vacías son inertes y a
cambio todas las instancias comparten la misma estructura.

**Las dos garantías innegociables:**

1. *Solo se reserva lo que se ofreció.* La memoria de lo ofrecido
   (`offered_slot`) vive en el CRM, no en quien conduce la conversación, y la
   comparación es por **epoch exacto**. Un modelo que alucine "el martes a las
   10" recibe un rechazo con la lista de lo que sí se ofreció.
2. *Nunca se confirma una cita que no se creó.* Re-validación al confirmar
   **más** un índice único parcial en Postgres sobre las citas activas: dos
   confirmaciones simultáneas del mismo instante no pueden ganar las dos, y la
   perdedora recibe `409 slot_taken` con alternativas frescas ya registradas
   como la nueva oferta.

**Los conectores.** Contrato público de cuatro operaciones —crear, mover,
borrar reunión y probar conexión— medido del uso real de la integración de Zoom
que lleva meses en producción en un CRM derivado de este. Tres incluidos:
`enlace-fijo` (soberano, el default), `zoom` y `google`. Escribir el tuyo en un
fork toca seis archivos y **cero** del motor: guía en
[`docs/agenda-conectores.md`](docs/agenda-conectores.md).

**Un tercero caído no cuesta la conversión.** Los efectos hacia el proveedor
corren después de escribir la verdad del CRM y son best-effort: si falla, la
cita **se crea igual** con el enlace pendiente, visible y reintentable desde
Citas. Quien confirma al cliente dice que el enlace llega en un momento, en vez
de prometer uno que no existe.

## Dos cosas que el revisor debe mirar con calma

**1. La constitución sube a 1.4.0.** `zoom` y `google` son servicios externos
fuera de la lista cerrada del Principio II (que además prohibía Google
nominalmente). La enmienda —propuesta por escrito y ratificada antes de
escribir una línea de esos conectores— admite **conectores opcionales** bajo
cinco condiciones: apagados por defecto, aislados tras adaptador, con un camino
sin dependencia externa que funcione igual, credenciales cifradas del propio
negocio, y verificables en CI encendidos y apagados. Ver
[`docs/adr-002-conectores-de-agenda.md`](docs/adr-002-conectores-de-agenda.md)
y la propuesta en `specs/015-motor-agenda-universal/enmienda-constitucional.md`.

**2. Va un fix de un bug preexistente, en su propio commit.** La feature 014
cambió el índice único de `contact` a `(organization_id, channel, wa_identity)`
y dejó dos `onConflictDoNothing` apuntando al índice viejo. Postgres no falla
al compilar ni al arrancar: falla en la petición. Resultado: **el Laboratorio y
el alta manual de contactos llevaban rotos en `main` desde ese merge**, y nada
lo notaba porque nada los ejercitaba contra una base real. Lo destapó el arnés
E2E de esta feature. Incluye test de vigilancia que escanea `src/`.

## Verificación

| Gate | Resultado |
|---|---|
| typecheck · lint · build | verde |
| Unit (`pnpm test`) | **346 pasan** (44 archivos) |
| E2E con `AGENDA=on` | **122/122 checks** contra la app viva |
| E2E con la bandera apagada | **92/92 checks** (5 prueban que la agenda no existe) |
| Migración `0009` | aplicada y re-ejecutada sin efecto (idempotente) |

El arnés corrió contra la app real con Postgres y los mocks: códigos **exactos**
(201 al crear, 200 al reprogramar, 409 con el sobre anidado y `slots` como
hermano), la carrera del hueco terminando en **una sola cita activa**, el enlace
pendiente cuando el proveedor no responde, y el conector Zoom contra su mock
(crear, mover conservando el enlace, cancelar borrando en el proveedor).

La CI ahora corre en **dos configuraciones** (todo apagado / todo encendido) —
la matriz que ADR-001 prometió y nunca se implementó.

## Decisiones que conviene conocer

- **Sin free/busy.** El contrato ni siquiera declara leer calendarios externos:
  meter al proveedor en el camino de la disponibilidad acoplaría su latencia y
  sus caídas a la pantalla que más se usa. Los compromisos de fuera se reflejan
  con bloqueos manuales.
- **Google crea el enlace de Meet de forma asíncrona** (confirmado en su
  documentación: la respuesta del insert puede venir `pending`). Por eso el
  conector re-lee el evento, y por eso el contrato ganó una quinta operación
  **opcional**, `refreshMeeting`: sin ella, "Reintentar enlace" habría creado un
  evento **duplicado** en el calendario del dueño.
- **El sandbox del Laboratorio** se prueba en unit
  (`tests/unit/agenda-sandbox.test.ts`) y no en el arnés: las conversaciones de
  prueba no son alcanzables desde la API pública —a propósito—, así que desde
  fuera solo podría observarse por ausencia. El test afirma lo que importa: que
  el conector no se llama, ni al crear, ni al reprogramar, ni al cancelar.
- **El README revierte** su sección "Fuera de alcance a propósito" respondiendo
  a sus dos argumentos originales, en vez de borrarla.
- La rama `004-motor-agenda` no se rebaseó: se usó como cantera. Nació de un
  `main` 76 commits atrás y su migración colisionaba de número — el costo que
  ADR-001 predijo para las ramas, documentado aquí como evidencia.

## Fuera de alcance

Recordatorios automáticos antes de la cita, múltiples calendarios por agente,
composición de conectores (Zoom **y** evento en Google a la vez), cancelar por
la superficie del bot (esa decisión es del dueño: el camino es handoff) y OAuth
con redirect dentro del producto para Google.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
