### PR TITLE
fix(envío): normalizar el troncal argentino 549 al mandar a Meta (#35)

### DIFF
--- a/scripts/e2e-selftest.mjs
+++ b/scripts/e2e-selftest.mjs
@@ -179,6 +179,60 @@ async function main() {
   );
   ok("el contacto reconciliado conserva su conversación", !!mxConv);
 
+  // Issue #35: un destinatario argentino llega como `549` + 10 dígitos y hay
+  // que ENVIARLE sin el 9. La identidad, en cambio, conserva lo que Meta
+  // reporta: si se reescribiera, dejaría de casar con el `wa_id` de cada
+  // webhook y el contacto se partiría en dos.
+  console.log("\n== us-bsuid: destinatario argentino (549 → 54) ==");
+  const AR_REPORTADO = "5491122334455";
+  await api("/api/dev/wa-mock/inbound", {
+    method: "POST",
+    body: JSON.stringify({
+      phoneNumberId: PN,
+      from: AR_REPORTADO,
+      name: "Lead AR",
+      text: "hola desde Argentina",
+      waMessageId: "wamid.e2e.ar.1",
+    }),
+  });
+  await sleep(1200);
+  const convAr = ((await api("/api/conversations")).json?.conversations ?? []).find(
+    (c) => c.contact.name === "Lead AR"
+  );
+  ok("la conversación argentina se creó", Boolean(convAr));
+  ok(
+    "la identidad guardada conserva el 9 que reporta Meta",
+    convAr?.contact.phone === AR_REPORTADO,
+    `phone=${convAr?.contact.phone}`
+  );
+
+  if (convAr) {
+    // Se cuenta lo que ya había en vez de vaciar el outbox: el DELETE del
+    // wa-mock reinicia su contador de wa_message_id, y en una RE-CORRIDA eso
+    // choca con los mensajes que ya están en la base (unique) y tumba el envío
+    // con un 500 que no tiene nada que ver con lo que se está probando.
+    const outboxAntes =
+      ((await api("/api/dev/wa-mock/outbox")).json?.outbox ?? []).length;
+    const envioAr = await api(`/api/conversations/${convAr.id}/messages`, {
+      method: "POST",
+      body: JSON.stringify({ text: "respuesta a Argentina" }),
+    });
+    ok("el mensaje a Argentina se envía", envioAr.res.ok, `status=${envioAr.res.status}`);
+    const outboxAr = (
+      (await api("/api/dev/wa-mock/outbox")).json?.outbox ?? []
+    ).slice(outboxAntes);
+    ok(
+      "por el cable viaja SIN el 9 (lo que la lista de permitidos acepta)",
+      outboxAr.some((o) => o.to === "541122334455"),
+      JSON.stringify(outboxAr.map((o) => o.to))
+    );
+    ok(
+      "…y nunca con el 9, que es lo que devolvía 131030",
+      !outboxAr.some((o) => o.to === AR_REPORTADO),
+      JSON.stringify(outboxAr.map((o) => o.to))
+    );
+  }
+
   console.log("\n== us-bot-api: autorización ==");
   const noKey = await api("/api/bot/media/media123");
   ok("media sin API key → 401", noKey.res.status === 401);

--- a/src/lib/meta/client.ts
+++ b/src/lib/meta/client.ts
@@ -102,5 +102,44 @@ export function normalizeMx(phone: string): string {
   return phone;
 }
 
-/** Alias histórico (envío). */
-export const normalizeRecipient = normalizeMx;
+/**
+ * Troncales que WhatsApp REPORTA pero que no se usan para ENVIAR, y que la
+ * identidad deja intactos a propósito.
+ *
+ * A diferencia de México, aquí la normalización NO puede ser simétrica: si la
+ * ingesta reescribiera la identidad, dejaría de coincidir con el `wa_id` que
+ * Meta manda en cada webhook —y con el que un cerebro externo consulta el
+ * gateway—, así que el contacto se partiría en dos. Se normaliza solo el
+ * número que viaja por el cable.
+ *
+ * Para agregar un país: una línea aquí y su caso en
+ * `tests/unit/meta-client.test.ts`.
+ */
+const SEND_ONLY_TRUNKS = [
+  // Argentina: Meta reporta `549` + 10 dígitos; se envía sin el 9 (issue #35).
+  { reported: "549", dialable: "54", nationalDigits: 10 },
+] as const;
+
+/**
+ * El número tal como hay que mandárselo a Meta.
+ *
+ * Es lo que la identidad ya canoniza, MÁS los troncales que solo estorban al
+ * enviar. Ojo con el alcance real del problema que arregla: el `131030`
+ * ("Recipient phone number not in allowed list") viene de la lista de
+ * destinatarios de prueba, que solo existe MIENTRAS el negocio no está
+ * verificado. Ya en producción no hay lista y Meta acepta las dos formas —
+ * normaliza internamente y responde el `wa_id` con el troncal puesto. O sea:
+ * esto desatasca la puesta en marcha, que es justo cuando una agencia está
+ * probando la instancia y el mensaje de error la manda a revisar una lista de
+ * permitidos que está bien.
+ */
+export function normalizeRecipient(phone: string): string {
+  const canonical = normalizeMx(phone);
+  for (const trunk of SEND_ONLY_TRUNKS) {
+    const expected = trunk.reported.length + trunk.nationalDigits;
+    if (canonical.length === expected && canonical.startsWith(trunk.reported)) {
+      return trunk.dialable + canonical.slice(trunk.reported.length);
+    }
+  }
+  return canonical;
+}

--- a/tests/unit/meta-client.test.ts
+++ b/tests/unit/meta-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { MetaApiError, normalizeRecipient } from "@/lib/meta/client";
+import { MetaApiError, normalizeMx, normalizeRecipient } from "@/lib/meta/client";
 
 describe("normalizeRecipient", () => {
   it("México móvil legado: 521 + 10 dígitos → 52 + 10 dígitos", () => {
@@ -10,13 +10,33 @@ describe("normalizeRecipient", () => {
     expect(normalizeRecipient("525512345678")).toBe("525512345678");
   });
 
-  it("otros países quedan intactos", () => {
-    expect(normalizeRecipient("14155552671")).toBe("14155552671");
-    expect(normalizeRecipient("5491122334455")).toBe("5491122334455");
+  it("Argentina móvil: 549 + 10 dígitos → 54 + 10 dígitos (issue #35)", () => {
+    // Meta reporta `549…` pero la lista de destinatarios de prueba solo
+    // acepta el número sin el 9: con el 9 responde 131030 y el panel muestra
+    // el número como habilitado, así que el error manda a revisar donde no es.
+    expect(normalizeRecipient("5491122334455")).toBe("541122334455");
   });
 
-  it("no confunde números que empiezan en 521 pero con otra longitud", () => {
+  it("Argentina ya normalizada queda intacta", () => {
+    expect(normalizeRecipient("541122334455")).toBe("541122334455");
+  });
+
+  it("otros países quedan intactos", () => {
+    expect(normalizeRecipient("14155552671")).toBe("14155552671");
+    expect(normalizeRecipient("50761234567")).toBe("50761234567");
+  });
+
+  it("no confunde números que empiezan en el troncal pero con otra longitud", () => {
     expect(normalizeRecipient("521123")).toBe("521123");
+    expect(normalizeRecipient("549123")).toBe("549123");
+    // 549 + 11 dígitos no es un móvil argentino: no se toca.
+    expect(normalizeRecipient("54911223344556")).toBe("54911223344556");
+  });
+
+  it("la identidad NO se toca: normalizar al enviar es asimétrico a propósito", () => {
+    // Si la ingesta reescribiera `549…`, la identidad guardada dejaría de
+    // coincidir con el `wa_id` de cada webhook y el contacto se partiría.
+    expect(normalizeMx("5491122334455")).toBe("5491122334455");
   });
 });
 


### PR DESCRIPTION
Closes #35.

**El diagnóstico, la causa raíz y la verificación en vivo son de @alit0**, que
además dejó el fix de su fork como referencia y se ofreció a mandar el PR. Va
acreditado como co-autor del commit. Gracias 🙌

## El problema

Meta reporta a un móvil argentino como `549` + 10 dígitos, pero la lista de
destinatarios de prueba solo acepta el número **sin el 9**. Con el 9 responde
`131030 "Recipient phone number not in allowed list"` mientras el panel muestra
ese mismo número como habilitado — el error manda a revisar justo donde no está
el problema.

En `src/lib/meta/client.ts`, `normalizeRecipient` era un alias:

```ts
export const normalizeRecipient = normalizeMx;   // solo contempla 521 (México)
```

## El fix

`normalizeRecipient` pasa a ser una función propia: **lo que ya canoniza la
identidad, más una tabla de troncales que solo estorban al enviar.**

```ts
const SEND_ONLY_TRUNKS = [
  // Argentina: Meta reporta `549` + 10 dígitos; se envía sin el 9 (issue #35).
  { reported: "549", dialable: "54", nationalDigits: 10 },
] as const;
```

Agregar un país es una línea aquí y su caso en el test. Se eligió tabla en vez
de un `if` porque ya van dos casos con la misma forma, y el tercero no debería
obligar a releer la función.

**`normalizeMx` no se toca, y la asimetría es deliberada** — es la parte fina
del asunto, y @alit0 ya la había razonado bien en el issue: si la ingesta
reescribiera `549…`, la identidad guardada dejaría de casar con el `wa_id` que
Meta manda en cada webhook —y con el que un cerebro externo consulta
`/api/bot/context`—, así que el contacto se partiría en dos. Se normaliza solo
el número que viaja por el cable. Hay un test que lo deja escrito.

## Un matiz sobre el alcance

El issue dice "todo envío falla". Al corroborarlo: el `131030` viene de la
**lista de destinatarios de prueba, que solo existe mientras el negocio no está
verificado**. En producción no hay lista y Meta acepta las dos formas —
normaliza internamente y devuelve el `wa_id` con el troncal puesto.

O sea: esto desatasca **la puesta en marcha**, que es exactamente cuando una
agencia está probando la instancia de su cliente y se topa con un error que la
manda a revisar una lista que está bien. No es un envío roto en producción.
Queda escrito en el código para que no se lea al revés dentro de un año.

## Verificación

| Gate | Resultado |
|---|---|
| typecheck · lint · build | verde |
| Unit (`pnpm test`) | **349 pasan** |
| Arnés E2E en vivo | **127/127 checks** (base limpia) |

Había un test que **afirmaba el bug** (`normalizeRecipient("5491122334455")` →
sin cambios); ahora afirma el comportamiento correcto, y se agregaron los casos
de borde: número ya normalizado, `549` con otra longitud, y la asimetría con la
identidad.

Los cinco checks nuevos del arnés miran **lo que sale por el cable**, no el
valor de la función: se ingesta un lead argentino, se le responde, y se afirma
que el `to` que recibió Graph es `541122334455` y **nunca** `5491122334455`.
Probar solo la función habría dejado pasar un fallo en cualquiera de los dos
puntos de envío (`send.ts` y `templates.ts`).

De paso, el bloque nuevo del arnés cuenta el outbox en vez de vaciarlo: el
`DELETE` del wa-mock reinicia su contador de `wa_message_id` y en una
re-corrida tumbaba el envío con un 500 ajeno a lo que se prueba.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
