### PR TITLE
feat(016): atribución de anuncios y Conversions API de Meta, tras la bandera ATRIBUCION

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,17 @@ META_GRAPH_API_VERSION=v25.0
 # Para encender Instagram (ver README - Conexion de Instagram):
 # CHANNELS=whatsapp,instagram
 
+# --- Atribucion de anuncios (opcional) -----------------------
+# Conversions API de Meta: reporta el lead calificado y la venta cerrada de las
+# conversaciones que llegaron por un anuncio Click-to-WhatsApp, para que tus
+# campanas optimicen hacia quien compra. Apagada por defecto: sin esta variable
+# no se captura el origen del anuncio, no se le reporta nada a Meta y toda su
+# superficie responde 404.
+# ATRIBUCION=on
+#
+# Encenderla NO pide credenciales nuevas: el dataset se pega en Ajustes -
+# Anuncios y el token se reusa del de WhatsApp. Guia: docs/atribucion-capi.md
+
 # --- Agenda (opcional) --------------------------------------
 # Motor de agendamiento: horarios, citas y reservas del agente. Apagado por
 # defecto. Sin esta variable no existe para nadie: ni pantalla de Citas, ni

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/015-motor-agenda-universal"
+  "feature_directory": "specs/016-atribucion-capi"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ externas: el trabajo en segundo plano (agente, Laboratorio) es in-process.
 | Conectar TU propio bot en vez del agente | `src/app/api/bot/*` + `src/server/bot/auth.ts` (X-API-Key) |
 | La agenda (horarios, huecos, citas) | `src/server/agenda/` — detrás de la bandera `AGENDA` (`flag.ts`) |
 | Cómo se entrega la reunión (Zoom, Meet…) | `src/server/agenda/connectors/` + catálogo en `src/lib/agenda-connectors.ts` · guía: [docs/agenda-conectores.md](docs/agenda-conectores.md) |
+| La atribución de anuncios y el reporte a Meta | `src/server/attribution/` — detrás de la bandera `ATRIBUCION` (`flag.ts`) + `src/lib/meta/capi.ts` · guía: [docs/atribucion-capi.md](docs/atribucion-capi.md) |
 | UI | `src/components/` + `src/app/(app)/` |
 
 Los mocks del entorno de pruebas viven en `src/app/api/dev/` (wa-mock +
@@ -74,7 +75,7 @@ Ver [.specify/memory/constitution.md](.specify/memory/constitution.md).
 - **Sandbox del Laboratorio**: las conversaciones `is_test` JAMÁS tocan la API
   real — el sender lanza excepción (no lo "arregles": es un guardrail). Lo
   mismo vale para la agenda: una cita de prueba nunca llega a un conector.
-- **Módulos opcionales (015)**: lo que no usa toda instancia va detrás de una
+- **Módulos opcionales (015, 016)**: lo que no usa toda instancia va detrás de una
   bandera de despliegue, apagado por defecto, con su superficie en 404 y la
   migración aplicada igual. Nunca en una rama aparte
   ([ADR-001](docs/adr-001-canales-opcionales.md),

--- a/README.md
+++ b/README.md
@@ -123,6 +123,25 @@ tu conector en tu fork siguiendo
 cae, la cita **se agenda igual** con el enlace pendiente de reintentar: un
 tercero caído no te cuesta la conversión.
 
+### 📈 Conversiones de anuncios (opcional, apagada por defecto)
+
+Si anuncias con **Click-to-WhatsApp**, Meta sabe qué conversaciones empezaron
+desde un anuncio, pero no cuáles sirvieron: sin nadie que se lo diga, optimiza
+hacia el público más barato de hacer escribir, que rara vez es el que compra.
+
+Enciéndela con `ATRIBUCION=on`, pega tu dataset en Ajustes → Anuncios (el token
+lo reusa de tu conexión de WhatsApp) y di qué etapa de TU pipeline significa
+"lead calificado". A partir de ahí el CRM le reporta a Meta el lead calificado y
+la venta cerrada —con su importe— por la **Conversions API**, y una tabla de
+actividad te dice qué se envió, con qué acuse y, cuando no salió, por qué.
+
+No se le pide nada al usuario que el CRM ya sepa: la venta cuelga de la etapa
+ganada que ya tienes, y todo se dispara desde la misma puerta que mueve leads,
+así que reporta igual si arrastras la tarjeta tú, el agente incluido o tu propio
+bot. Si Meta se cae, el lead se mueve igual: una conversión jamás vale un
+movimiento bloqueado. Los gotchas de Meta que cuesta descubrir solo están en
+[`docs/atribucion-capi.md`](docs/atribucion-capi.md).
+
 ### 📄 Plantillas · 👥 Multi-usuario · 🔐 Self-hosted
 
 Plantillas con varias variables `{{1}}…{{n}}` y aprobación de Meta

--- a/docs/atribucion-capi.md
+++ b/docs/atribucion-capi.md
@@ -1,0 +1,144 @@
+# Atribución de anuncios y Conversions API
+
+> Feature opcional (016), apagada por defecto. Se enciende con `ATRIBUCION=on`.
+
+## El problema que resuelve
+
+Si anuncias con **Click-to-WhatsApp**, Meta sabe qué conversaciones
+**empezaron** desde un anuncio. No sabe cuáles **sirvieron**. Sin nadie que se
+lo diga, el algoritmo optimiza hacia lo único que ve —que alguien abra el
+chat— y te entrega el público más barato de hacer escribir, que rara vez es el
+que compra. Se siente como "me llegan muchos mensajes y no cierro ninguno".
+
+Vocero está en el único lugar donde esa verdad existe: sabe que esta
+conversación vino del anuncio A, que se calificó el martes y que se ganó el
+viernes por $12,000. Encender esta feature es devolverle a Meta ese desenlace,
+para que el mismo presupuesto empiece a comprar clientes en vez de chats.
+
+## Cómo se enciende
+
+1. `ATRIBUCION=on` en el entorno (en Coolify: variable de runtime, y
+   **redeploy** — reiniciar no basta).
+2. Ajustes → **Anuncios**: pega el **ID de tu dataset** y guarda. Si ya
+   conectaste WhatsApp, **no necesitas pegar token**: se reusa el del negocio,
+   que es el mismo que autoriza publicar en el dataset.
+3. Elige **qué etapa de tu pipeline significa "lead calificado"**. La venta no
+   se configura: se reporta sola cuando el trato entra a tu etapa ganada.
+
+Eso es todo. A partir de ahí, cada lead que llegó por un anuncio y avanza en tu
+tablero se le reporta a Meta.
+
+### De dónde sale el ID del dataset
+
+Administrador de eventos de Meta → tu conjunto de datos → el número largo. En
+la práctica, el dataset de mensajería **es el de tu propia cuenta de WhatsApp**:
+`POST {waba_id}/dataset` en la Graph API devuelve ese mismo id, y es idempotente
+(repetirlo devuelve el existente).
+
+## Qué se reporta, exactamente
+
+| Cuándo | Evento de Meta | Datos |
+|---|---|---|
+| El lead entra a tu etapa "calificado" | `QualifiedLead` | `lead_stage: "qualified"` |
+| El lead entra a tu etapa ganada | `Purchase` | `lead_stage: "won"` + `value`/`currency` si el trato tiene monto |
+
+Ambos salen con el `ctwa_clid` del clic y el id de tu cuenta de WhatsApp.
+**Nunca** viaja el teléfono, el nombre ni el texto del contacto.
+
+Los dos eventos se disparan desde la única puerta que mueve leads de etapa, así
+que da igual quién lo mueva: tú arrastrando la tarjeta, el agente incluido o tu
+propio bot por `/api/bot/*`.
+
+## Cómo saber si está funcionando
+
+Ajustes → Anuncios → **Actividad**. Ahí está lo último que se reportó, con su
+estado:
+
+- **Enviado** — Meta acusó recibo (`fbtrace_id` es la referencia que pide su
+  soporte para rastrear un evento).
+- **Fallido** — Meta lo rechazó, o el token venció, o se cayó la red. El motivo
+  está escrito tal cual lo dijo Meta.
+- **Omitido** — no había nada que reportar: la conversación no vino de un
+  anuncio, o falta configurar el dataset.
+
+Esa tabla es la fuente de verdad, no el Administrador de eventos: sus reportes
+tardan y sus APIs de estadísticas **están ciegas a los eventos de mensajería**
+(devuelven vacío aunque el dataset esté recibiendo eventos).
+
+## Gotchas de Meta que cuesta descubrir solo
+
+Esto es lo que se aprendió operando esta integración en producción durante
+meses. Ninguno aparece con esa claridad en la documentación oficial:
+
+1. **Meta responde `200` aunque descarte tu evento.** El único acuse real es
+   `events_received >= 1`. Vocero lo comprueba y marca la fila como fallida
+   cuando llega en cero — si no, un evento tirado a la basura se vería idéntico
+   a uno bueno.
+2. **No existe el evento de prueba sintético.** Meta valida el `ctwa_clid`
+   contra un clic real: cualquier valor inventado devuelve `code 100 /
+   error_subcode 2804087`. La única forma de registrar una conversión es un lead
+   que de verdad hizo clic en tu anuncio.
+3. **`custom_data` es lo único reglable.** Si algún día envuelves estos eventos
+   en una *conversión personalizada*, sus reglas solo pueden mirar `custom_data`
+   y la URL — `event_name` y el origen de acción **no son parámetros
+   reglables**. Por eso cada evento sale con `lead_stage`: sin él, la conversión
+   personalizada se queda en cero para siempre y nada te dice por qué.
+4. **El catálogo de eventos es cerrado.** `business_messaging` solo acepta
+   14 nombres (`Purchase`, `QualifiedLead`, `InitiateCheckout`, `ViewContent`…).
+   Un nombre propio es un `400` opaco.
+5. **`QualifiedLead` solo es elegible en campañas de CLIENTES POTENCIALES.** Si
+   optimizas una campaña de **ventas** con destino de mensajes, ese evento no
+   aparece en el selector (ver la receta de abajo).
+6. **El aviso "sin evento de conversión configurado"** que Meta pinta en el
+   selector de la campaña puede quedarse ahí para siempre aunque tu dataset esté
+   recibiendo eventos: ese registro es un constructo del píxel web y no se puede
+   escribir para un dataset de mensajería pura. Es cosmético; la campaña publica
+   igual y la atribución va por el `ctwa_clid`.
+
+## Receta: optimizar una campaña de VENTAS
+
+Como `QualifiedLead` no es elegible ahí, quien quiera optimizar una campaña de
+ventas con destino de mensajes necesita un evento que **sí** esté en la
+intersección de "campaña de ventas" y "catálogo de mensajería":
+`InitiateCheckout`, `ViewContent` o `Purchase`.
+
+Vocero **no** hace esto de fábrica a propósito: duplicar cada lead calificado
+como "inició pago" es una decisión de negocio, no una verdad del CRM, y quien la
+tome debe saber que lo está haciendo. Si la quieres, son tres líneas en tu fork:
+
+```ts
+// src/server/attribution/conversions.ts — dentro de reportStageChange,
+// después de emitir QualifiedLead:
+await emitConversion(
+  input.organizationId,
+  row.conversationId,
+  "InitiateCheckout",           // el espejo que tu campaña de ventas sí acepta
+  { lead_stage: "qualified" }
+);
+```
+
+`emitConversion` es público justamente para esto: hereda el dedup, el manejo del
+acuse y el registro en la actividad. Dos advertencias ganadas a golpes:
+
+- El espejo debe acompañar a un envío **recién intentado**. Si lo emites por un
+  lead calificado hace semanas, saldrá con la fecha de hoy y romperá la
+  atribución.
+- Deja `Purchase` para la venta cerrada. Y **jamás** dispares un `Purchase` con
+  un importe de prueba: un solo valor falso envenena la optimización por valor.
+
+## Preguntas frecuentes
+
+**¿Y los leads de antes de encender la bandera?** No se atribuyen: sin `ATRIBUCION`
+el CRM no guarda el `ctwa_clid`, y sin él no hay nada que reportar. Tampoco se
+pierde gran cosa — la ventana de atribución de Meta se mide en días.
+
+**¿Qué pasa si Meta está caído?** El lead se mueve igual. La conversión queda
+registrada como fallida con el motivo. Ninguna parte de tu operación depende de
+que Meta conteste.
+
+**¿Y el Laboratorio?** Una conversación de prueba **nunca** produce un evento.
+Es el mismo guardrail que impide que el Laboratorio mande WhatsApps reales.
+
+**¿Se puede apagar?** Sí: quita `ATRIBUCION` y toda la superficie desaparece. O
+desconecta el dataset desde la pantalla y deja de reportarse, conservando la
+bitácora de lo que ya se dijo.

--- a/drizzle/0010_atribucion_capi.sql
+++ b/drizzle/0010_atribucion_capi.sql
@@ -1,0 +1,82 @@
+-- 016 Atribucion de anuncios Click-to-WhatsApp y Conversions API de Meta
+-- (origen del anuncio, eventos reportados y la conexion del negocio).
+--
+-- Editada a mano sobre la generada para ser RE-EJECUTABLE (Constitucion IV):
+-- IF NOT EXISTS en tablas e indices, y DO-block en cada clave foranea.
+--
+-- Es puramente ADITIVA: no toca ninguna tabla existente, asi que aplicarla
+-- sobre una instancia con datos no puede perder nada. Se aplica SIEMPRE, con
+-- la bandera ATRIBUCION encendida o apagada: unas tablas vacias son inertes y
+-- a cambio todas las instancias comparten la misma estructura (ADR-001).
+
+CREATE TABLE IF NOT EXISTS "ad_attribution" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"contact_id" text NOT NULL,
+	"conversation_id" text NOT NULL,
+	"ctwa_clid" text,
+	"source_id" text,
+	"source_type" text,
+	"source_url" text,
+	"headline" text,
+	"body" text,
+	"media_type" text,
+	"raw" jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "capi_settings" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"dataset_id" text NOT NULL,
+	"token_cipher" text NOT NULL,
+	"token_iv" text NOT NULL,
+	"token_tag" text NOT NULL,
+	"qualified_stage_id" text,
+	"status" text DEFAULT 'connected' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "conversion_event" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"conversation_id" text NOT NULL,
+	"attribution_id" text,
+	"event_name" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"error" text,
+	"fb_trace_id" text,
+	"sent_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+	ALTER TABLE "ad_attribution" ADD CONSTRAINT "ad_attribution_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN
+	ALTER TABLE "ad_attribution" ADD CONSTRAINT "ad_attribution_contact_id_contact_id_fk" FOREIGN KEY ("contact_id") REFERENCES "public"."contact"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN
+	ALTER TABLE "ad_attribution" ADD CONSTRAINT "ad_attribution_conversation_id_conversation_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversation"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN
+	ALTER TABLE "capi_settings" ADD CONSTRAINT "capi_settings_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN
+	ALTER TABLE "capi_settings" ADD CONSTRAINT "capi_settings_qualified_stage_id_pipeline_stage_id_fk" FOREIGN KEY ("qualified_stage_id") REFERENCES "public"."pipeline_stage"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN
+	ALTER TABLE "conversion_event" ADD CONSTRAINT "conversion_event_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN
+	ALTER TABLE "conversion_event" ADD CONSTRAINT "conversion_event_conversation_id_conversation_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversation"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN
+	ALTER TABLE "conversion_event" ADD CONSTRAINT "conversion_event_attribution_id_ad_attribution_id_fk" FOREIGN KEY ("attribution_id") REFERENCES "public"."ad_attribution"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "ad_attribution_org_conversation_uq" ON "ad_attribution" USING btree ("organization_id","conversation_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ad_attribution_org_contact_idx" ON "ad_attribution" USING btree ("organization_id","contact_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "capi_settings_org_uq" ON "capi_settings" USING btree ("organization_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "conversion_event_org_conv_name_uq" ON "conversion_event" USING btree ("organization_id","conversation_id","event_name");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "conversion_event_org_created_idx" ON "conversion_event" USING btree ("organization_id","created_at");

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,3762 @@
+{
+  "id": "de0a2c97-62e7-4850-bb47-20a56ec37d2a",
+  "prevId": "4744308a-ddd1-4ee2-95c3-eda8a9abc9f6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ad_attribution": {
+      "name": "ad_attribution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ctwa_clid": {
+          "name": "ctwa_clid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headline": {
+          "name": "headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ad_attribution_org_conversation_uq": {
+          "name": "ad_attribution_org_conversation_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ad_attribution_org_contact_idx": {
+          "name": "ad_attribution_org_contact_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ad_attribution_organization_id_organization_id_fk": {
+          "name": "ad_attribution_organization_id_organization_id_fk",
+          "tableFrom": "ad_attribution",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ad_attribution_contact_id_contact_id_fk": {
+          "name": "ad_attribution_contact_id_contact_id_fk",
+          "tableFrom": "ad_attribution",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ad_attribution_conversation_id_conversation_id_fk": {
+          "name": "ad_attribution_conversation_id_conversation_id_fk",
+          "tableFrom": "ad_attribution",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_profile": {
+      "name": "agent_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asistente'"
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalation_rules": {
+          "name": "escalation_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_profile_org_uq": {
+          "name": "agent_profile_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_profile_organization_id_organization_id_fk": {
+          "name": "agent_profile_organization_id_organization_id_fk",
+          "tableFrom": "agent_profile",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_case": {
+      "name": "agent_test_case",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "veredicto": {
+          "name": "veredicto",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hallazgos": {
+          "name": "hallazgos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_case_run_idx": {
+          "name": "test_case_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_case_organization_id_organization_id_fk": {
+          "name": "agent_test_case_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_run_id_agent_test_run_id_fk": {
+          "name": "agent_test_case_run_id_agent_test_run_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "agent_test_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_conversation_id_conversation_id_fk": {
+          "name": "agent_test_case_conversation_id_conversation_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_run": {
+      "name": "agent_test_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "test_run_org_running_uq": {
+          "name": "test_run_org_running_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_test_run\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_run_org_idx": {
+          "name": "test_run_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_run_organization_id_organization_id_fk": {
+          "name": "agent_test_run_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking": {
+      "name": "booking",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'session'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'agendada'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector": {
+          "name": "connector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_link": {
+          "name": "meeting_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_pending": {
+          "name": "link_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_test": {
+          "name": "is_test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "booking_org_when_idx": {
+          "name": "booking_org_when_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_org_status_idx": {
+          "name": "booking_org_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_org_active_slot_uq": {
+          "name": "booking_org_active_slot_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"booking\".\"status\" in ('agendada','realizada') and \"booking\".\"is_test\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_organization_id_organization_id_fk": {
+          "name": "booking_organization_id_organization_id_fk",
+          "tableFrom": "booking",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "booking_contact_id_contact_id_fk": {
+          "name": "booking_contact_id_contact_id_fk",
+          "tableFrom": "booking",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "booking_conversation_id_conversation_id_fk": {
+          "name": "booking_conversation_id_conversation_id_fk",
+          "tableFrom": "booking",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "booking_lead_id_lead_id_fk": {
+          "name": "booking_lead_id_lead_id_fk",
+          "tableFrom": "booking",
+          "tableTo": "lead",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_settings": {
+      "name": "calendar_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_hours": {
+          "name": "weekly_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_minutes": {
+          "name": "slot_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "buffer_minutes": {
+          "name": "buffer_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "min_notice_hours": {
+          "name": "min_notice_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "max_days_ahead": {
+          "name": "max_days_ahead",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/Mexico_City'"
+        },
+        "connector": {
+          "name": "connector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enlace-fijo'"
+        },
+        "meeting_link": {
+          "name": "meeting_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_settings_org_uq": {
+          "name": "calendar_settings_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_settings_organization_id_organization_id_fk": {
+          "name": "calendar_settings_organization_id_organization_id_fk",
+          "tableFrom": "calendar_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capi_settings": {
+      "name": "capi_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_cipher": {
+          "name": "token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qualified_stage_id": {
+          "name": "qualified_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "capi_settings_org_uq": {
+          "name": "capi_settings_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capi_settings_organization_id_organization_id_fk": {
+          "name": "capi_settings_organization_id_organization_id_fk",
+          "tableFrom": "capi_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "capi_settings_qualified_stage_id_pipeline_stage_id_fk": {
+          "name": "capi_settings_qualified_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "capi_settings",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "qualified_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact": {
+      "name": "contact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'whatsapp'"
+        },
+        "wa_identity": {
+          "name": "wa_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_user_id": {
+          "name": "wa_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ficha": {
+          "name": "ficha",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_org_channel_identity_uq": {
+          "name": "contact_org_channel_identity_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_wa_user_id_idx": {
+          "name": "contact_org_wa_user_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_name_idx": {
+          "name": "contact_org_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_organization_id_organization_id_fk": {
+          "name": "contact_organization_id_organization_id_fk",
+          "tableFrom": "contact",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_test": {
+          "name": "is_test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'whatsapp'"
+        },
+        "channel_thread_ref": {
+          "name": "channel_thread_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_enabled": {
+          "name": "ai_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handoff_at": {
+          "name": "handoff_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_reason": {
+          "name": "handoff_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_inbound_at": {
+          "name": "last_inbound_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_org_contact_real_uq": {
+          "name": "conversation_org_contact_real_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation\".\"is_test\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_org_last_idx": {
+          "name": "conversation_org_last_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_organization_id_organization_id_fk": {
+          "name": "conversation_organization_id_organization_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_contact_id_contact_id_fk": {
+          "name": "conversation_contact_id_contact_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversion_event": {
+      "name": "conversion_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribution_id": {
+          "name": "attribution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fb_trace_id": {
+          "name": "fb_trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversion_event_org_conv_name_uq": {
+          "name": "conversion_event_org_conv_name_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversion_event_org_created_idx": {
+          "name": "conversion_event_org_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversion_event_organization_id_organization_id_fk": {
+          "name": "conversion_event_organization_id_organization_id_fk",
+          "tableFrom": "conversion_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversion_event_conversation_id_conversation_id_fk": {
+          "name": "conversion_event_conversation_id_conversation_id_fk",
+          "tableFrom": "conversion_event",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversion_event_attribution_id_ad_attribution_id_fk": {
+          "name": "conversion_event_attribution_id_ad_attribution_id_fk",
+          "tableFrom": "conversion_event",
+          "tableTo": "ad_attribution",
+          "columnsFrom": [
+            "attribution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_credentials": {
+      "name": "google_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_cipher": {
+          "name": "client_secret_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_iv": {
+          "name": "client_secret_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_tag": {
+          "name": "client_secret_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_cipher": {
+          "name": "refresh_token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_iv": {
+          "name": "refresh_token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_tag": {
+          "name": "refresh_token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "google_credentials_org_uq": {
+          "name": "google_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_credentials_organization_id_organization_id_fk": {
+          "name": "google_credentials_organization_id_organization_id_fk",
+          "tableFrom": "google_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instagram_credentials": {
+      "name": "instagram_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ig_user_id": {
+          "name": "ig_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_ref": {
+          "name": "account_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_cipher": {
+          "name": "token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instagram_credentials_org_uq": {
+          "name": "instagram_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instagram_credentials_ig_user_uq": {
+          "name": "instagram_credentials_ig_user_uq",
+          "columns": [
+            {
+              "expression": "ig_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instagram_credentials_account_ref_idx": {
+          "name": "instagram_credentials_account_ref_idx",
+          "columns": [
+            {
+              "expression": "account_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instagram_credentials_organization_id_organization_id_fk": {
+          "name": "instagram_credentials_organization_id_organization_id_fk",
+          "tableFrom": "instagram_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_entry": {
+      "name": "kb_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kb_org_idx": {
+          "name": "kb_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_entry_organization_id_organization_id_fk": {
+          "name": "kb_entry_organization_id_organization_id_fk",
+          "tableFrom": "kb_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead": {
+      "name": "lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_updated_at": {
+          "name": "priority_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lead_contact_uq": {
+          "name": "lead_contact_uq",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lead_org_stage_idx": {
+          "name": "lead_org_stage_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_organization_id_organization_id_fk": {
+          "name": "lead_organization_id_organization_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_contact_id_contact_id_fk": {
+          "name": "lead_contact_id_contact_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead_stage_event": {
+      "name": "lead_stage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_stage_id": {
+          "name": "from_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_stage_name": {
+          "name": "from_stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage_id": {
+          "name": "to_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage_name": {
+          "name": "to_stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_stage_kind": {
+          "name": "to_stage_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dueno'"
+        },
+        "approximate": {
+          "name": "approximate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "loss_reason": {
+          "name": "loss_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loss_note": {
+          "name": "loss_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lse_org_occurred_idx": {
+          "name": "lse_org_occurred_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lse_lead_occurred_idx": {
+          "name": "lse_lead_occurred_idx",
+          "columns": [
+            {
+              "expression": "lead_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lse_org_kind_occurred_idx": {
+          "name": "lse_org_kind_occurred_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_stage_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_stage_event_organization_id_organization_id_fk": {
+          "name": "lead_stage_event_organization_id_organization_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_lead_id_lead_id_fk": {
+          "name": "lead_stage_event_lead_id_lead_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "lead",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_contact_id_contact_id_fk": {
+          "name": "lead_stage_event_contact_id_contact_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_from_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_event_from_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "from_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_to_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_event_to_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "to_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_actor_user_id_user_id_fk": {
+          "name": "lead_stage_event_actor_user_id_user_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lse_loss_reason_ck": {
+          "name": "lse_loss_reason_ck",
+          "value": "\"lead_stage_event\".\"to_stage_kind\" <> 'lost' OR \"lead_stage_event\".\"approximate\" = true OR \"lead_stage_event\".\"loss_reason\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_asset": {
+      "name": "media_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_media_id": {
+          "name": "wa_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_status": {
+          "name": "fetch_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_asset_org_idx": {
+          "name": "media_asset_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_asset_wa_media_idx": {
+          "name": "media_asset_wa_media_idx",
+          "columns": [
+            {
+              "expression": "wa_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_asset_organization_id_organization_id_fk": {
+          "name": "media_asset_organization_id_organization_id_fk",
+          "tableFrom": "media_asset",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_message_id": {
+          "name": "wa_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated": {
+          "name": "ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'operator'"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_timestamp": {
+          "name": "wa_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_org_conv_idx": {
+          "name": "message_org_conv_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_organization_id_organization_id_fk": {
+          "name": "message_organization_id_organization_id_fk",
+          "tableFrom": "message",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_media_asset_id_media_asset_id_fk": {
+          "name": "message_media_asset_id_media_asset_id_fk",
+          "tableFrom": "message",
+          "tableTo": "media_asset",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_wa_message_id_unique": {
+          "name": "message_wa_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wa_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_credentials": {
+      "name": "meta_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waba_id": {
+          "name": "waba_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number_id": {
+          "name": "phone_number_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_phone_number": {
+          "name": "display_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_name": {
+          "name": "verified_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_cipher": {
+          "name": "token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meta_credentials_org_uq": {
+          "name": "meta_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meta_credentials_phone_uq": {
+          "name": "meta_credentials_phone_uq",
+          "columns": [
+            {
+              "expression": "phone_number_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meta_credentials_organization_id_organization_id_fk": {
+          "name": "meta_credentials_organization_id_organization_id_fk",
+          "tableFrom": "meta_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.offered_slot": {
+      "name": "offered_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_utc": {
+          "name": "start_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offered_at": {
+          "name": "offered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "offered_slot_conv_idx": {
+          "name": "offered_slot_conv_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "offered_slot_organization_id_organization_id_fk": {
+          "name": "offered_slot_organization_id_organization_id_fk",
+          "tableFrom": "offered_slot",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "offered_slot_conversation_id_conversation_id_fk": {
+          "name": "offered_slot_conversation_id_conversation_id_fk",
+          "tableFrom": "offered_slot",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_stage": {
+      "name": "pipeline_stage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stage_org_pos_idx": {
+          "name": "stage_org_pos_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_stage_organization_id_organization_id_fk": {
+          "name": "pipeline_stage_organization_id_organization_id_fk",
+          "tableFrom": "pipeline_stage",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_template_id": {
+          "name": "wa_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_org_name_lang_uq": {
+          "name": "template_org_name_lang_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_organization_id_organization_id_fk": {
+          "name": "template_organization_id_organization_id_fk",
+          "tableFrom": "template",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zoom_credentials": {
+      "name": "zoom_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_cipher": {
+          "name": "secret_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_iv": {
+          "name": "secret_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_tag": {
+          "name": "secret_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "zoom_credentials_org_uq": {
+          "name": "zoom_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zoom_credentials_organization_id_organization_id_fk": {
+          "name": "zoom_credentials_organization_id_organization_id_fk",
+          "tableFrom": "zoom_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1787796724315,
       "tag": "0009_motor_agenda",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1787960052077,
+      "tag": "0010_atribucion_capi",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/e2e-selftest.mjs
+++ b/scripts/e2e-selftest.mjs
@@ -976,6 +976,7 @@ async function main() {
   );
 
   await agendaChecks();
+  await atribucionChecks();
 
   console.log(`\n===== ${checks - failures}/${checks} checks OK, ${failures} fallos =====`);
   process.exit(failures > 0 ? 1 : 0);
@@ -1415,3 +1416,375 @@ main().catch((err) => {
   console.error("ERROR FATAL:", err);
   process.exit(1);
 });
+
+/* ============================================================
+ * 016 — Atribución de anuncios y Conversions API (tests/e2e/us-atribucion.md)
+ *
+ * Cubre las dos configuraciones de la bandera, la conexión del dataset, la
+ * captura del anuncio, los dos eventos con la FORMA de su payload, el dedup,
+ * y —lo que más importa— que un fallo de Meta jamás cuesta el movimiento del
+ * lead.
+ *
+ * Los contactos llevan un sufijo por corrida: el dedup de conversiones es
+ * permanente por diseño, así que re-correr el arnés contra la MISMA base
+ * tiene que estrenar leads o estaría midiendo los de la corrida anterior.
+ * ============================================================ */
+
+async function atribucionChecks() {
+  const encendida = /^(on|1|true|si|sí|yes)$/i.test(
+    (process.env.ATRIBUCION ?? "").trim()
+  );
+  const SUF = String(Date.now()).slice(-6);
+  const tel = (n) => `52155${SUF}${n}`;
+  const nom = (base) => `${base} ${SUF}`;
+
+  console.log("\n== 016: la bandera de la atribución ==");
+
+  if (!encendida) {
+    for (const ruta of ["/api/settings/capi", "/api/settings/capi/events"]) {
+      const { res } = await api(ruta);
+      ok(
+        `${ruta} → 404 con la atribución apagada`,
+        res.status === 404,
+        `status=${res.status}`
+      );
+    }
+    const put = await api("/api/settings/capi", {
+      method: "PUT",
+      body: JSON.stringify({ datasetId: "ds-e2e" }),
+    });
+    ok(
+      "PUT /api/settings/capi → 404 con la atribución apagada",
+      put.res.status === 404,
+      `status=${put.res.status}`
+    );
+    const page = await fetch(`${BASE}/settings/ads`, { headers: { cookie } });
+    ok(
+      "la pantalla /settings/ads no existe",
+      page.status === 404,
+      `status=${page.status}`
+    );
+
+    // Y un mensaje que SÍ viene de un anuncio se atiende como cualquier otro:
+    // la instancia que no atribuye no se entera del referral, pero tampoco se
+    // rompe con él.
+    const inb = await api("/api/dev/wa-mock/inbound", {
+      method: "POST",
+      body: JSON.stringify({
+        phoneNumberId: PN,
+        from: tel("1"),
+        name: nom("Lead con anuncio apagada"),
+        text: "vi su anuncio",
+        ctwaClid: "clid-apagada",
+        waMessageId: `wamid.e2e.016.off.${SUF}`,
+      }),
+    });
+    ok("inbound con anuncio entregado igual", inb.res.ok);
+    await sleep(1400);
+    const convsOff = (await api("/api/conversations")).json?.conversations ?? [];
+    ok(
+      "la conversación del anuncio existe (la ingesta no se rompe)",
+      convsOff.some((c) => c.contact.name === nom("Lead con anuncio apagada"))
+    );
+    console.log(
+      "  (atribución apagada: el resto de los checks de 016 no aplican)"
+    );
+    return;
+  }
+
+  /* ---------------- US2: conectar el dataset ---------------- */
+
+  console.log("\n== 016: conectar el dataset (US2) ==");
+  // Se parte de desconectado: así el primer check afirma lo que dice afirmar
+  // aunque el arnés se re-corra sobre la misma base.
+  await api("/api/settings/capi", { method: "DELETE" });
+  const vacio = await api("/api/settings/capi");
+  ok(
+    "sin configurar responde 200 con capi: null (no 404)",
+    vacio.res.status === 200 && vacio.json?.capi === null,
+    JSON.stringify(vacio.json)
+  );
+
+  const board0 = (await api("/api/pipeline/board")).json;
+  const etapaCalificado = board0.stages.filter((s) => s.kind === "open").at(-1);
+  const etapaGanada = board0.stages.find((s) => s.kind === "won");
+  const etapaInicial = board0.stages.find((s) => s.kind === "open");
+
+  const etapaAjena = await api("/api/settings/capi", {
+    method: "PUT",
+    body: JSON.stringify({
+      datasetId: "ds-e2e",
+      qualifiedStageId: "stg_de_otro_negocio",
+    }),
+  });
+  ok(
+    "una etapa que no es del negocio se rechaza con 422 etapa_invalida",
+    etapaAjena.res.status === 422 &&
+      etapaAjena.json?.error?.code === "etapa_invalida",
+    `status=${etapaAjena.res.status} ${JSON.stringify(etapaAjena.json)}`
+  );
+
+  const guardado = await api("/api/settings/capi", {
+    method: "PUT",
+    body: JSON.stringify({
+      datasetId: "ds-e2e",
+      qualifiedStageId: etapaCalificado.id,
+    }),
+  });
+  ok(
+    "se guarda el dataset sin pegar token",
+    guardado.res.ok,
+    `status=${guardado.res.status}`
+  );
+
+  const cfg = (await api("/api/settings/capi")).json?.capi;
+  ok(
+    "reusó el token de WhatsApp y solo muestra sus últimos 4",
+    cfg?.datasetId === "ds-e2e" && cfg?.tokenLast4 === "-e2e",
+    JSON.stringify(cfg)
+  );
+  ok(
+    "el token completo NUNCA sale del servidor",
+    !JSON.stringify(cfg).includes("tok-e2e"),
+    JSON.stringify(cfg)
+  );
+
+  /* ---------------- US3 + US4: capturar y calificar ---------------- */
+
+  console.log("\n== 016: del anuncio al lead calificado (US3/US4) ==");
+  await api("/api/dev/wa-mock/capi-events", { method: "DELETE" });
+
+  const CLID = `clid-e2e-${SUF}`;
+  const NOMBRE_AD = nom("Lead de anuncio");
+  await api("/api/dev/wa-mock/inbound", {
+    method: "POST",
+    body: JSON.stringify({
+      phoneNumberId: PN,
+      from: tel("2"),
+      name: NOMBRE_AD,
+      text: "hola, vengo del anuncio",
+      ctwaClid: CLID,
+      adHeadline: "Kit de verano",
+      waMessageId: `wamid.e2e.016.ad.${SUF}.1`,
+    }),
+  });
+  await sleep(1400);
+
+  // Segundo mensaje con OTRO referral: el primero gana y no se sobreescribe.
+  await api("/api/dev/wa-mock/inbound", {
+    method: "POST",
+    body: JSON.stringify({
+      phoneNumberId: PN,
+      from: tel("2"),
+      name: NOMBRE_AD,
+      text: "sigo aquí",
+      ctwaClid: "clid-que-no-debe-ganar",
+      waMessageId: `wamid.e2e.016.ad.${SUF}.2`,
+    }),
+  });
+  await sleep(1200);
+
+  const board1 = (await api("/api/pipeline/board")).json;
+  const leadAd = board1.leads.find((l) => l.contact.name === NOMBRE_AD);
+  ok("el lead del anuncio existe en el tablero", !!leadAd);
+
+  const mov1 = await api(`/api/pipeline/leads/${leadAd.id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ stageId: etapaCalificado.id }),
+  });
+  ok(
+    "el lead se mueve a la etapa calificada",
+    mov1.res.ok,
+    `status=${mov1.res.status}`
+  );
+  await sleep(800);
+
+  const act1 = (await api("/api/settings/capi/events")).json?.events ?? [];
+  const calificado = act1.find(
+    (e) => e.eventName === "QualifiedLead" && e.contactName === NOMBRE_AD
+  );
+  ok(
+    "se reportó QualifiedLead con acuse de Meta",
+    calificado?.status === "sent" && !!calificado?.fbTraceId,
+    JSON.stringify(calificado)
+  );
+  ok(
+    "la actividad dice de qué anuncio vino",
+    calificado?.adHeadline === "Kit de verano",
+    JSON.stringify(calificado)
+  );
+
+  const capi1 = (await api("/api/dev/wa-mock/capi-events")).json?.capiEvents ?? [];
+  const evento1 = capi1.find((e) => e.eventName === "QualifiedLead");
+  ok(
+    "el evento viajó con el ctwa_clid del PRIMER referral",
+    evento1?.ctwaClid === CLID,
+    JSON.stringify(evento1?.ctwaClid)
+  );
+  ok(
+    "y con custom_data.lead_stage (lo único reglable en Meta)",
+    evento1?.customData?.lead_stage === "qualified",
+    JSON.stringify(evento1?.customData)
+  );
+
+  // Dedup: sacarlo y volverlo a meter no re-reporta.
+  await api(`/api/pipeline/leads/${leadAd.id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ stageId: etapaInicial.id }),
+  });
+  await api(`/api/pipeline/leads/${leadAd.id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ stageId: etapaCalificado.id }),
+  });
+  await sleep(800);
+  const act2 = (await api("/api/settings/capi/events")).json?.events ?? [];
+  const califsDeEste = act2.filter(
+    (e) => e.eventName === "QualifiedLead" && e.contactName === NOMBRE_AD
+  );
+  ok(
+    "volver a calificar NO reporta dos veces",
+    califsDeEste.length === 1,
+    `${califsDeEste.length} filas`
+  );
+
+  /* ---------------- US5: la venta ---------------- */
+
+  console.log("\n== 016: la venta (US5) ==");
+  const venta = await api(`/api/pipeline/leads/${leadAd.id}`, {
+    method: "PATCH",
+    body: JSON.stringify({
+      stageId: etapaGanada.id,
+      amountCents: 45050,
+      currency: "MXN",
+    }),
+  });
+  ok("el trato se marca como ganado", venta.res.ok, `status=${venta.res.status}`);
+  await sleep(800);
+
+  const act3 = (await api("/api/settings/capi/events")).json?.events ?? [];
+  const compra = act3.find(
+    (e) => e.eventName === "Purchase" && e.contactName === NOMBRE_AD
+  );
+  ok("se reportó la venta", compra?.status === "sent", JSON.stringify(compra));
+
+  const capi2 = (await api("/api/dev/wa-mock/capi-events")).json?.capiEvents ?? [];
+  const evento2 = capi2.find((e) => e.eventName === "Purchase");
+  ok(
+    "la venta viajó en UNIDADES de la moneda, no en centavos",
+    evento2?.customData?.value === 450.5 &&
+      evento2?.customData?.currency === "MXN",
+    JSON.stringify(evento2?.customData)
+  );
+
+  await api(`/api/pipeline/leads/${leadAd.id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ stageId: etapaCalificado.id }),
+  });
+  await api(`/api/pipeline/leads/${leadAd.id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ stageId: etapaGanada.id }),
+  });
+  await sleep(800);
+  const act4 = (await api("/api/settings/capi/events")).json?.events ?? [];
+  const comprasDeEste = act4.filter(
+    (e) => e.eventName === "Purchase" && e.contactName === NOMBRE_AD
+  );
+  ok(
+    "re-ganar NO manda una segunda compra (a Meta no se le des-envía nada)",
+    comprasDeEste.length === 1,
+    `${comprasDeEste.length} filas`
+  );
+
+  /* ---------------- Los caminos infelices ---------------- */
+
+  console.log("\n== 016: caminos infelices ==");
+
+  // Un lead que no vino de un anuncio: se registra el motivo y nada falla.
+  const NOMBRE_ORG = nom("Lead organico");
+  await api("/api/dev/wa-mock/inbound", {
+    method: "POST",
+    body: JSON.stringify({
+      phoneNumberId: PN,
+      from: tel("3"),
+      name: NOMBRE_ORG,
+      text: "hola",
+      waMessageId: `wamid.e2e.016.org.${SUF}`,
+    }),
+  });
+  await sleep(1400);
+  const board2 = (await api("/api/pipeline/board")).json;
+  const leadOrg = board2.leads.find((l) => l.contact.name === NOMBRE_ORG);
+  await api(`/api/pipeline/leads/${leadOrg.id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ stageId: etapaCalificado.id }),
+  });
+  await sleep(800);
+  const act5 = (await api("/api/settings/capi/events")).json?.events ?? [];
+  const omitido = act5.find((e) => e.contactName === NOMBRE_ORG);
+  ok(
+    "un lead sin anuncio queda OMITIDO con el motivo escrito",
+    omitido?.status === "skipped" && /ctwa_clid/.test(omitido?.error ?? ""),
+    JSON.stringify(omitido)
+  );
+
+  // Meta rechazando: el 200 mentiroso (events_received: 0).
+  const NOMBRE_FAIL = nom("Lead con Meta caido");
+  await api("/api/settings/capi", {
+    method: "PUT",
+    body: JSON.stringify({
+      datasetId: "ds-e2e-fail",
+      qualifiedStageId: etapaCalificado.id,
+    }),
+  });
+  await api("/api/dev/wa-mock/inbound", {
+    method: "POST",
+    body: JSON.stringify({
+      phoneNumberId: PN,
+      from: tel("4"),
+      name: NOMBRE_FAIL,
+      text: "vengo del anuncio",
+      ctwaClid: `clid-fail-${SUF}`,
+      waMessageId: `wamid.e2e.016.fail.${SUF}`,
+    }),
+  });
+  await sleep(1400);
+  const board3 = (await api("/api/pipeline/board")).json;
+  const leadFail = board3.leads.find((l) => l.contact.name === NOMBRE_FAIL);
+  const movFail = await api(`/api/pipeline/leads/${leadFail.id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ stageId: etapaCalificado.id }),
+  });
+  ok(
+    "con Meta rechazando, el lead SE MUEVE igual",
+    movFail.res.ok,
+    `status=${movFail.res.status}`
+  );
+  await sleep(800);
+  const board4 = (await api("/api/pipeline/board")).json;
+  const leadFail2 = board4.leads.find((l) => l.contact.name === NOMBRE_FAIL);
+  ok(
+    "y se queda en la etapa a la que lo movieron",
+    leadFail2?.stageId === etapaCalificado.id,
+    JSON.stringify(leadFail2?.stageId)
+  );
+  const act6 = (await api("/api/settings/capi/events")).json?.events ?? [];
+  const fallido = act6.find((e) => e.contactName === NOMBRE_FAIL);
+  ok(
+    "la fila queda FALLIDA con lo que dijo Meta (200 pero events_received=0)",
+    fallido?.status === "failed" &&
+      /events_received=0/.test(fallido?.error ?? ""),
+    JSON.stringify(fallido)
+  );
+
+  // Desconectar: deja de reportarse, pero la bitácora de lo ya dicho se queda.
+  const del = await api("/api/settings/capi", { method: "DELETE" });
+  ok("se puede desconectar", del.res.ok);
+  const trasBorrar = (await api("/api/settings/capi")).json;
+  ok("tras desconectar, no hay configuración", trasBorrar?.capi === null);
+  const act7 = (await api("/api/settings/capi/events")).json?.events ?? [];
+  ok(
+    "los eventos ya reportados NO se borran al desconectar",
+    act7.length >= 3,
+    `${act7.length} filas`
+  );
+}

--- a/specs/016-atribucion-capi/checklist.md
+++ b/specs/016-atribucion-capi/checklist.md
@@ -1,0 +1,47 @@
+# Checklist de calidad — 016 Atribución y Conversions API
+
+Se marca contra el código, no contra la intención.
+
+## La bandera (ADR-001)
+
+- [ ] Sin `ATRIBUCION`: pantalla y rutas en **404** (no 403, no 401).
+- [ ] Sin la bandera, la ingesta **no** guarda atribución aunque llegue referral.
+- [ ] Sin la bandera, la pestaña de Ajustes no se pinta.
+- [ ] La migración se aplica igual en ambos casos.
+- [ ] El prompt del agente no cambia con la bandera.
+
+## Seguridad
+
+- [ ] El token del dataset se guarda cifrado con `lib/crypto` (no en claro, no
+      con un segundo mecanismo).
+- [ ] Hacia el cliente solo viajan `last4` y estado.
+- [ ] Hacia Meta no viaja teléfono, nombre ni texto del contacto: solo el
+      `ctwa_clid` y el id del WABA.
+- [ ] Ningún token aparece en logs ni en mensajes de error.
+
+## Corrección del reporte
+
+- [ ] `events_received < 1` ⇒ `failed`, nunca `sent`.
+- [ ] Nombre fuera del catálogo ⇒ error con motivo legible antes de salir.
+- [ ] `custom_data.lead_stage` viaja en los dos eventos.
+- [ ] `value` en unidades de la moneda, nunca centavos; sin monto, sin `value`.
+- [ ] Dedup por UNIQUE en base (no un `select` previo).
+- [ ] Conversaciones `is_test` no emiten.
+
+## Robustez
+
+- [ ] Un fallo de Meta no impide mover el lead (probado en el arnés).
+- [ ] La llamada a Meta ocurre **fuera** de la transacción de etapas.
+- [ ] Sin dataset configurado, la fila queda `skipped` con motivo.
+- [ ] Reintento del webhook no duplica atribución.
+
+## Multi-tenancy
+
+- [ ] Toda query pasa por `scoped()`.
+- [ ] `qualifiedStageId` se valida contra las etapas de la propia organización.
+
+## Verificación
+
+- [ ] `pnpm typecheck && pnpm lint && pnpm build && pnpm test` en verde.
+- [ ] Arnés E2E en verde **encendida** y **apagada**.
+- [ ] `docs/atribucion-capi.md` explica los gotchas de Meta que costaron días.

--- a/specs/016-atribucion-capi/checklist.md
+++ b/specs/016-atribucion-capi/checklist.md
@@ -4,44 +4,44 @@ Se marca contra el código, no contra la intención.
 
 ## La bandera (ADR-001)
 
-- [ ] Sin `ATRIBUCION`: pantalla y rutas en **404** (no 403, no 401).
-- [ ] Sin la bandera, la ingesta **no** guarda atribución aunque llegue referral.
-- [ ] Sin la bandera, la pestaña de Ajustes no se pinta.
-- [ ] La migración se aplica igual en ambos casos.
-- [ ] El prompt del agente no cambia con la bandera.
+- [x] Sin `ATRIBUCION`: pantalla y rutas en **404** (no 403, no 401).
+- [x] Sin la bandera, la ingesta **no** guarda atribución aunque llegue referral.
+- [x] Sin la bandera, la pestaña de Ajustes no se pinta.
+- [x] La migración se aplica igual en ambos casos.
+- [x] El prompt del agente no cambia con la bandera.
 
 ## Seguridad
 
-- [ ] El token del dataset se guarda cifrado con `lib/crypto` (no en claro, no
+- [x] El token del dataset se guarda cifrado con `lib/crypto` (no en claro, no
       con un segundo mecanismo).
-- [ ] Hacia el cliente solo viajan `last4` y estado.
-- [ ] Hacia Meta no viaja teléfono, nombre ni texto del contacto: solo el
+- [x] Hacia el cliente solo viajan `last4` y estado.
+- [x] Hacia Meta no viaja teléfono, nombre ni texto del contacto: solo el
       `ctwa_clid` y el id del WABA.
-- [ ] Ningún token aparece en logs ni en mensajes de error.
+- [x] Ningún token aparece en logs ni en mensajes de error.
 
 ## Corrección del reporte
 
-- [ ] `events_received < 1` ⇒ `failed`, nunca `sent`.
-- [ ] Nombre fuera del catálogo ⇒ error con motivo legible antes de salir.
-- [ ] `custom_data.lead_stage` viaja en los dos eventos.
-- [ ] `value` en unidades de la moneda, nunca centavos; sin monto, sin `value`.
-- [ ] Dedup por UNIQUE en base (no un `select` previo).
-- [ ] Conversaciones `is_test` no emiten.
+- [x] `events_received < 1` ⇒ `failed`, nunca `sent`.
+- [x] Nombre fuera del catálogo ⇒ error con motivo legible antes de salir.
+- [x] `custom_data.lead_stage` viaja en los dos eventos.
+- [x] `value` en unidades de la moneda, nunca centavos; sin monto, sin `value`.
+- [x] Dedup por UNIQUE en base (no un `select` previo).
+- [x] Conversaciones `is_test` no emiten.
 
 ## Robustez
 
-- [ ] Un fallo de Meta no impide mover el lead (probado en el arnés).
-- [ ] La llamada a Meta ocurre **fuera** de la transacción de etapas.
-- [ ] Sin dataset configurado, la fila queda `skipped` con motivo.
-- [ ] Reintento del webhook no duplica atribución.
+- [x] Un fallo de Meta no impide mover el lead (probado en el arnés).
+- [x] La llamada a Meta ocurre **fuera** de la transacción de etapas.
+- [x] Sin dataset configurado, la fila queda `skipped` con motivo.
+- [x] Reintento del webhook no duplica atribución.
 
 ## Multi-tenancy
 
-- [ ] Toda query pasa por `scoped()`.
-- [ ] `qualifiedStageId` se valida contra las etapas de la propia organización.
+- [x] Toda query pasa por `scoped()`.
+- [x] `qualifiedStageId` se valida contra las etapas de la propia organización.
 
 ## Verificación
 
-- [ ] `pnpm typecheck && pnpm lint && pnpm build && pnpm test` en verde.
-- [ ] Arnés E2E en verde **encendida** y **apagada**.
-- [ ] `docs/atribucion-capi.md` explica los gotchas de Meta que costaron días.
+- [x] `pnpm typecheck && pnpm lint && pnpm build && pnpm test` en verde.
+- [x] Arnés E2E en verde **encendida** y **apagada**.
+- [x] `docs/atribucion-capi.md` explica los gotchas de Meta que costaron días.

--- a/specs/016-atribucion-capi/contracts/evento-meta.md
+++ b/specs/016-atribucion-capi/contracts/evento-meta.md
@@ -1,0 +1,64 @@
+# Contrato — El evento que sale hacia Meta
+
+Frontera de salida única: `graphRequest` de `src/lib/meta/client.ts`, el mismo
+cliente con el que el CRM manda mensajes. No hay un segundo camino a internet.
+
+`POST {META_GRAPH_BASE_URL}/{version}/{datasetId}/events`
+`Authorization: Bearer <token del dataset>`
+
+```jsonc
+{
+  "data": [
+    {
+      "event_name": "QualifiedLead",        // catálogo CERRADO (abajo)
+      "event_time": 1787000000,             // epoch en SEGUNDOS
+      "action_source": "business_messaging",
+      "messaging_channel": "whatsapp",
+      "user_data": {
+        "ctwa_clid": "ARAaB…",              // el clic, NO el teléfono
+        "whatsapp_business_account_id": "1593715272371283"
+      },
+      "custom_data": { "lead_stage": "qualified" }
+    }
+  ],
+  "partner_agent": "vocero-crm"
+}
+```
+
+Para `Purchase` con monto capturado, `custom_data` lleva además
+`{ "value": 450.5, "currency": "MXN" }` — **unidades de la moneda**, no centavos.
+
+## Catálogo cerrado de `business_messaging`
+
+`Purchase` · `LeadSubmitted` · `QualifiedLead` · `InitiateCheckout` ·
+`AddToCart` · `ViewContent` · `OrderCreated` · `OrderShipped` ·
+`OrderDelivered` · `OrderCanceled` · `OrderReturned` · `CartAbandoned` ·
+`RatingProvided` · `ReviewProvided`
+
+Cualquier otro nombre es un `400` opaco de Meta. Se valida **antes** de salir y
+se falla con el motivo escrito. Vocero solo emite dos de ellos; la constante
+existe para que un fork que agregue el suyo no descubra el catálogo a golpes.
+
+## La respuesta, y la trampa
+
+```jsonc
+{ "events_received": 1, "messages": [], "fbtrace_id": "AkiF9pt…" }
+```
+
+**Meta responde `200` aunque descarte el evento.** `events_received` es el único
+acuse real: con `0`, el evento se registra como **fallido** con su `fbtrace_id`,
+nunca como enviado (D5). Errores conocidos que llegan así o como `400`:
+
+| Señal | Qué pasó |
+|---|---|
+| `code 100 / error_subcode 2804087` | `ctwa_clid` inválido — Meta lo valida contra un clic real: **no existe evento sintético**. |
+| `events_received: 0` sin explicación | Suele ser antigüedad del clid: fuera de la ventana de atribución. |
+| `OAuthException 190` | Token vencido o sin permiso sobre el dataset. |
+
+## Invariantes
+
+1. Nunca sale un evento sin `ctwa_clid` (sin él Meta no puede empatar nada).
+2. Nunca sale un evento de una conversación `is_test` (guardrail del Laboratorio).
+3. Nunca sale el mismo evento dos veces para la misma conversación (UNIQUE en la
+   base, no un `if` en el código).
+4. Un fallo aquí jamás propaga: quien disparó la conversión no se entera.

--- a/specs/016-atribucion-capi/contracts/settings-capi.md
+++ b/specs/016-atribucion-capi/contracts/settings-capi.md
@@ -1,0 +1,81 @@
+# Contrato — Ajustes de atribución (`/api/settings/capi`)
+
+Autenticada por sesión (`withAuth`), alcance por organización. **Con la bandera
+`ATRIBUCION` apagada, todos estos endpoints responden `404` sin cuerpo**: en esa
+instancia no existen.
+
+Errores con el sobre estándar del proyecto: `{ error: { code, message } }`.
+
+---
+
+## `GET /api/settings/capi`
+
+Estado de la conexión.
+
+```jsonc
+// Sin configurar
+{ "capi": null }
+
+// Configurada
+{
+  "capi": {
+    "datasetId": "1708105527110154",
+    "status": "connected",
+    "tokenLast4": "a91X",          // NUNCA el token completo
+    "qualifiedStageId": "stg_…"     // o null
+  }
+}
+```
+
+## `PUT /api/settings/capi`
+
+Conecta o actualiza. Cuerpo:
+
+```jsonc
+{
+  "datasetId": "1708105527110154",  // requerido, no vacío
+  "token": "EAAG…",                 // OPCIONAL — omitirlo reusa el token de WhatsApp
+  "qualifiedStageId": "stg_…"       // opcional; null lo desactiva
+}
+```
+
+| Caso | Respuesta |
+|---|---|
+| OK | `200 { "ok": true }` |
+| Sin `token` y sin conexión de WhatsApp | `409 sin_whatsapp` |
+| `qualifiedStageId` que no es de esta organización | `422 etapa_invalida` |
+| Cuerpo inválido | `422 invalid_body` |
+
+**Por qué se reusa el token**: el token del negocio que ya autoriza mensajería es
+el mismo que autoriza publicar en su dataset. Pedirlo otra vez solo consigue que
+alguien pegue un secreto en un chat.
+
+## `DELETE /api/settings/capi`
+
+`200 { "ok": true }`. Borra dataset y token; deja de reportarse. Los eventos ya
+registrados **no** se borran: son la bitácora de lo que se le dijo a Meta.
+
+## `GET /api/settings/capi/events?limit=25`
+
+Actividad reciente, más nueva primero. `limit` 1..50 (default 25); fuera de rango
+se recorta, no falla.
+
+```jsonc
+{
+  "events": [
+    {
+      "id": "cve_…",
+      "conversationId": "cv_…",
+      "eventName": "QualifiedLead",
+      "contactName": "Marina",       // null si la conversación ya no existe
+      "adHeadline": "Kit de verano",  // titular del anuncio, o null
+      "status": "sent",              // sent | failed | skipped | pending
+      "at": "2026-08-28T18:04:11.000Z",
+      "fbTraceId": "AkiF9ptU5s1…",
+      "error": null
+    }
+  ]
+}
+```
+
+Solo lectura: este endpoint jamás escribe.

--- a/specs/016-atribucion-capi/data-model.md
+++ b/specs/016-atribucion-capi/data-model.md
@@ -1,0 +1,99 @@
+# Data Model — 016 Atribución de anuncios y Conversions API
+
+Migración `drizzle/0010_atribucion_capi.sql`: **aditiva**, re-ejecutable y
+aplicada **siempre** al arrancar el contenedor. Con la bandera apagada las tres
+tablas quedan vacías e inertes — ese es el trato de ADR-001: todas las instancias
+comparten la misma estructura y solo paga peso quien enciende.
+
+Prefijos de id nuevos en `src/lib/db/ids.ts`: `att` (atribución), `cve` (evento
+de conversión), `capi` (configuración).
+
+---
+
+## `ad_attribution` — de qué anuncio vino la conversación
+
+| Columna | Tipo | Notas |
+|---|---|---|
+| `id` | text PK | `att_…` |
+| `organization_id` | text NOT NULL → `organization` (cascade) | Multi-tenancy (III). |
+| `contact_id` | text NOT NULL → `contact` (cascade) | |
+| `conversation_id` | text NOT NULL → `conversation` (cascade) | |
+| `ctwa_clid` | text | El identificador del clic. **Es la llave de todo**: sin él no hay nada que reportar. Nullable porque hay referrals de anuncio sin clid (p. ej. orgánicos de otras superficies). |
+| `source_id` | text | Id del anuncio. |
+| `source_type` | text | `ad`, `post`… |
+| `source_url` | text | |
+| `headline` | text | Titular del anuncio: lo único de esto que se muestra hoy (en la actividad). |
+| `body` | text | |
+| `media_type` | text | |
+| `raw` | jsonb NOT NULL | Payload íntegro del referral. Es la póliza contra "Meta agregó un campo": nada se pierde y un fork puede pintar el creativo sin migrar. |
+| `created_at` | timestamp NOT NULL default now | |
+
+**Índices**
+
+- `ad_attribution_org_conversation_uq` UNIQUE (`organization_id`,
+  `conversation_id`) — **el primer referral gana**. Es lo que vuelve idempotente
+  la ingesta ante los reintentos de Meta (IV): el insert es
+  `ON CONFLICT DO NOTHING`, no un "consulta y luego inserta" que dos webhooks
+  simultáneos ganarían los dos.
+- `ad_attribution_org_contact_idx` (`organization_id`, `contact_id`).
+
+---
+
+## `conversion_event` — cada intento de reportarle algo a Meta
+
+| Columna | Tipo | Notas |
+|---|---|---|
+| `id` | text PK | `cve_…` |
+| `organization_id` | text NOT NULL → `organization` (cascade) | |
+| `conversation_id` | text NOT NULL → `conversation` (cascade) | |
+| `attribution_id` | text → `ad_attribution` (set null) | Con qué atribución se mandó. |
+| `event_name` | text NOT NULL | Nombre del catálogo de Meta tal cual (D7). |
+| `status` | text NOT NULL default `pending` | `pending` \| `sent` \| `failed` \| `skipped`. |
+| `error` | text | Motivo legible: por qué se omitió o qué dijo Meta. |
+| `fb_trace_id` | text | Acuse del envío. La única referencia que Meta pide para rastrear un evento; sin persistirla, un `sent` no se puede reclamar. |
+| `sent_at` | timestamp | |
+| `created_at` | timestamp NOT NULL default now | |
+
+**Índices**
+
+- `conversion_event_org_conv_name_uq` UNIQUE (`organization_id`,
+  `conversation_id`, `event_name`) — el dedup **es** este índice. La fila se
+  inserta ANTES de hablar con Meta y con `ON CONFLICT DO NOTHING`: si no vuelve
+  fila, alguien más ya reportó ese evento y no se hace nada. Dos movimientos
+  simultáneos del mismo lead no pueden mandar dos compras.
+
+**Ciclo de vida**: `pending` (insertada) → `sent` (Meta acusó ≥ 1) ·
+`failed` (Meta rechazó, o 200 con cero recibidos, o red caída) · `skipped` (no
+había nada que reportar: sin `ctwa_clid`, sin dataset configurado).
+
+Las filas `skipped` **no son basura**: son la respuesta a "¿por qué este lead no
+aparece en Meta?", que sin ellas se contesta adivinando.
+
+---
+
+## `capi_settings` — la conexión del negocio
+
+| Columna | Tipo | Notas |
+|---|---|---|
+| `id` | text PK | `capi_…` |
+| `organization_id` | text NOT NULL → `organization` (cascade) | |
+| `dataset_id` | text NOT NULL | Id del dataset de Meta. |
+| `token_cipher` / `token_iv` / `token_tag` | text NOT NULL | Token cifrado AES-256-GCM con `lib/crypto` — el mismo mecanismo que las credenciales de WhatsApp, no un segundo (I). |
+| `qualified_stage_id` | text → `pipeline_stage` (set null) | La etapa que este negocio considera "lead calificado" (D4). NULL = no se emite ese evento. `set null` a propósito: borrar la etapa apaga el evento, no rompe el guardado. |
+| `status` | text NOT NULL default `connected` | `connected` \| `error`. |
+| `created_at` / `updated_at` | timestamp NOT NULL | |
+
+**Índice**: `capi_settings_org_uq` UNIQUE (`organization_id`) — una conexión por
+negocio; guardar de nuevo es un upsert.
+
+---
+
+## Lo que NO se agrega
+
+- **Ninguna columna nueva en `lead`, `conversation` o `contact`.** La atribución
+  cuelga por FK; el monto de la venta se lee de `lead.amount_cents` /
+  `lead.currency`, que ya existen.
+- **Ninguna tabla de traducción de eventos** (D7).
+- **`thumbnail`** del creativo: fuera de alcance; el binario del CDN de Meta
+  caduca en días y guardarlo es una descarga dentro de la ingesta. `raw` conserva
+  la URL para quien la quiera.

--- a/specs/016-atribucion-capi/plan.md
+++ b/specs/016-atribucion-capi/plan.md
@@ -1,0 +1,127 @@
+# Implementation Plan: Atribución de anuncios y Conversions API
+
+**Branch**: `016-atribucion-capi` | **Date**: 2026-08-28 | **Spec**: [spec.md](./spec.md)
+
+**Carril declarado**: **ciclo completo** (Principio VI) — toca el modelo de datos
+(tres tablas nuevas) y publica un contrato (`/api/settings/capi`).
+
+## Summary
+
+Se agrega al core la atribución de anuncios CTWA y el reporte de conversiones a
+Meta, detrás de la bandera `ATRIBUCION` (apagada por defecto, criterios ADR-001).
+Tres piezas: **capturar** el `ctwa_clid` del primer mensaje que viene de un
+anuncio; **reportar** `QualifiedLead` y `Purchase` desde la puerta única de
+etapas, con dedup en base y best-effort absoluto; y una **pantalla** para
+conectar el dataset, elegir qué etapa significa "calificado" y ver qué se le
+reportó a Meta.
+
+Lo que sube es el mecanismo, no la operación de nadie: la etapa calificada la
+elige cada negocio, la venta cuelga del `kind = "won"` que ya existe, y quedan
+fuera el backfill, el laboratorio de eventos y el espejo de venta del fork.
+
+## Technical Context
+
+**Language/Version**: TypeScript estricto (`strict` + `noUncheckedIndexedAccess`), Node 22
+
+**Primary Dependencies**: **ninguna nueva**. Salida por `graphRequest`
+(`src/lib/meta/client.ts`), cifrado por `lib/crypto`, validación con Zod — todo
+ya presente.
+
+**Storage**: PostgreSQL + Drizzle. Tres tablas (`ad_attribution`,
+`conversion_event`, `capi_settings`) en `drizzle/0010_atribucion_capi.sql`,
+aditiva y aplicada siempre.
+
+**Testing**: Vitest para lo puro (payload, catálogo, centavos→unidades, bandera,
+traducción de filas de actividad) + `pnpm test:e2e` extendido, corrido en las
+**dos** configuraciones. El mock de Graph aprende `POST {dataset}/events` (D10).
+
+**Target Platform**: el mismo monolito self-hosted; sin procesos ni servicios nuevos.
+
+**Performance Goals**: la emisión agrega una llamada HTTP a Meta al movimiento de
+etapa que dispara (timeout del cliente Graph), fuera de la transacción. Ningún
+otro camino se toca.
+
+**Constraints**: `organization_id` vía `scoped()`; secretos cifrados y solo
+`last4` hacia afuera; `is_test` sin efectos externos; bandera apagada ⇒ 404 en
+toda la superficie, sin captura y con el prompt del agente intacto.
+
+**Scale/Scope**: dos eventos por lead como máximo, uno por cambio de etapa
+relevante. La actividad es un panel de 25–50 filas.
+
+## Constitution Check
+
+*GATE: evaluado antes de la Fase 0 y re-evaluado tras el diseño.*
+
+| Principio | Cómo lo cumple |
+|---|---|
+| **I. Seguridad** | Token del dataset cifrado AES-256-GCM con `lib/crypto` (mismo mecanismo que WhatsApp); hacia el cliente solo `last4` y estado; nunca a logs. El `ctwa_clid` es un identificador de clic, no un dato personal del contacto: hacia Meta **no viaja teléfono ni nombre**. |
+| **II. Soberanía (1.4.0)** | ✅ No introduce un tercero nuevo: es **la misma Meta Graph API** del canal permitido, igual que el canal de Instagram (014). Aun así se entrega con el traje completo de conector opcional: apagado por defecto tras `ATRIBUCION`, aislado en `lib/meta/capi.ts` con contrato público, degradación definida (su fallo jamás bloquea la operación), credenciales del propio negocio cifradas, y CI apagado/encendido. Cero dependencias de runtime nuevas. |
+| **III. Multi-tenancy** | `organization_id NOT NULL` en las tres tablas; todo acceso por `scoped()`; configuración única por organización. |
+| **IV. Idempotencia** | El dedup **es** un UNIQUE con `ON CONFLICT DO NOTHING`, no un chequeo previo: dos webhooks o dos movimientos simultáneos no duplican. Migración re-ejecutable. |
+| **V. Calidad verificable** | Gate técnico + unit de las piezas puras + arnés E2E en las dos configuraciones, incluido el camino infeliz (Meta rechazando). |
+| **VI. Specs antes de código** | Carril ciclo completo declarado; spec, research, data-model y contratos preceden al código. |
+| **VII. Trazabilidad** | Cada decisión no obvia queda en `research.md` con su evidencia de producción; la reversión de "esto no sube" (evaluación 2026-08-15) se argumenta por escrito en el spec. |
+| **VIII. Foco vertical** | El CRM ya sabe de dónde vino el lead y cómo terminó; esto solo lo devuelve a quien cobra por traerlo. No es una suite de analítica: dos eventos, una pantalla, cero dashboards. |
+| **IX. Verificación en vivo** | `quickstart.md` define el self-test contra la app viva con mocks; nada se declara Hecho sin ese loop en verde. |
+
+**Guardrail del Laboratorio**: una conversación `is_test` jamás emite un evento —
+aserción antes de salir, hermana de la del sender y de la de los conectores de
+agenda.
+
+**Resultado del gate**: PASA sin violaciones. No requiere enmienda
+constitucional: a diferencia de la 015, aquí no entra ningún proveedor nuevo.
+
+## Project Structure
+
+```
+specs/016-atribucion-capi/
+├── spec.md · plan.md · research.md · data-model.md
+├── quickstart.md · checklist.md · tasks.md
+└── contracts/
+    ├── settings-capi.md      # el contrato interno (4 endpoints)
+    └── evento-meta.md        # el contrato de salida (payload + acuse)
+
+src/
+├── lib/
+│   ├── db/schema.ts                      # + 3 tablas
+│   ├── db/ids.ts                         # + 3 prefijos
+│   ├── env.ts                            # + ATRIBUCION (documentada)
+│   └── meta/capi.ts                      # NUEVO — payload, catálogo, acuse
+├── server/attribution/
+│   ├── flag.ts                           # NUEVO — la bandera (patrón agenda/flag.ts)
+│   ├── store.ts                          # NUEVO — captura del referral
+│   ├── settings.ts                       # NUEVO — configuración cifrada
+│   └── conversions.ts                    # NUEVO — emisión + actividad
+├── server/inbox/{webhook,ingest}.ts      # + tipo referral y su paso
+├── server/leads/stage-history.ts         # + emisión tras el commit
+├── app/api/settings/capi/{route,events/route}.ts   # NUEVO
+├── app/(app)/settings/ads/page.tsx       # NUEVO — pantalla tras la bandera
+├── app/(app)/settings/layout.tsx         # + pestaña condicionada
+├── components/settings/{settings-nav,ads-client}.tsx
+└── app/api/dev/wa-mock/**                # + referral simulado y {dataset}/events
+
+drizzle/0010_atribucion_capi.sql
+docs/atribucion-capi.md                   # guía del dueño (incluye la receta del espejo)
+tests/unit/{capi-payload,capi-flag,conversions}.test.ts
+tests/e2e/us-atribucion.md + scripts/e2e-selftest.mjs
+```
+
+## Fases
+
+**Fase 0 — Research** ✅ `research.md` (D1–D11).
+
+**Fase 1 — Diseño** ✅ `data-model.md` + `contracts/`.
+
+**Fase 2 — Tareas** → `tasks.md`, agrupadas por historia (US1…US6) con el
+fundacional primero: sin esquema y sin bandera no hay nada que probar.
+
+**Fase 3 — Implementación y verificación**: gate técnico + arnés en las dos
+configuraciones. La feature no está Hecha hasta que el arnés pase **encendida y
+apagada** (FR-016).
+
+## Complexity Tracking
+
+Ninguna violación que rastrear. La única complejidad que esta feature agrega
+—una llamada de red colgada del movimiento de etapa— se acota con tres reglas
+duras: fuera de la transacción, envuelta en `try/catch`, y con su desenlace
+escrito en una fila que el dueño puede leer.

--- a/specs/016-atribucion-capi/quickstart.md
+++ b/specs/016-atribucion-capi/quickstart.md
@@ -1,0 +1,100 @@
+# Quickstart — probar la atribución y el reporte a Meta de punta a punta
+
+Feature: `016-atribucion-capi`. Todo el alcance se ejercita en localhost contra
+el mock de Graph, **sin tocar Meta** (Constitución IX: local primero). Y no es
+por comodidad: Meta valida el `ctwa_clid` contra un clic real, así que un evento
+sintético contra la API real es imposible por diseño (research D10).
+
+## 1. Entorno
+
+```bash
+# .env (además de lo habitual: DATABASE_URL, BETTER_AUTH_SECRET, ENCRYPTION_KEY…)
+ATRIBUCION=on                               # la bandera de esta feature
+WA_MOCK_ENABLED=true
+META_GRAPH_BASE_URL=http://localhost:3000/api/dev/wa-mock/graph
+OPENROUTER_BASE_URL=http://localhost:3000/api/dev/ai-mock
+```
+
+App viva con BD migrada (`pnpm db:migrate` en dev; en contenedor migra al
+arranque).
+
+## 2. La bandera, primero apagada
+
+1. Arranca **sin** `ATRIBUCION` → `GET /api/settings/capi`,
+   `PUT /api/settings/capi`, `GET /api/settings/capi/events` y la pantalla
+   `/settings/ads` responden **404**; Ajustes no muestra la pestaña.
+2. Manda un inbound **con anuncio** (abajo) → el mensaje entra normal y
+   `GET /api/settings/capi/events` sigue en 404: no se capturó nada.
+3. Arranca con `ATRIBUCION=on` → todo lo anterior existe y la migración no
+   cambió (ya estaba aplicada: inerte apagada).
+
+## 3. Conectar el dataset
+
+1. Ajustes → **Anuncios**: pega un dataset (cualquier id sirve contra el mock) y
+   **no** pegues token → guarda reusando el de WhatsApp.
+   Comprueba: `GET /api/settings/capi` devuelve `tokenLast4`, nunca el token.
+2. Sin conexión de WhatsApp y sin token → `409 sin_whatsapp`.
+3. Elige la etapa que significa "lead calificado" (p. ej. *Interesado*).
+
+## 4. Capturar el anuncio
+
+```bash
+curl -X POST localhost:3000/api/dev/wa-mock/inbound -H 'content-type: application/json' -d '{
+  "phoneNumberId": "<el de tus credenciales>",
+  "from": "5215500001111",
+  "name": "Marina",
+  "text": "vi su anuncio",
+  "ctwaClid": "ARAaB_clic_de_prueba",
+  "adHeadline": "Kit de verano"
+}'
+```
+
+Reenvía el MISMO payload: no se duplica (el primer referral gana). Un segundo
+mensaje del mismo contacto **sin** anuncio no borra el origen.
+
+## 5. Reportar el lead calificado
+
+1. Mueve el lead de Marina a la etapa marcada como calificada — arrástralo en el
+   Pipeline, o `PATCH /api/pipeline/leads/{id}`, o desde un cerebro externo.
+2. Ajustes → Anuncios → **Actividad**: fila `QualifiedLead`, estado **enviado**,
+   con `fbtrace_id`.
+3. `GET /api/dev/wa-mock/graph/_state` (o el log del mock) muestra el payload:
+   `action_source: business_messaging`, `messaging_channel: whatsapp`,
+   `user_data.ctwa_clid`, y `custom_data.lead_stage = "qualified"`.
+4. Sácalo y vuélvelo a meter a esa etapa → **no** aparece una segunda fila.
+
+## 6. Reportar la venta
+
+1. Pon monto al trato (p. ej. $450.50) y muévelo a **Cliente** (etapa ganada).
+2. Actividad: fila `Purchase` enviada; el payload lleva `value: 450.5` y
+   `currency`. **Centavos → unidades**: si ves `45050`, está mal.
+3. Un trato **sin** monto reporta la venta **sin** `value` (nunca `value: 0`).
+4. Sácalo de Ganado y vuélvelo a ganar → sin fila nueva.
+
+## 7. Los caminos infelices (los que de verdad importan)
+
+- **Lead sin anuncio**: mueve a la etapa calificada un lead que llegó sin
+  `ctwa_clid` → fila **omitida** con el motivo escrito. Nada falla.
+- **Meta rechaza**: usa un dataset terminado en `-fail` (el mock responde 200 con
+  `events_received: 0`) → el lead **se mueve igual**, y la fila queda **fallida**
+  con el `fbtrace_id`. Repite con un token terminado en `-invalid` (401).
+- **Sin dataset configurado**: desconecta y mueve un lead → fila omitida
+  ("atribución no configurada"), nunca un error al usuario.
+
+## 8. Sandbox del Laboratorio
+
+Corre una conversación del Laboratorio hasta que su lead cambie de etapa: **no**
+aparece ninguna fila hacia Meta y el `_state` del mock queda sin eventos. Igual
+que el sender: `is_test` no toca el mundo real.
+
+## 9. Gate y arnés
+
+```bash
+pnpm typecheck && pnpm lint && pnpm build && pnpm test   # el piso
+pnpm test:e2e                                            # el arnés, con la app viva
+```
+
+El arnés incluye la sección de atribución (guion `tests/e2e/us-atribucion.md`) y
+**se corre dos veces**: con `ATRIBUCION=on` (camino completo) y sin ella (la
+superficie no existe). Una feature opcional que solo se prueba encendida no está
+probada.

--- a/specs/016-atribucion-capi/research.md
+++ b/specs/016-atribucion-capi/research.md
@@ -1,0 +1,182 @@
+# Research — 016 Atribución de anuncios y Conversions API
+
+Decisiones de la Fase 0. Cada una dice qué se eligió, contra qué, y con qué
+evidencia. Buena parte de la evidencia viene de **13 meses-persona de operación
+real** del fork de agencia (dataset vivo desde el 29-jul-2026): eso es lo que
+esta feature aporta que no se puede sacar de la documentación de Meta.
+
+---
+
+## D1 — La bandera se llama `ATRIBUCION`
+
+**Decisión**: `ATRIBUCION=on`, misma gramática que `AGENDA` (`on`/`1`/`true`/
+`si`/`sí`/`yes`), leída de `process.env` directo y declarada en `lib/env.ts`.
+
+**Contra qué**: `CAPI` (el nombre técnico) y `ADS`.
+
+**Por qué**: la bandera enciende dos cosas —capturar de qué anuncio vino una
+conversación y reportarle a Meta el desenlace—, y "atribución" es el término que
+las abarca. `CAPI` nombra solo la mitad y además es jerga de Meta: el día que
+alguien reporte a otra red, la bandera seguiría sirviendo y el nombre no.
+
+**Precedente exacto**: `src/server/agenda/flag.ts`. Se copia su forma, incluido
+el comentario de por qué no pasa por `getEnv()` (preguntar si una feature existe
+no puede depender de que TODO el entorno valide).
+
+---
+
+## D2 — La captura del `referral` también va detrás de la bandera
+
+**Decisión**: con la bandera apagada, la ingesta **no** guarda atribución.
+
+**Contra qué**: capturar siempre (el dato llega gratis en el webhook) y usarlo
+solo si la bandera está encendida.
+
+**Tensión real**: capturar siempre haría que encender la bandera meses después
+tuviera historia que reportar. Pero ADR-001 promete "apagada ⇒ ni rastro", y una
+tabla que se llena sola con identificadores de clic de Meta en una instancia que
+nunca pidió esa función rompe la promesa por el lado que más importa: el de los
+datos.
+
+**Consecuencia aceptada y documentada**: encender la bandera atribuye de ahí en
+adelante. No es grave — la ventana de atribución de Meta es de días, no de
+meses, así que la historia vieja tampoco sería reportable.
+
+---
+
+## D3 — Los eventos se emiten desde la puerta única de etapas
+
+**Decisión**: `QualifiedLead` y `Purchase` salen desde `moveLeadToStage`, después
+del commit de la transacción, best-effort.
+
+**Contra qué**: el diseño del fork, que emite desde donde el bot escribe la ficha
+(`/api/bot/ficha`) y desde el servicio de agenda.
+
+**Evidencia (del propio fork, documentada en su bitácora)**: con ese diseño,
+*arrastrar* un lead a la etapa "Calificado" en el tablero **no emitía nada**.
+Nunca estorbó allá porque en ese negocio quien califica siempre es el bot; en
+Vocero, donde el dueño mueve tarjetas a mano y el cerebro puede ser cualquiera,
+sería un hueco silencioso: lo peor que le puede pasar a una métrica.
+
+**Por qué es el lugar correcto**: `moveLeadToStage` ya es "la ÚNICA puerta que
+escribe `lead.stage_id`", con un test de vigilancia que falla si alguien escribe
+etapas por fuera. Colgar de ahí la emisión hereda esa garantía: los cuatro
+caminos que mueven un lead reportan igual, y el quinto que alguien agregue
+también.
+
+**Cuidado obligatorio**: la emisión va **fuera** de la transacción (después del
+commit) y envuelta en `try/catch`. Una llamada de red dentro de la transacción la
+mantendría abierta mientras Meta piensa.
+
+---
+
+## D4 — "Lead calificado" es una etapa que elige el negocio
+
+**Decisión**: `capi_settings.qualified_stage_id` — un selector en la pantalla con
+las etapas de esa organización. Sin elección, no se emite `QualifiedLead`.
+
+**Contra qué**: (a) cablear el nombre "Calificado"; (b) inferirlo por posición;
+(c) un `kind` nuevo en `pipeline_stage`.
+
+**Por qué**: las etapas sembradas de Vocero son Nuevo / En conversación /
+Interesado / Cliente / Perdido — **no hay ninguna llamada "Calificado"**, y cada
+negocio renombra las suyas. Inferir por posición adivina. Un `kind` nuevo obliga
+a migrar el enum y a decidir por el usuario. Un `stage_id` elegido es explícito,
+reversible y no toca el modelo del pipeline.
+
+**Por qué la venta NO se configura igual**: `kind = "won"` ya existe, es un ancla
+no borrable del pipeline y de él ya cuelga toda la analítica. Pedirle al usuario
+que elija otra vez lo que el CRM ya sabe sería puro formulario.
+
+---
+
+## D5 — `events_received` es el único acuse real
+
+**Decisión**: un evento cuenta como enviado **solo** con `events_received >= 1`;
+un 200 con cero se registra como fallido, con el `fbtrace_id` en el motivo.
+
+**Evidencia de producción**: Meta responde **200 aunque descarte el evento**
+(clid inválido, fuera de ventana, campo mal puesto). Sin mirar el acuse, "enviado"
+solo significaría "no hubo error HTTP", y un evento descartado en silencio se
+vería idéntico a uno bueno — el modo de fallo más caro posible, porque el negocio
+cree que está optimizando y no.
+
+---
+
+## D6 — Cada evento viaja con `custom_data.lead_stage`
+
+**Decisión**: `QualifiedLead` → `{ lead_stage: "qualified" }`; `Purchase` →
+`{ lead_stage: "won" }` (más `value`/`currency` si hay monto).
+
+**Evidencia de producción (3 días en cero)**: una conversión personalizada de
+Meta solo sabe escribir reglas contra `custom_data` y la URL. `event_name` y
+`action_source` **no son parámetros reglables**, y estos eventos no llevan
+`event_source_url`. Un evento sin `custom_data` no puede cumplir NINGUNA regla:
+la conversión personalizada se queda en cero para siempre y nadie entiende por
+qué. Costó tres días descubrirlo; el CRM lo manda de fábrica.
+
+---
+
+## D7 — Se guardan los nombres de Meta, sin traducción interna
+
+**Decisión**: `conversion_event.event_name` guarda `QualifiedLead` / `Purchase`
+tal cual, validados contra el catálogo cerrado de `business_messaging`.
+
+**Contra qué**: el esquema del fork, que guarda nombres de dominio propios
+(`LeadQualified`, `SessionBooked`) y traduce en la frontera de salida.
+
+**Por qué**: esa traducción existe allá porque su dominio nombró los eventos
+antes de leer el catálogo de Meta — y el primer envío real habría muerto en 400.
+En un CRM que reporta exactamente dos eventos, una tabla de traducción es una
+pieza que solo puede desincronizarse. El catálogo cerrado sí se conserva como
+constante: mandar un nombre que no está en él es un 400 opaco, y vale más fallar
+antes con un motivo legible.
+
+---
+
+## D8 — `Purchase` sin monto va sin `value`
+
+**Decisión**: si el trato no tiene monto (o es 0), el evento sale sin `value` ni
+`currency`.
+
+**Por qué**: `value: 0` no es "no sé cuánto": le enseña al optimizador que las
+ventas de este negocio valen cero, que es peor que no decirle nada. La venta se
+cuenta igual; solo no se le pone precio. La conversión centavos → unidades
+(`4500` → `45.00`) vive en una función pura con test propio: Meta espera unidades
+de la moneda y la base guarda centavos enteros.
+
+---
+
+## D9 — `partner_agent: "vocero-crm"`
+
+**Decisión**: constante fija del proyecto.
+
+**Por qué**: Meta usa ese campo para saber qué software integró el evento. El
+fork manda su propio nombre, que es exactamente el tipo de cosa que no debe
+subir. Ningún fork necesita cambiarlo, pero puede.
+
+---
+
+## D10 — Se prueba de punta a punta contra el mock de Graph
+
+**Decisión**: el mock de Graph aprende `POST {dataset}/events` — valida el nombre
+contra el catálogo, exige `ctwa_clid`, y responde `events_received` y un
+`fbtrace_id` simulado. Con `datasets` que terminan en `-fail`, responde el 200
+mentiroso con `events_received: 0` para ejercitar el camino infeliz.
+
+**Por qué no se prueba contra Meta**: verificado en producción que **no existe
+evento sintético**: Meta valida el `ctwa_clid` contra un clic real y devuelve
+`code 100 / error_subcode 2804087` con cualquier valor inventado, por bien
+formado que esté. Un self-test que dependiera de un anuncio vivo no sería
+reproducible por nadie más.
+
+---
+
+## D11 — La actividad es un panel, no un export
+
+**Decisión**: `GET /api/settings/capi/events` con tope duro de 50 filas (25 por
+defecto), solo lectura, sin acciones.
+
+**Por qué**: la pregunta que resuelve es "¿esto está funcionando?" y se responde
+con las últimas filas. Un export invita a paginación, filtros y un CSV que nadie
+mantiene. Si un negocio quiere análisis, tiene su base de datos.

--- a/specs/016-atribucion-capi/spec.md
+++ b/specs/016-atribucion-capi/spec.md
@@ -1,0 +1,237 @@
+# Feature Specification: Atribución de anuncios y Conversions API (bandera `ATRIBUCION`)
+
+**Feature Branch**: `016-atribucion-capi`
+
+**Created**: 2026-08-28
+
+**Status**: Draft
+
+**Input**: Decisión del dueño 2026-08-28: llevar a Vocero raíz, **en modo
+bandera** (como la multicanalidad de IG y el motor de agenda), lo que el fork de
+agencia lleva en producción desde el 29-jul-2026 sobre la **Conversions API de
+Meta**. Alcance acordado en la misma decisión: **núcleo neutro** — capturar el
+origen del anuncio, reportar el lead calificado y la venta, y una pantalla para
+configurarlo y ver qué se reportó. Nada de la operación avanzada de la agencia
+(ver "Fuera de alcance").
+
+## Contexto de negocio
+
+Un negocio que anuncia con **Click-to-WhatsApp** (CTWA) paga por conversaciones.
+Meta sabe cuáles empezaron; **no sabe cuáles sirvieron**. Sin nadie que se lo
+diga, el algoritmo optimiza hacia lo único que ve —que alguien abra el chat— y
+entrega el público más barato de hacer escribir, que no es el que compra. El
+negocio lo vive como "me llegan muchos mensajes y no cierro ninguno".
+
+Vocero está en el único lugar donde esa verdad existe: sabe que la conversación
+`cv_x` vino del anuncio `A`, que su lead se calificó el martes y que se ganó el
+viernes por $12,000. La Conversions API es el camino oficial para devolverle a
+Meta ese desenlace, y `business_messaging` es su variante para conversaciones de
+WhatsApp: se manda el `ctwa_clid` del clic —no el teléfono— y Meta lo empata con
+la campaña que lo generó.
+
+Con eso, el mismo presupuesto empieza a comprar *leads calificados* en vez de
+*chats*. Es la diferencia entre un CRM que ordena conversaciones y uno que
+participa en el resultado.
+
+### Por qué ahora, y por qué no antes
+
+Esta feature tiene historia y conviene decirla completa:
+
+1. El fork de agencia la implementó en julio (su spec 004) y la opera desde
+   entonces. En la evaluación de upstream del 2026-08-15 se decidió **no
+   subirla**, con un motivo correcto: aquel código manda `partner_agent:
+   "aishia-crm"` y **codifica decisiones de producto de una agencia** —vetar el
+   evento de "sesión agendada" porque su tasa de asistencia era 0%, duplicar
+   cada lead calificado con un `InitiateCheckout` para poder optimizar una
+   campaña de ventas—. Eso es la operación de un negocio, no el núcleo de un CRM.
+2. Lo que cambió no es la opinión sobre ese código, sino que ahora existe el
+   **carril**: ADR-001 (canales) y ADR-002 / feature 015 (agenda) establecieron
+   que lo opcional viaja en `main`, apagado tras una bandera, con la migración
+   aplicada igual. La constitución 1.4.0 lo escribió como categoría.
+3. Así que sube **el mecanismo, sin las decisiones**: qué etapa significa
+   "calificado" lo elige cada negocio en su pantalla; el evento de venta cuelga
+   de la etapa ganada que el CRM ya tiene; y `partner_agent` dice `vocero-crm`.
+
+## Alcance
+
+**Entra** (núcleo neutro):
+
+- Capturar el origen del anuncio (`referral`, con su `ctwa_clid`) cuando el
+  primer mensaje de una conversación viene de un anuncio CTWA.
+- Reportar a Meta **`QualifiedLead`** cuando el lead entra a la etapa que el
+  negocio marcó como "lead calificado".
+- Reportar **`Purchase`** cuando el lead entra a una etapa **ganada**, con el
+  monto del trato si está capturado.
+- Pantalla de Ajustes para conectar el dataset y elegir esa etapa, más la
+  **actividad reciente**: qué se reportó, cuándo, con qué acuse y —cuando no
+  salió— por qué.
+- Todo detrás de la bandera `ATRIBUCION`, apagada por defecto.
+
+**Fuera de alcance a propósito** (existe en el fork; no sube en esta feature):
+
+| Qué | Por qué no |
+|---|---|
+| **Backfill** de conversiones viejas | Operación avanzada; su diseño correcto (anti-join, herencia del `event_time` original, corte terminal fuera de ventana) es media feature por sí solo y solo tiene sentido cuando ya llevas meses reportando. |
+| **Laboratorio de eventos** (disparar uno a voluntad) | Herramienta de quien opera campañas a diario; sin ella el CRM se diagnostica igual con la tabla de actividad. |
+| **Espejo de venta** (duplicar el calificado como `InitiateCheckout`) | Decisión de producto de una agencia para poder optimizar una campaña de *ventas* con un evento de *clientes potenciales*. Se documenta en la guía como receta; no se cablea. |
+| **Miniatura del creativo** y ficha de "de qué anuncio vino" | UI nueva y una descarga de binario dentro de la ingesta. El dato crudo del anuncio **sí** se guarda (`raw`), así que un fork puede pintarlo sin migrar nada. |
+| Evento por **cita agendada** | No existe en el catálogo de Meta para mensajería, y reportar "agendó" como conversión enseña la señal equivocada cuando la gente no llega. |
+
+## User Scenarios & Testing
+
+### US1 — La bandera (P1)
+
+**Como** dueño de una instancia que no anuncia,
+**quiero** que el CRM no mencione nunca la atribución de anuncios,
+**para** no cargar con una pantalla, una credencial y un concepto que no uso.
+
+**Criterios de aceptación**
+
+1. **Dado** una instancia sin `ATRIBUCION`, **cuando** entro a Ajustes,
+   **entonces** no existe la pestaña de anuncios.
+2. **Dado** esa instancia, **cuando** pido cualquier ruta de la superficie
+   (`/api/settings/capi`, `/api/settings/capi/events`, la pantalla), **entonces**
+   responde **404** — no 403: en esta instancia eso no existe.
+3. **Dado** esa instancia, **cuando** llega un mensaje que sí trae `referral` de
+   anuncio, **entonces** se procesa como cualquier mensaje y **no** se guarda
+   atribución alguna.
+4. **Dado** `ATRIBUCION=on`, **cuando** entro a Ajustes, **entonces** la pestaña
+   existe y la instancia opera igual en todo lo demás.
+
+### US2 — Conectar el dataset (P1)
+
+**Como** dueño que anuncia,
+**quiero** conectar mi dataset de Meta sin volver a copiar un token,
+**para** empezar a reportar en menos de un minuto.
+
+1. **Dado** que ya conecté WhatsApp, **cuando** guardo solo el ID del dataset,
+   **entonces** el CRM **reusa el token del negocio** que ya tiene cifrado, y no
+   me pide otro.
+2. **Dado** que quiero un token distinto, **cuando** lo pego, **entonces** se
+   guarda cifrado y hacia afuera solo se ven sus últimos 4.
+3. **Dado** que no hay conexión de WhatsApp y no pego token, **cuando** guardo,
+   **entonces** falla con `409 sin_whatsapp` y me dice qué hacer.
+4. **Cuando** elijo cuál de MIS etapas significa "lead calificado", **entonces**
+   queda guardada; si no elijo ninguna, ese evento no se emite (la venta sí).
+5. **Cuando** desconecto, **entonces** el dataset y el token se borran y deja de
+   reportarse.
+
+### US3 — Capturar el origen del anuncio (P1)
+
+1. **Dado** `ATRIBUCION=on`, **cuando** entra el primer mensaje de una
+   conversación con `referral`, **entonces** se guarda su `ctwa_clid` y los datos
+   del anuncio, junto a contacto y conversación.
+2. **Dado** que Meta reintenta el mismo webhook, **cuando** vuelve a llegar,
+   **entonces** no se duplica: el **primer** referral de la conversación gana.
+3. **Dado** que el contacto escribe después sin `referral`, **entonces** el
+   origen sigue siendo el que se capturó.
+
+### US4 — Reportar el lead calificado (P1)
+
+1. **Dado** un lead cuya conversación vino de un anuncio y un dataset conectado,
+   **cuando** el lead entra a la etapa marcada como calificada —lo arrastre el
+   dueño, lo mueva el agente incluido o un cerebro externo por `/api/bot/*`—,
+   **entonces** el CRM reporta `QualifiedLead` y la actividad lo muestra como
+   **enviado** con su `fbtrace_id`.
+2. **Dado** que ya se reportó, **cuando** el lead sale y vuelve a esa etapa,
+   **entonces** **no** se reporta de nuevo.
+3. **Dado** un lead que NO vino de un anuncio, **entonces** queda **omitido**
+   con el motivo escrito, y nada falla.
+4. **Dado** que Meta está caído o el token venció, **entonces** el lead se mueve
+   igual, la fila queda **fallida** con el error, y la operación no se entera.
+
+### US5 — Reportar la venta (P1)
+
+1. **Cuando** el lead entra a una etapa **ganada**, **entonces** se reporta
+   `Purchase`; si el trato tiene monto, viaja su **valor y moneda**.
+2. **Dado** un trato **sin** monto, **entonces** se reporta la venta **sin**
+   valor — nunca `value: 0`: enseñarle a Meta que las ventas de este negocio
+   valen cero es peor que no decirle el importe.
+3. **Dado** que se saca de Ganado y se vuelve a ganar, **entonces** no se
+   re-reporta: a Meta no se le puede des-enviar una compra.
+4. **Dado** un lead capturado a mano que nunca escribió por WhatsApp,
+   **entonces** no hay nada que atribuir y no se reporta.
+
+### US6 — Ver qué se reportó (P2)
+
+1. **Cuando** abro la pantalla, **entonces** veo las últimas conversiones: quién,
+   qué evento, cuándo, su estado y —si falló u omitió— el motivo en palabras.
+2. **Dado** un envío exitoso, **entonces** veo el `fbtrace_id`: es la única
+   referencia que Meta pide para rastrear un evento de su lado.
+
+### Casos límite
+
+- **Meta responde 200 y descarta el evento.** `events_received` es el único acuse
+  real; un 200 con cero recibidos se registra como **fallido** con su
+  `fbtrace_id`, no como enviado.
+- **Nombre fuera del catálogo.** El catálogo de `business_messaging` es cerrado;
+  se valida antes de salir, para fallar con un motivo legible y no con un 400
+  opaco de Meta.
+- **Conversación de Laboratorio (`is_test`).** Jamás produce un evento hacia
+  Meta: mismo guardrail que el sender.
+- **Bandera encendida a mitad del camino.** Solo se atribuyen conversaciones
+  nuevas: no hay `ctwa_clid` retroactivo. Documentado en la guía.
+- **`ctwa_clid` viejo.** Meta puede descartarlo por antigüedad; la fila queda
+  fallida con el motivo tal cual lo dio Meta.
+
+## Requisitos funcionales
+
+- **FR-001**: La superficie completa (pantalla, rutas y captura) no existe sin la
+  bandera `ATRIBUCION`; la migración se aplica siempre.
+- **FR-002**: Con la bandera apagada, el prompt del agente y la operación quedan
+  idénticos: la feature no se menciona en ningún lado.
+- **FR-003**: El primer `referral` de una conversación se guarda con su
+  `ctwa_clid` y su payload crudo; es idempotente por (organización, conversación).
+- **FR-004**: El token del dataset se guarda **cifrado** (AES-256-GCM,
+  `lib/crypto`) y jamás sale del servidor; hacia el cliente, solo `last4`.
+- **FR-005**: Guardar sin token reusa el token del negocio ya conectado.
+- **FR-006**: El negocio elige **cuál de sus etapas** significa "lead
+  calificado"; sin elección, ese evento no se emite.
+- **FR-007**: Entrar a la etapa calificada emite `QualifiedLead`; entrar a una
+  etapa ganada emite `Purchase`, con `value`/`currency` si hay monto > 0.
+- **FR-008**: Ambos eventos se emiten desde la **puerta única de etapas**
+  (`moveLeadToStage`), para que cualquier camino que mueva un lead —dueño, agente
+  incluido, bot externo— reporte igual.
+- **FR-009**: Dedup por (organización, conversación, evento): la misma
+  conversación jamás reporta dos veces el mismo evento.
+- **FR-010**: Toda emisión es **best-effort**: ningún fallo de Meta, de red o de
+  configuración puede impedir que el lead se mueva.
+- **FR-011**: Cada intento deja fila con estado `sent` / `failed` / `skipped` y
+  motivo legible; los enviados guardan `fbtrace_id`.
+- **FR-012**: Un evento se considera enviado **solo** si `events_received >= 1`.
+- **FR-013**: Cada evento viaja con `custom_data.lead_stage` (`qualified` /
+  `won`): es lo único contra lo que una conversión personalizada de Meta puede
+  escribir reglas.
+- **FR-014**: Las conversaciones `is_test` nunca emiten.
+- **FR-015**: Cero dependencias de runtime nuevas; misma frontera de salida
+  (`lib/meta/client`) que el resto del CRM.
+- **FR-016**: El arnés E2E cubre la feature **encendida y apagada**.
+
+## Criterios de éxito
+
+- **SC-001**: Con la bandera apagada, las rutas dan 404, la pestaña no se pinta y
+  un inbound con `referral` no deja rastro (verificado en el arnés).
+- **SC-002**: Conectar el dataset toma un campo y un clic para quien ya conectó
+  WhatsApp.
+- **SC-003**: Mover un lead a la etapa calificada deja, en menos de 2 s, una fila
+  `sent` con `fbtrace_id` en la actividad.
+- **SC-004**: Con Meta devolviendo error, el lead se mueve igual: cero
+  movimientos bloqueados en el camino infeliz del arnés.
+- **SC-005**: Mover el mismo lead diez veces produce **un** evento por tipo.
+
+## Entidades
+
+- **Atribución de anuncio** — el origen de una conversación: `ctwa_clid`,
+  identificadores y textos del anuncio, y el payload crudo. Una por conversación.
+- **Evento de conversión** — un intento de reportar un desenlace a Meta: evento,
+  estado, acuse, motivo del fallo. Único por (organización, conversación, evento).
+- **Configuración de CAPI** — dataset, token cifrado y la etapa que el negocio
+  considera "lead calificado". Una por organización.
+
+## Supuestos
+
+- El dataset de `business_messaging` es el de la propia cuenta de WhatsApp del
+  negocio (en la práctica, `POST {waba_id}/dataset` devuelve ese mismo id), y el
+  token del negocio ya conectado tiene permiso para publicar en él.
+- Los nombres `QualifiedLead` y `Purchase` pertenecen al catálogo cerrado de Meta
+  para `business_messaging` y se guardan tal cual: sin traducción interna.

--- a/specs/016-atribucion-capi/spec.md
+++ b/specs/016-atribucion-capi/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-08-28
 
-**Status**: Draft
+**Status**: Implementada y verificada en vivo (2026-08-28) — arnés E2E en verde en las dos configuraciones de la bandera
 
 **Input**: Decisión del dueño 2026-08-28: llevar a Vocero raíz, **en modo
 bandera** (como la multicanalidad de IG y el motor de agenda), lo que el fork de

--- a/specs/016-atribucion-capi/tasks.md
+++ b/specs/016-atribucion-capi/tasks.md
@@ -1,0 +1,97 @@
+# Tasks — 016 Atribución de anuncios y Conversions API
+
+Rama `016-atribucion-capi`. Agrupadas por historia; lo fundacional primero
+porque sin esquema y sin bandera no hay nada que encender ni que probar.
+`[P]` = paralelizable (archivos distintos, sin dependencia).
+
+---
+
+## Fase 1 — Fundacional (bloquea todo)
+
+- [ ] **T001** `src/lib/db/schema.ts`: tablas `ad_attribution`,
+      `conversion_event` y `capi_settings` con sus índices UNIQUE, tal como
+      `data-model.md`.
+- [ ] **T002** `src/lib/db/ids.ts`: prefijos `att`, `cve`, `capi`. [P]
+- [ ] **T003** `pnpm db:generate` → `drizzle/0010_atribucion_capi.sql` (aditiva,
+      re-ejecutable) y su entrada en el journal.
+- [ ] **T004** `src/server/attribution/flag.ts`: `parseAtribucionFlag`,
+      `atribucionEnabled`, `atribucionDisabledResponse` (404 sin cuerpo), con el
+      porqué escrito — calco de `server/agenda/flag.ts`.
+- [ ] **T005** `src/lib/env.ts`: `ATRIBUCION` opcional, documentada inline. [P]
+- [ ] **T006** `tests/unit/atribucion-flag.test.ts`: valores encendidos,
+      apagados y basura. [P]
+
+## Fase 2 — US1: la bandera (P1)
+
+- [ ] **T007** `src/app/(app)/settings/layout.tsx` + `components/settings/settings-nav.tsx`:
+      pestaña "Anuncios" solo con la bandera encendida (patrón `agenda`).
+- [ ] **T008** `src/app/(app)/settings/ads/page.tsx`: `notFound()` sin bandera.
+- [ ] **T009** Guardia de bandera en las dos rutas de API (404 antes de auth).
+
+## Fase 3 — US2: conectar el dataset (P1)
+
+- [ ] **T010** `src/server/attribution/settings.ts`: `getCapiSettings` (descifra),
+      `saveCapiSettings` (upsert cifrado), `deleteCapiSettings`,
+      `getCapiSettingsView` (lo que ve el cliente: `last4`, nunca el token).
+- [ ] **T011** `src/app/api/settings/capi/route.ts`: `GET` / `PUT` / `DELETE` con
+      Zod; sin token reusa el de `metaCredentials` (`409 sin_whatsapp`);
+      `qualifiedStageId` validado contra las etapas de la organización
+      (`422 etapa_invalida`).
+- [ ] **T012** `src/components/settings/ads-client.tsx`: formulario (dataset,
+      token opcional con ayuda, selector de etapa), estado conectado con
+      `last4`, botón desconectar.
+
+## Fase 4 — US3: capturar el anuncio (P1)
+
+- [ ] **T013** `src/server/inbox/webhook.ts`: tipo `WebhookReferral` y
+      `referral?` en el mensaje entrante. [P]
+- [ ] **T014** `src/server/attribution/store.ts`: `recordAttribution`
+      (`ON CONFLICT DO NOTHING` por org+conversación) y
+      `getAttributionForConversation`.
+- [ ] **T015** `src/server/inbox/ingest.ts`: pasar el `referral` y capturarlo
+      **antes** del dedup del mensaje, solo con la bandera encendida.
+- [ ] **T016** Mock de inbound (`wa-mock/inbound` + `server/dev/wa-mock-inbound.ts`):
+      campos `ctwaClid` / `adHeadline` / `adSourceId` para simular un anuncio.
+
+## Fase 5 — US4/US5: reportar (P1)
+
+- [ ] **T017** `src/lib/meta/capi.ts`: catálogo cerrado, `buildEventPayload`
+      (`action_source`, `messaging_channel`, `user_data`, `custom_data`,
+      `partner_agent: "vocero-crm"`), `sendBusinessMessagingEvent` con la regla
+      `events_received >= 1`.
+- [ ] **T018** `src/server/attribution/conversions.ts`: `emitConversion`
+      (dedup por UNIQUE, `skipped` con motivo, `failed` con el error de Meta,
+      `sent` con `fbtrace_id`), guardia `is_test`, best-effort absoluto.
+- [ ] **T019** `purchaseCustomDataFromAmount` (centavos → unidades; sin monto,
+      sin `value`) y la resolución del monto del lead. [P]
+- [ ] **T020** `src/server/leads/stage-history.ts`: tras el commit, si la etapa
+      destino es la calificada → `QualifiedLead`; si su `kind` es `won` →
+      `Purchase`. Fuera de la transacción y envuelto.
+- [ ] **T021** Mock de Graph: `POST {dataset}/events` — valida catálogo y
+      `ctwa_clid`, responde `events_received`/`fbtrace_id`, y simula el 200
+      mentiroso con datasets `-fail`.
+- [ ] **T022** `tests/unit/capi-payload.test.ts`: forma exacta del payload,
+      catálogo, merge de `custom_data`, y el rechazo por `events_received: 0`. [P]
+- [ ] **T023** `tests/unit/conversions.test.ts`: centavos→unidades, sin monto,
+      y la traducción de fila de actividad. [P]
+
+## Fase 6 — US6: ver qué se reportó (P2)
+
+- [ ] **T024** `listConversionActivity` con tope duro (25/50) + titular del
+      anuncio por join.
+- [ ] **T025** `src/app/api/settings/capi/events/route.ts`.
+- [ ] **T026** Tabla de actividad en la pantalla: estado en palabras, motivo del
+      fallo/omisión, `fbtrace_id` y refresco manual.
+
+## Fase 7 — Cierre
+
+- [ ] **T027** `tests/e2e/us-atribucion.md`: el guion de la historia.
+- [ ] **T028** `scripts/e2e-selftest.mjs`: sección nueva — apagada (404 + sin
+      captura) y encendida (configurar, capturar, calificar, ganar, dedup, sin
+      anuncio, Meta rechazando).
+- [ ] **T029** `docs/atribucion-capi.md`: guía del dueño — qué es el dataset, de
+      dónde sale, los gotchas de Meta y la receta del espejo de venta para quien
+      la necesite. [P]
+- [ ] **T030** `README.md` + `.env.example` + `CLAUDE.md`: la feature opcional,
+      la variable y la fila del mapa de código. [P]
+- [ ] **T031** Gate técnico completo y arnés en las **dos** configuraciones.

--- a/specs/016-atribucion-capi/tasks.md
+++ b/specs/016-atribucion-capi/tasks.md
@@ -8,90 +8,116 @@ porque sin esquema y sin bandera no hay nada que encender ni que probar.
 
 ## Fase 1 — Fundacional (bloquea todo)
 
-- [ ] **T001** `src/lib/db/schema.ts`: tablas `ad_attribution`,
+- [x] **T001** `src/lib/db/schema.ts`: tablas `ad_attribution`,
       `conversion_event` y `capi_settings` con sus índices UNIQUE, tal como
       `data-model.md`.
-- [ ] **T002** `src/lib/db/ids.ts`: prefijos `att`, `cve`, `capi`. [P]
-- [ ] **T003** `pnpm db:generate` → `drizzle/0010_atribucion_capi.sql` (aditiva,
+- [x] **T002** `src/lib/db/ids.ts`: prefijos `att`, `cve`, `capi`. [P]
+- [x] **T003** `pnpm db:generate` → `drizzle/0010_atribucion_capi.sql` (aditiva,
       re-ejecutable) y su entrada en el journal.
-- [ ] **T004** `src/server/attribution/flag.ts`: `parseAtribucionFlag`,
+- [x] **T004** `src/server/attribution/flag.ts`: `parseAtribucionFlag`,
       `atribucionEnabled`, `atribucionDisabledResponse` (404 sin cuerpo), con el
       porqué escrito — calco de `server/agenda/flag.ts`.
-- [ ] **T005** `src/lib/env.ts`: `ATRIBUCION` opcional, documentada inline. [P]
-- [ ] **T006** `tests/unit/atribucion-flag.test.ts`: valores encendidos,
+- [x] **T005** `src/lib/env.ts`: `ATRIBUCION` opcional, documentada inline. [P]
+- [x] **T006** `tests/unit/atribucion-flag.test.ts`: valores encendidos,
       apagados y basura. [P]
 
 ## Fase 2 — US1: la bandera (P1)
 
-- [ ] **T007** `src/app/(app)/settings/layout.tsx` + `components/settings/settings-nav.tsx`:
+- [x] **T007** `src/app/(app)/settings/layout.tsx` + `components/settings/settings-nav.tsx`:
       pestaña "Anuncios" solo con la bandera encendida (patrón `agenda`).
-- [ ] **T008** `src/app/(app)/settings/ads/page.tsx`: `notFound()` sin bandera.
-- [ ] **T009** Guardia de bandera en las dos rutas de API (404 antes de auth).
+- [x] **T008** `src/app/(app)/settings/ads/page.tsx`: `notFound()` sin bandera.
+- [x] **T009** Guardia de bandera como primera línea de cada handler de API
+      (patrón de la agenda: 404 en cuanto hay sesión).
 
 ## Fase 3 — US2: conectar el dataset (P1)
 
-- [ ] **T010** `src/server/attribution/settings.ts`: `getCapiSettings` (descifra),
+- [x] **T010** `src/server/attribution/settings.ts`: `getCapiSettings` (descifra),
       `saveCapiSettings` (upsert cifrado), `deleteCapiSettings`,
       `getCapiSettingsView` (lo que ve el cliente: `last4`, nunca el token).
-- [ ] **T011** `src/app/api/settings/capi/route.ts`: `GET` / `PUT` / `DELETE` con
+- [x] **T011** `src/app/api/settings/capi/route.ts`: `GET` / `PUT` / `DELETE` con
       Zod; sin token reusa el de `metaCredentials` (`409 sin_whatsapp`);
       `qualifiedStageId` validado contra las etapas de la organización
       (`422 etapa_invalida`).
-- [ ] **T012** `src/components/settings/ads-client.tsx`: formulario (dataset,
+- [x] **T012** `src/components/settings/ads-client.tsx`: formulario (dataset,
       token opcional con ayuda, selector de etapa), estado conectado con
       `last4`, botón desconectar.
 
 ## Fase 4 — US3: capturar el anuncio (P1)
 
-- [ ] **T013** `src/server/inbox/webhook.ts`: tipo `WebhookReferral` y
+- [x] **T013** `src/server/inbox/webhook.ts`: tipo `WebhookReferral` y
       `referral?` en el mensaje entrante. [P]
-- [ ] **T014** `src/server/attribution/store.ts`: `recordAttribution`
+- [x] **T014** `src/server/attribution/store.ts`: `recordAttribution`
       (`ON CONFLICT DO NOTHING` por org+conversación) y
       `getAttributionForConversation`.
-- [ ] **T015** `src/server/inbox/ingest.ts`: pasar el `referral` y capturarlo
+- [x] **T015** `src/server/inbox/ingest.ts`: pasar el `referral` y capturarlo
       **antes** del dedup del mensaje, solo con la bandera encendida.
-- [ ] **T016** Mock de inbound (`wa-mock/inbound` + `server/dev/wa-mock-inbound.ts`):
+- [x] **T016** Mock de inbound (`wa-mock/inbound` + `server/dev/wa-mock-inbound.ts`):
       campos `ctwaClid` / `adHeadline` / `adSourceId` para simular un anuncio.
 
 ## Fase 5 — US4/US5: reportar (P1)
 
-- [ ] **T017** `src/lib/meta/capi.ts`: catálogo cerrado, `buildEventPayload`
+- [x] **T017** `src/lib/meta/capi.ts`: catálogo cerrado, `buildEventPayload`
       (`action_source`, `messaging_channel`, `user_data`, `custom_data`,
       `partner_agent: "vocero-crm"`), `sendBusinessMessagingEvent` con la regla
       `events_received >= 1`.
-- [ ] **T018** `src/server/attribution/conversions.ts`: `emitConversion`
+- [x] **T018** `src/server/attribution/conversions.ts`: `emitConversion`
       (dedup por UNIQUE, `skipped` con motivo, `failed` con el error de Meta,
       `sent` con `fbtrace_id`), guardia `is_test`, best-effort absoluto.
-- [ ] **T019** `purchaseCustomDataFromAmount` (centavos → unidades; sin monto,
+- [x] **T019** `purchaseCustomDataFromAmount` (centavos → unidades; sin monto,
       sin `value`) y la resolución del monto del lead. [P]
-- [ ] **T020** `src/server/leads/stage-history.ts`: tras el commit, si la etapa
+- [x] **T020** `src/server/leads/stage-history.ts`: tras el commit, si la etapa
       destino es la calificada → `QualifiedLead`; si su `kind` es `won` →
       `Purchase`. Fuera de la transacción y envuelto.
-- [ ] **T021** Mock de Graph: `POST {dataset}/events` — valida catálogo y
+- [x] **T021** Mock de Graph: `POST {dataset}/events` — valida catálogo y
       `ctwa_clid`, responde `events_received`/`fbtrace_id`, y simula el 200
       mentiroso con datasets `-fail`.
-- [ ] **T022** `tests/unit/capi-payload.test.ts`: forma exacta del payload,
+- [x] **T022** `tests/unit/capi-payload.test.ts`: forma exacta del payload,
       catálogo, merge de `custom_data`, y el rechazo por `events_received: 0`. [P]
-- [ ] **T023** `tests/unit/conversions.test.ts`: centavos→unidades, sin monto,
+- [x] **T023** `tests/unit/conversions.test.ts`: centavos→unidades, sin monto,
       y la traducción de fila de actividad. [P]
 
 ## Fase 6 — US6: ver qué se reportó (P2)
 
-- [ ] **T024** `listConversionActivity` con tope duro (25/50) + titular del
+- [x] **T024** `listConversionActivity` con tope duro (25/50) + titular del
       anuncio por join.
-- [ ] **T025** `src/app/api/settings/capi/events/route.ts`.
-- [ ] **T026** Tabla de actividad en la pantalla: estado en palabras, motivo del
+- [x] **T025** `src/app/api/settings/capi/events/route.ts`.
+- [x] **T026** Tabla de actividad en la pantalla: estado en palabras, motivo del
       fallo/omisión, `fbtrace_id` y refresco manual.
 
 ## Fase 7 — Cierre
 
-- [ ] **T027** `tests/e2e/us-atribucion.md`: el guion de la historia.
-- [ ] **T028** `scripts/e2e-selftest.mjs`: sección nueva — apagada (404 + sin
+- [x] **T027** `tests/e2e/us-atribucion.md`: el guion de la historia.
+- [x] **T028** `scripts/e2e-selftest.mjs`: sección nueva — apagada (404 + sin
       captura) y encendida (configurar, capturar, calificar, ganar, dedup, sin
       anuncio, Meta rechazando).
-- [ ] **T029** `docs/atribucion-capi.md`: guía del dueño — qué es el dataset, de
+- [x] **T029** `docs/atribucion-capi.md`: guía del dueño — qué es el dataset, de
       dónde sale, los gotchas de Meta y la receta del espejo de venta para quien
       la necesite. [P]
-- [ ] **T030** `README.md` + `.env.example` + `CLAUDE.md`: la feature opcional,
+- [x] **T030** `README.md` + `.env.example` + `CLAUDE.md`: la feature opcional,
       la variable y la fila del mapa de código. [P]
-- [ ] **T031** Gate técnico completo y arnés en las **dos** configuraciones.
+- [x] **T031** Gate técnico completo y arnés en las **dos** configuraciones.
+
+---
+
+## Verificación (2026-08-28)
+
+Gate técnico: `pnpm typecheck` · `pnpm lint` · `pnpm build` · `pnpm test`
+(**371 unit**, 22 de esta feature) — todo en verde.
+
+Arnés E2E contra la app viva con mocks, en las **dos** configuraciones y con
+base nueva por ronda:
+
+| Configuración | Resultado |
+|---|---|
+| `ATRIBUCION=on` | **120/120 checks** |
+| sin la bandera | **103/103 checks** (incluidos los 6 que prueban que no existe) |
+
+Comprobado además contra la base, que es donde vive la promesa de ADR-001: con
+la bandera apagada, tras un inbound CON anuncio, `ad_attribution` y
+`conversion_event` quedan en **0 filas**. Con la bandera encendida, las cuatro
+filas esperadas: `QualifiedLead` enviada con acuse, `Purchase` enviada,
+una omitida (lead sin anuncio) y una fallida (Meta descartando con
+`events_received: 0`).
+
+La migración `0010` se aplicó dos veces seguidas sobre la misma base sin error
+(solo avisos de "ya existe"): re-ejecutable como exige la Constitución IV.

--- a/specs/README.md
+++ b/specs/README.md
@@ -12,6 +12,7 @@ producto** — y saberlo antes de leerla ahorra una confusión.
 | `003-paridad-inbox-whatsapp` | — | spec |
 | `014-canal-instagram` | Ciclo completo | spec |
 | `015-motor-agenda-universal` | Ciclo completo | spec, plan, research, data-model, 2 contratos, quickstart, checklist, tasks + la enmienda constitucional que habilitó los conectores |
+| `016-atribucion-capi` | Ciclo completo | spec, plan, research, data-model, 2 contratos, quickstart, checklist, tasks |
 
 Los tres carriles —ciclo completo, ligero y exento— están definidos en el
 [Principio VI de la constitución](../.specify/memory/constitution.md). El

--- a/src/app/(app)/settings/ads/page.tsx
+++ b/src/app/(app)/settings/ads/page.tsx
@@ -1,0 +1,11 @@
+import { notFound } from "next/navigation";
+import { AdsClient } from "@/components/settings/ads-client";
+import { atribucionEnabled } from "@/server/attribution/flag";
+
+export const dynamic = "force-dynamic";
+
+export default function AdsSettingsPage() {
+  // Sin la bandera esta pantalla no existe en esta instancia.
+  if (!atribucionEnabled()) notFound();
+  return <AdsClient />;
+}

--- a/src/app/(app)/settings/layout.tsx
+++ b/src/app/(app)/settings/layout.tsx
@@ -1,5 +1,6 @@
 import { SettingsNav } from "@/components/settings/settings-nav";
 import { agendaEnabled } from "@/server/agenda/flag";
+import { atribucionEnabled } from "@/server/attribution/flag";
 
 // La bandera se lee en cada petición: si esto se resolviera al construir, la
 // imagen quedaría con la agenda apagada para siempre y encenderla en la
@@ -16,7 +17,7 @@ export default function SettingsLayout({
       </header>
       {/* En móvil las pestañas van arriba (en fila), no como columna lateral. */}
       <div className="flex min-h-0 flex-1 flex-col sm:flex-row">
-        <SettingsNav agenda={agendaEnabled()} />
+        <SettingsNav agenda={agendaEnabled()} atribucion={atribucionEnabled()} />
         <div className="min-w-0 flex-1 overflow-y-auto p-4 sm:p-6">{children}</div>
       </div>
     </div>

--- a/src/app/api/dev/wa-mock/capi-events/route.ts
+++ b/src/app/api/dev/wa-mock/capi-events/route.ts
@@ -1,0 +1,22 @@
+import { mockGuard } from "@/lib/dev-guard";
+import { getWaMockState } from "@/server/dev/wa-mock-state";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * 016 — Lo que el CRM le mandó a la Conversions API del mock. Existe para que
+ * el self-test pueda afirmar sobre la FORMA del evento (nombre, ctwa_clid,
+ * `custom_data`, valor en unidades) y no solo sobre "no hubo error".
+ */
+export async function GET() {
+  const guard = mockGuard();
+  if (guard) return guard;
+  return Response.json({ capiEvents: getWaMockState().capiEvents });
+}
+
+export async function DELETE() {
+  const guard = mockGuard();
+  if (guard) return guard;
+  getWaMockState().capiEvents.length = 0;
+  return Response.json({ cleared: true });
+}

--- a/src/app/api/dev/wa-mock/graph/[...path]/route.ts
+++ b/src/app/api/dev/wa-mock/graph/[...path]/route.ts
@@ -15,6 +15,24 @@ export const dynamic = "force-dynamic";
 
 type Params = { params: Promise<{ path: string[] }> };
 
+/** 016 — Catálogo cerrado de Meta para `business_messaging` (mismo que el real). */
+const CAPI_EVENT_NAMES = new Set([
+  "Purchase",
+  "LeadSubmitted",
+  "QualifiedLead",
+  "InitiateCheckout",
+  "AddToCart",
+  "ViewContent",
+  "OrderCreated",
+  "OrderShipped",
+  "OrderDelivered",
+  "OrderCanceled",
+  "OrderReturned",
+  "CartAbandoned",
+  "RatingProvided",
+  "ReviewProvided",
+]);
+
 function bearerToken(req: Request): string {
   const h = req.headers.get("authorization") ?? "";
   return h.startsWith("Bearer ") ? h.slice(7) : "";
@@ -107,6 +125,70 @@ export async function POST(req: Request, ctx: Params) {
   }
 
   const body = (await req.json().catch(() => ({}))) as Record<string, unknown>;
+
+  // 016 — POST {datasetId}/events: Conversions API. Imita las tres cosas que
+  // de verdad importan del endpoint real: el catálogo cerrado de nombres, la
+  // exigencia del ctwa_clid, y —sobre todo— que Meta puede responder 200
+  // DESCARTANDO el evento. Los datasets terminados en "-fail" reproducen eso
+  // último, que es el modo de fallo que nadie ve venir.
+  if (path.length === 2 && path[1] === "events") {
+    const state = getWaMockState();
+    const events = Array.isArray(body.data)
+      ? (body.data as Record<string, unknown>[])
+      : [];
+    const event = events[0];
+    const eventName = String(event?.event_name ?? "");
+    const userData = (event?.user_data ?? {}) as Record<string, unknown>;
+    const ctwaClid = userData.ctwa_clid ? String(userData.ctwa_clid) : null;
+
+    if (!CAPI_EVENT_NAMES.has(eventName)) {
+      return Response.json(
+        {
+          error: {
+            message: `(#100) Invalid parameter: event_name ${eventName || "(vacío)"}`,
+            type: "GraphMethodException",
+            code: 100,
+            fbtrace_id: "mock-capi-badname",
+          },
+        },
+        { status: 400 }
+      );
+    }
+    if (!ctwaClid) {
+      return Response.json(
+        {
+          error: {
+            message: "Messaging Event Invalid Ctwa Clid",
+            type: "GraphMethodException",
+            code: 100,
+            error_subcode: 2804087,
+            fbtrace_id: "mock-capi-noclid",
+          },
+        },
+        { status: 400 }
+      );
+    }
+
+    const datasetId = path[0]!;
+    state.capiEvents.push({
+      n: nextN(),
+      datasetId,
+      eventName,
+      ctwaClid,
+      customData:
+        (event?.custom_data as Record<string, unknown> | undefined) ?? null,
+      body,
+      at: new Date().toISOString(),
+    });
+
+    // El 200 mentiroso: recibido por HTTP, descartado por Meta.
+    const received = datasetId.endsWith("-fail") ? 0 : 1;
+    return Response.json({
+      events_received: received,
+      messages: [],
+      fbtrace_id: `mock-capi-${state.capiEvents.length}`,
+    });
+  }
 
   // POST {phoneNumberId}/messages con status:"read" → typing/leído:
   // NO es un mensaje saliente — no contamina el outbox.

--- a/src/app/api/dev/wa-mock/inbound/route.ts
+++ b/src/app/api/dev/wa-mock/inbound/route.ts
@@ -26,6 +26,10 @@ const schema = z
     caption: z.string().optional(),
     filename: z.string().optional(),
     location: z.record(z.unknown()).optional(),
+    // 016 — anuncio de origen simulado (referral)
+    ctwaClid: z.string().optional(),
+    adHeadline: z.string().optional(),
+    adSourceId: z.string().optional(),
   })
   .refine((v) => v.from || v.fromUserId, {
     message: "Se requiere from o fromUserId",

--- a/src/app/api/settings/capi/events/route.ts
+++ b/src/app/api/settings/capi/events/route.ts
@@ -1,0 +1,26 @@
+import { withAuth } from "@/lib/api";
+import {
+  atribucionDisabledResponse,
+  atribucionEnabled,
+} from "@/server/attribution/flag";
+import { listConversionActivity } from "@/server/attribution/conversions";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * 016 — Actividad reciente de conversiones (solo lectura).
+ *
+ * Responde la única pregunta que importa cuando uno duda de esto: "¿le está
+ * llegando algo a Meta y, si no, por qué?". Sin acciones: este endpoint jamás
+ * escribe.
+ */
+export const GET = withAuth(async (session, req: Request) => {
+  if (!atribucionEnabled()) return atribucionDisabledResponse();
+  const raw = new URL(req.url).searchParams.get("limit");
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  // Un límite fuera de rango se recorta, no falla: es un panel, no un contrato
+  // de paginación.
+  const limit = Number.isFinite(parsed) ? parsed : undefined;
+  const events = await listConversionActivity(session.organizationId, limit);
+  return Response.json({ events });
+});

--- a/src/app/api/settings/capi/route.ts
+++ b/src/app/api/settings/capi/route.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+import { apiError, parseBody, withAuth } from "@/lib/api";
+import {
+  atribucionDisabledResponse,
+  atribucionEnabled,
+} from "@/server/attribution/flag";
+import {
+  deleteCapiSettings,
+  getCapiSettingsView,
+  saveCapiSettings,
+  stageBelongsToOrg,
+} from "@/server/attribution/settings";
+import { getCredentialsByOrg } from "@/server/whatsapp/credentials";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * 016 — La conexión del negocio con su dataset de Meta.
+ *
+ * Sin la bandera `ATRIBUCION` esto no existe: 404, no 403 — no hay nada que
+ * revelar sobre un endpoint que esta instancia no tiene.
+ */
+
+export const GET = withAuth(async (session) => {
+  if (!atribucionEnabled()) return atribucionDisabledResponse();
+  const capi = await getCapiSettingsView(session.organizationId);
+  return Response.json({ capi });
+});
+
+const putSchema = z.object({
+  datasetId: z.string().trim().min(1),
+  /**
+   * Omitirlo reusa el token del negocio que ya conectó WhatsApp: es el mismo
+   * token que autoriza publicar en su dataset, y pedirlo otra vez solo
+   * consigue que alguien pegue un secreto en un chat.
+   */
+  token: z.string().trim().min(1).optional(),
+  /** La etapa que ESTE negocio considera "lead calificado"; null lo apaga. */
+  qualifiedStageId: z.string().trim().min(1).nullish(),
+});
+
+export const PUT = withAuth(async (session, req: Request) => {
+  if (!atribucionEnabled()) return atribucionDisabledResponse();
+
+  const body = await parseBody(req, putSchema);
+  if (!body.ok) return body.response;
+
+  let token = body.data.token;
+  if (!token) {
+    const credentials = await getCredentialsByOrg(session.organizationId);
+    if (!credentials) {
+      return apiError(
+        409,
+        "sin_whatsapp",
+        "No hay conexión de WhatsApp de la cual reusar el token: pega uno explícito"
+      );
+    }
+    token = credentials.token;
+  }
+
+  const qualifiedStageId = body.data.qualifiedStageId ?? null;
+  if (
+    qualifiedStageId &&
+    !(await stageBelongsToOrg(session.organizationId, qualifiedStageId))
+  ) {
+    return apiError(
+      422,
+      "etapa_invalida",
+      "Esa etapa no es de este negocio"
+    );
+  }
+
+  await saveCapiSettings({
+    organizationId: session.organizationId,
+    datasetId: body.data.datasetId,
+    token,
+    qualifiedStageId,
+  });
+  return Response.json({ ok: true });
+});
+
+export const DELETE = withAuth(async (session) => {
+  if (!atribucionEnabled()) return atribucionDisabledResponse();
+  await deleteCapiSettings(session.organizationId);
+  return Response.json({ ok: true });
+});

--- a/src/components/settings/ads-client.tsx
+++ b/src/components/settings/ads-client.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+/**
+ * 016 — Ajustes → Anuncios: conectar el dataset de Meta, decir qué etapa
+ * significa "lead calificado" y ver qué se le ha reportado.
+ */
+
+type Capi = {
+  datasetId: string;
+  status: "connected" | "error";
+  tokenLast4: string;
+  qualifiedStageId: string | null;
+};
+
+type Stage = { id: string; name: string; kind: "open" | "won" | "lost" };
+
+type ActivityRow = {
+  id: string;
+  eventName: string;
+  contactName: string | null;
+  adHeadline: string | null;
+  status: "pending" | "sent" | "failed" | "skipped";
+  at: string;
+  fbTraceId: string | null;
+  error: string | null;
+};
+
+const STATUS_LABEL: Record<ActivityRow["status"], string> = {
+  sent: "Enviado",
+  failed: "Falló",
+  skipped: "Omitido",
+  pending: "En curso",
+};
+
+const STATUS_VARIANT: Record<
+  ActivityRow["status"],
+  "success" | "destructive" | "secondary"
+> = {
+  sent: "success",
+  failed: "destructive",
+  skipped: "secondary",
+  pending: "secondary",
+};
+
+/** Qué significa cada evento, en el idioma del negocio y no en el de Meta. */
+const EVENT_LABEL: Record<string, string> = {
+  QualifiedLead: "Lead calificado",
+  Purchase: "Venta",
+};
+
+export function AdsClient() {
+  const [capi, setCapi] = useState<Capi | null>(null);
+  const [stages, setStages] = useState<Stage[]>([]);
+  const [activity, setActivity] = useState<ActivityRow[] | null>(null);
+  const [datasetId, setDatasetId] = useState("");
+  const [token, setToken] = useState("");
+  const [qualifiedStageId, setQualifiedStageId] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadActivity = useCallback(async () => {
+    const res = await fetch("/api/settings/capi/events").catch(() => null);
+    if (!res?.ok) return setActivity([]);
+    const data = (await res.json()) as { events: ActivityRow[] };
+    setActivity(data.events);
+  }, []);
+
+  useEffect(() => {
+    void (async () => {
+      const [cfg, stg] = await Promise.all([
+        fetch("/api/settings/capi").catch(() => null),
+        fetch("/api/pipeline/stages").catch(() => null),
+      ]);
+      if (cfg?.ok) {
+        const data = (await cfg.json()) as { capi: Capi | null };
+        setCapi(data.capi);
+        setDatasetId(data.capi?.datasetId ?? "");
+        setQualifiedStageId(data.capi?.qualifiedStageId ?? "");
+      }
+      if (stg?.ok) {
+        const data = (await stg.json()) as { stages: Stage[] };
+        setStages(data.stages);
+      }
+      await loadActivity();
+    })();
+  }, [loadActivity]);
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    setSaved(false);
+    const res = await fetch("/api/settings/capi", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        datasetId: datasetId.trim(),
+        // Vacío = reusar el token de WhatsApp. Se omite en vez de mandar "".
+        ...(token.trim() ? { token: token.trim() } : {}),
+        qualifiedStageId: qualifiedStageId || null,
+      }),
+    }).catch(() => null);
+    setSaving(false);
+    if (!res?.ok) {
+      const body = (await res?.json().catch(() => null)) as
+        | { error?: { message?: string } }
+        | null;
+      setError(body?.error?.message ?? "No se pudo guardar");
+      return;
+    }
+    setToken("");
+    setSaved(true);
+    const cfg = await fetch("/api/settings/capi").catch(() => null);
+    if (cfg?.ok) {
+      const data = (await cfg.json()) as { capi: Capi | null };
+      setCapi(data.capi);
+    }
+  }
+
+  async function disconnect() {
+    setSaving(true);
+    await fetch("/api/settings/capi", { method: "DELETE" }).catch(() => null);
+    setSaving(false);
+    setCapi(null);
+    setDatasetId("");
+    setToken("");
+    setQualifiedStageId("");
+    setSaved(false);
+  }
+
+  return (
+    <div className="max-w-3xl space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Conversiones de anuncios</CardTitle>
+          <CardDescription>
+            Meta sabe qué conversaciones empezaron desde un anuncio, pero no
+            cuáles sirvieron. Conecta tu dataset y el CRM le avisará cuándo un
+            lead se califica y cuándo se cierra la venta, para que optimice
+            hacia quien compra y no hacia quien solo escribe.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {capi ? (
+            <p className="text-sm text-muted-foreground">
+              Conectado al dataset{" "}
+              <span className="font-medium text-foreground">
+                {capi.datasetId}
+              </span>{" "}
+              · token ····{capi.tokenLast4}
+            </p>
+          ) : null}
+
+          <div className="space-y-1.5">
+            <Label htmlFor="capi-dataset">ID del dataset</Label>
+            <Input
+              id="capi-dataset"
+              value={datasetId}
+              onChange={(e) => setDatasetId(e.target.value)}
+              placeholder="1708105527110154"
+            />
+            <p className="text-xs text-muted-foreground">
+              Administrador de eventos de Meta → tu conjunto de datos. Suele ser
+              el de tu propia cuenta de WhatsApp.
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="capi-token">Token (opcional)</Label>
+            <Input
+              id="capi-token"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              placeholder="Déjalo vacío para reusar el de WhatsApp"
+              autoComplete="off"
+            />
+            <p className="text-xs text-muted-foreground">
+              El token de tu conexión de WhatsApp ya suele poder publicar en el
+              dataset. Solo pega uno si Meta te dio otro distinto.
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="capi-stage">¿Qué etapa es un lead calificado?</Label>
+            <select
+              id="capi-stage"
+              value={qualifiedStageId}
+              onChange={(e) => setQualifiedStageId(e.target.value)}
+              className="h-9 w-full rounded-md border border-input bg-card px-2 text-sm"
+            >
+              <option value="">No reportar leads calificados</option>
+              {stages
+                .filter((s) => s.kind === "open")
+                .map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.name}
+                  </option>
+                ))}
+            </select>
+            <p className="text-xs text-muted-foreground">
+              La venta se reporta sola cuando el trato entra a tu etapa ganada.
+            </p>
+          </div>
+
+          {error ? (
+            <p className="text-sm text-danger-text" role="alert">
+              {error}
+            </p>
+          ) : null}
+          {saved ? (
+            <p className="text-sm text-success-text">Guardado.</p>
+          ) : null}
+
+          <div className="flex gap-2">
+            <Button onClick={save} disabled={saving || !datasetId.trim()}>
+              {saving ? "Guardando…" : "Guardar"}
+            </Button>
+            {capi ? (
+              <Button variant="outline" onClick={disconnect} disabled={saving}>
+                Desconectar
+              </Button>
+            ) : null}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Actividad reciente</CardTitle>
+          <CardDescription>
+            Lo último que se le reportó a Meta. Si algo no salió, aquí dice por
+            qué — es la forma de saber si esto funciona, sin salir del CRM.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Button variant="outline" onClick={() => void loadActivity()}>
+            Actualizar
+          </Button>
+          {activity === null ? (
+            <p className="text-sm text-muted-foreground">Cargando…</p>
+          ) : activity.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Todavía no hay conversiones. Aparecerán cuando un lead que llegó
+              por un anuncio avance de etapa.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="text-left text-xs uppercase text-muted-foreground">
+                  <tr>
+                    <th className="py-2 pr-3 font-medium">Evento</th>
+                    <th className="py-2 pr-3 font-medium">Contacto</th>
+                    <th className="py-2 pr-3 font-medium">Estado</th>
+                    <th className="py-2 pr-3 font-medium">Cuándo</th>
+                    <th className="py-2 font-medium">Detalle</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {activity.map((row) => (
+                    <tr key={row.id} className="border-t align-top">
+                      <td className="py-2 pr-3">
+                        {EVENT_LABEL[row.eventName] ?? row.eventName}
+                        {row.adHeadline ? (
+                          <span className="block text-xs text-muted-foreground">
+                            {row.adHeadline}
+                          </span>
+                        ) : null}
+                      </td>
+                      <td className="py-2 pr-3">{row.contactName ?? "—"}</td>
+                      <td className="py-2 pr-3">
+                        <Badge variant={STATUS_VARIANT[row.status]}>
+                          {STATUS_LABEL[row.status]}
+                        </Badge>
+                      </td>
+                      <td className="py-2 pr-3 whitespace-nowrap text-muted-foreground">
+                        {new Date(row.at).toLocaleString()}
+                      </td>
+                      <td className="py-2 text-xs text-muted-foreground">
+                        {row.error ?? row.fbTraceId ?? "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/settings/settings-nav.tsx
+++ b/src/components/settings/settings-nav.tsx
@@ -16,11 +16,24 @@ const TABS: Tab[] = [
 /** 015 — "Agenda" solo existe si esta instancia encendió la bandera. */
 const AGENDA_TAB: Tab = { href: "/settings/calendar", label: "Agenda" };
 
-export function SettingsNav({ agenda = false }: { agenda?: boolean }) {
+/** 016 — Igual con "Anuncios" y la bandera ATRIBUCION. */
+const ADS_TAB: Tab = { href: "/settings/ads", label: "Anuncios" };
+
+export function SettingsNav({
+  agenda = false,
+  atribucion = false,
+}: {
+  agenda?: boolean;
+  atribucion?: boolean;
+}) {
   const pathname = usePathname();
   // Qué pestañas existen lo decide el servidor y baja por prop: este es un
   // componente de cliente y no puede leer variables de entorno.
-  const tabs = agenda ? [...TABS, AGENDA_TAB] : TABS;
+  const tabs = [
+    ...TABS,
+    ...(agenda ? [AGENDA_TAB] : []),
+    ...(atribucion ? [ADS_TAB] : []),
+  ];
   return (
     <nav className="flex shrink-0 gap-1 overflow-x-auto border-b p-2 sm:w-44 sm:flex-col sm:space-y-1 sm:overflow-visible sm:border-b-0 sm:border-r sm:p-3">
       {tabs.map((t) => (

--- a/src/lib/db/ids.ts
+++ b/src/lib/db/ids.ts
@@ -25,6 +25,10 @@ const prefixes = {
   offeredSlot: "ofs",
   zoomCredentials: "zcred",
   googleCredentials: "gcred",
+  // 016 — atribución de anuncios
+  adAttribution: "att",
+  conversionEvent: "cve",
+  capiSettings: "capi",
 } as const;
 
 export type IdKind = keyof typeof prefixes;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -844,3 +844,135 @@ export const agentTestCase = pgTable(
   },
   (t) => [index("test_case_run_idx").on(t.runId)]
 );
+
+/* ============================================================
+ * 016 — Atribución de anuncios y Conversions API
+ * (detrás de la bandera ATRIBUCION)
+ * ============================================================ */
+
+/**
+ * De qué anuncio vino una conversación. El primer referral gana: el UNIQUE de
+ * abajo es lo que vuelve idempotente la captura ante los reintentos de Meta,
+ * en vez de un "consulta y luego inserta" que dos webhooks simultáneos
+ * ganarían los dos.
+ */
+export const adAttribution = pgTable(
+  "ad_attribution",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    contactId: text("contact_id")
+      .notNull()
+      .references(() => contact.id, { onDelete: "cascade" }),
+    conversationId: text("conversation_id")
+      .notNull()
+      .references(() => conversation.id, { onDelete: "cascade" }),
+    /**
+     * El identificador del clic en el anuncio. Es la llave de TODO: sin él no
+     * hay nada que reportarle a Meta. Nullable porque hay referrals sin clid.
+     */
+    ctwaClid: text("ctwa_clid"),
+    sourceId: text("source_id"),
+    sourceType: text("source_type"),
+    sourceUrl: text("source_url"),
+    headline: text("headline"),
+    body: text("body"),
+    mediaType: text("media_type"),
+    /**
+     * Payload íntegro del referral. Es la póliza contra "Meta agregó un campo":
+     * nada se pierde y un fork puede pintar el creativo sin migrar nada.
+     */
+    raw: jsonb("raw").notNull(),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex("ad_attribution_org_conversation_uq").on(
+      t.organizationId,
+      t.conversationId
+    ),
+    index("ad_attribution_org_contact_idx").on(t.organizationId, t.contactId),
+  ]
+);
+
+/**
+ * Cada intento de reportarle un desenlace a Meta. Las filas `skipped` no son
+ * basura: son la respuesta a "¿por qué este lead no aparece en Meta?", que sin
+ * ellas se contesta adivinando.
+ */
+export const conversionEvent = pgTable(
+  "conversion_event",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    conversationId: text("conversation_id")
+      .notNull()
+      .references(() => conversation.id, { onDelete: "cascade" }),
+    attributionId: text("attribution_id").references(() => adAttribution.id, {
+      onDelete: "set null",
+    }),
+    /** Nombre del catálogo de Meta tal cual (`QualifiedLead`, `Purchase`). */
+    eventName: text("event_name").notNull(),
+    status: text("status", { enum: ["pending", "sent", "failed", "skipped"] })
+      .notNull()
+      .default("pending"),
+    /** Motivo legible: por qué se omitió, o qué contestó Meta. */
+    error: text("error"),
+    /**
+     * Acuse del envío. Es la única referencia que Meta pide para rastrear un
+     * evento de su lado; sin persistirla, un `sent` no se puede reclamar.
+     */
+    fbTraceId: text("fb_trace_id"),
+    sentAt: timestamp("sent_at"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (t) => [
+    // El dedup ES este índice: la fila se inserta ANTES de hablar con Meta y
+    // con ON CONFLICT DO NOTHING. Dos movimientos simultáneos del mismo lead
+    // no pueden mandar dos compras.
+    uniqueIndex("conversion_event_org_conv_name_uq").on(
+      t.organizationId,
+      t.conversationId,
+      t.eventName
+    ),
+    index("conversion_event_org_created_idx").on(
+      t.organizationId,
+      t.createdAt
+    ),
+  ]
+);
+
+/** Conexión del negocio con su dataset de Meta (token cifrado en reposo). */
+export const capiSettings = pgTable(
+  "capi_settings",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    datasetId: text("dataset_id").notNull(),
+    tokenCipher: text("token_cipher").notNull(),
+    tokenIv: text("token_iv").notNull(),
+    tokenTag: text("token_tag").notNull(),
+    /**
+     * Qué etapa significa "lead calificado" PARA ESTE NEGOCIO. Las etapas
+     * sembradas de Vocero no incluyen ninguna con ese nombre y cada quien
+     * renombra las suyas, así que se elige en vez de adivinarse. NULL = ese
+     * evento no se emite. `set null` a propósito: borrar la etapa apaga el
+     * evento, no rompe la configuración.
+     */
+    qualifiedStageId: text("qualified_stage_id").references(
+      () => pipelineStage.id,
+      { onDelete: "set null" }
+    ),
+    status: text("status", { enum: ["connected", "error"] })
+      .notNull()
+      .default("connected"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (t) => [uniqueIndex("capi_settings_org_uq").on(t.organizationId)]
+);

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -33,6 +33,11 @@ const envSchema = z.object({
   // 015: motor de agenda. Apagado por defecto — sin el, toda la superficie de
   // agenda responde 404 y la UI no la menciona. Ej.: AGENDA=on
   AGENDA: z.string().optional(),
+  // 016: atribucion de anuncios y reporte a la Conversions API de Meta.
+  // Apagada por defecto: sin ella no se captura de que anuncio vino una
+  // conversacion, no se le reporta nada a Meta y la superficie da 404.
+  // Ej.: ATRIBUCION=on
+  ATRIBUCION: z.string().optional(),
   // 015: bases de los conectores. Solo se sobreescriben para apuntar a los
   // mocks en el self-test; en producción se usan las reales.
   ZOOM_BASE_URL: z.string().url().default("https://api.zoom.us/v2"),

--- a/src/lib/meta/capi.ts
+++ b/src/lib/meta/capi.ts
@@ -1,0 +1,153 @@
+import { graphRequest } from "@/lib/meta/client";
+
+/**
+ * 016 — Conversions API de Meta, variante `business_messaging`.
+ *
+ * Frontera de salida única: el mismo `graphRequest` con el que el CRM manda
+ * mensajes. No hay un segundo camino a internet, ni un cliente nuevo, ni una
+ * dependencia nueva: es la misma Graph API del canal que ya usa la instancia.
+ *
+ * Qué hace esto por el negocio: Meta sabe qué conversaciones EMPEZARON desde un
+ * anuncio, pero no sabe cuáles sirvieron. Sin nadie que se lo diga, optimiza
+ * hacia lo único que ve —que alguien abra el chat— y entrega el público más
+ * barato de hacer escribir, que no es el que compra.
+ */
+
+/** Cómo se identifica el software que integró el evento. Constante del proyecto. */
+const PARTNER_AGENT = "vocero-crm";
+
+export type BusinessMessagingEvent = {
+  eventName: string;
+  /** Epoch en SEGUNDOS del momento de la conversión. */
+  eventTime: number;
+  ctwaClid: string;
+  wabaId: string;
+  /**
+   * `custom_data` del evento. Importa más de lo que parece: es lo ÚNICO contra
+   * lo que una **conversión personalizada** de Meta puede escribir reglas. Ni
+   * `event_name` ni `action_source` son parámetros reglables, y estos eventos
+   * no llevan `event_source_url`, así que un evento sin `custom_data` no puede
+   * cumplir NINGUNA regla — y una conversión personalizada sin reglas
+   * cumplibles se queda en cero para siempre, sin decir por qué.
+   */
+  customData?: Record<string, unknown>;
+};
+
+/**
+ * Catálogo CERRADO de `event_name` que Meta acepta con
+ * `action_source: "business_messaging"`. Cualquier otro nombre es un 400 opaco.
+ *
+ * Vocero solo emite dos de ellos (`QualifiedLead` y `Purchase`); la lista
+ * completa vive aquí para que un fork que agregue el suyo no descubra el
+ * catálogo a golpes.
+ *
+ * Doc: /docs/marketing-api/conversions-api/business-messaging
+ */
+export const META_BUSINESS_MESSAGING_EVENTS = [
+  "Purchase",
+  "LeadSubmitted",
+  "QualifiedLead",
+  "InitiateCheckout",
+  "AddToCart",
+  "ViewContent",
+  "OrderCreated",
+  "OrderShipped",
+  "OrderDelivered",
+  "OrderCanceled",
+  "OrderReturned",
+  "CartAbandoned",
+  "RatingProvided",
+  "ReviewProvided",
+] as const;
+
+export type MetaBusinessMessagingEvent =
+  (typeof META_BUSINESS_MESSAGING_EVENTS)[number];
+
+export function isMetaBusinessMessagingEvent(
+  name: string
+): name is MetaBusinessMessagingEvent {
+  return (META_BUSINESS_MESSAGING_EVENTS as readonly string[]).includes(name);
+}
+
+/**
+ * Meta responde 200 aunque no haya contabilizado nada: `events_received` es el
+ * único acuse real. Sin mirarlo, "enviado" solo significaría "no hubo un HTTP
+ * de error", y un evento descartado en silencio se vería idéntico a uno bueno.
+ */
+export type CapiAck = {
+  eventsReceived: number;
+  fbTraceId: string | null;
+  /** Respuesta cruda: cuando algo no cuadra, el `messages[]` de Meta dice más. */
+  raw: unknown;
+};
+
+export async function sendBusinessMessagingEvent(input: {
+  datasetId: string;
+  token: string;
+  event: BusinessMessagingEvent;
+}): Promise<CapiAck> {
+  // Validar ANTES de armar el payload: un nombre fuera del catálogo se rechaza
+  // con un 400 opaco, así que se falla aquí y con el motivo escrito.
+  if (!isMetaBusinessMessagingEvent(input.event.eventName)) {
+    throw new Error(
+      `"${input.event.eventName}" no está en el catálogo de eventos ` +
+        `business_messaging de Meta (${META_BUSINESS_MESSAGING_EVENTS.join(", ")})`
+    );
+  }
+
+  const res = await graphRequest<{
+    events_received?: number;
+    fbtrace_id?: string;
+  }>(`${input.datasetId}/events`, {
+    method: "POST",
+    token: input.token,
+    body: buildEventPayload(input.event),
+  });
+
+  const eventsReceived = res?.events_received ?? 0;
+  if (eventsReceived < 1) {
+    // 200 con cero recibidos: Meta lo descartó. Se falla para que la fila quede
+    // `failed` con el motivo, en vez de un `sent` que miente.
+    throw new Error(
+      `Meta respondió 200 pero events_received=${eventsReceived} ` +
+        `(evento descartado; fbtrace_id: ${res?.fbtrace_id ?? "n/d"})`
+    );
+  }
+
+  return {
+    eventsReceived,
+    fbTraceId: res?.fbtrace_id ?? null,
+    raw: res,
+  };
+}
+
+/**
+ * Arma el body de `POST {dataset}/events`. Separada y exportada para poder
+ * fijar la FORMA del payload en un test: el modo de fallar de este endpoint es
+ * un 200 con `events_received: 0`, donde un campo mal puesto se ve exactamente
+ * igual que uno bien puesto.
+ */
+export function buildEventPayload(
+  event: BusinessMessagingEvent
+): Record<string, unknown> {
+  const data: Record<string, unknown> = {
+    event_name: event.eventName,
+    event_time: event.eventTime,
+    action_source: "business_messaging",
+    messaging_channel: "whatsapp",
+    // Hacia Meta NO viaja teléfono, nombre ni texto del contacto: solo el
+    // identificador del clic y el de la cuenta de WhatsApp del negocio.
+    user_data: {
+      ctwa_clid: event.ctwaClid,
+      whatsapp_business_account_id: event.wabaId,
+    },
+  };
+
+  // Se omite si queda vacío: mandar `custom_data: {}` no aporta nada reglable y
+  // ensucia el payload que uno inspecciona cuando algo falla.
+  if (event.customData && Object.keys(event.customData).length > 0) {
+    data.custom_data = event.customData;
+  }
+
+  return { data: [data], partner_agent: PARTNER_AGENT };
+}

--- a/src/server/attribution/conversions.ts
+++ b/src/server/attribution/conversions.ts
@@ -1,0 +1,325 @@
+import { and, desc, eq } from "drizzle-orm";
+import { getDb, schema } from "@/lib/db";
+import { newId } from "@/lib/db/ids";
+import { scoped } from "@/lib/db/tenant";
+import { sendBusinessMessagingEvent } from "@/lib/meta/capi";
+import { getCredentialsByOrg } from "@/server/whatsapp/credentials";
+import { atribucionEnabled } from "@/server/attribution/flag";
+import { getCapiSettings } from "@/server/attribution/settings";
+import { getAttributionForConversation } from "@/server/attribution/store";
+
+/**
+ * 016 — Reporte de conversiones a Meta.
+ *
+ * Tres reglas duras, y ninguna es opcional:
+ *
+ * 1. **Dedup en la base**, no en el código: la fila se inserta ANTES de hablar
+ *    con Meta, con `ON CONFLICT DO NOTHING` sobre (org, conversación, evento).
+ *    A Meta no se le puede des-enviar una compra.
+ * 2. **Best-effort absoluto**: nada de lo que pase aquí —Meta caído, token
+ *    vencido, dataset sin configurar— puede impedir que el lead se mueva de
+ *    etapa. Se registra el desenlace y se sigue.
+ * 3. **Todo intento deja rastro**: `sent`, `failed` o `skipped` con el motivo
+ *    escrito. Las filas `skipped` son la respuesta a "¿por qué este lead no
+ *    aparece en Meta?", que sin ellas se contesta adivinando.
+ */
+
+/** Los dos eventos que Vocero emite (nombres del catálogo de Meta, tal cual). */
+export const QUALIFIED_EVENT = "QualifiedLead";
+export const PURCHASE_EVENT = "Purchase";
+
+const NO_CLID_REASON =
+  "sin ctwa_clid: la conversación no vino de un anuncio de WhatsApp";
+const NOT_CONFIGURED_REASON =
+  "atribución no configurada: falta el dataset de Meta o la conexión de WhatsApp";
+
+type EmitOutcome = "sent" | "failed" | "skipped" | "dedup" | "error";
+
+/**
+ * Reporta un evento de una conversación. Público para que un fork pueda emitir
+ * los suyos (p. ej. el espejo `InitiateCheckout` que documenta la guía) sin
+ * reimplementar el dedup ni el manejo del acuse.
+ */
+export async function emitConversion(
+  organizationId: string,
+  conversationId: string,
+  eventName: string,
+  customData?: Record<string, unknown>
+): Promise<EmitOutcome> {
+  try {
+    const db = getDb();
+
+    // Dedup atómico: si ya existe ese evento para esta conversación, no-op.
+    const inserted = await db
+      .insert(schema.conversionEvent)
+      .values({
+        id: newId("conversionEvent"),
+        organizationId,
+        conversationId,
+        eventName,
+      })
+      .onConflictDoNothing({
+        target: [
+          schema.conversionEvent.organizationId,
+          schema.conversionEvent.conversationId,
+          schema.conversionEvent.eventName,
+        ],
+      })
+      .returning();
+
+    const event = inserted[0];
+    if (!event) return "dedup";
+
+    const attribution = await getAttributionForConversation(
+      organizationId,
+      conversationId
+    );
+    const settings = await getCapiSettings(organizationId);
+    const credentials = await getCredentialsByOrg(organizationId);
+
+    if (!attribution?.ctwaClid || !settings || !credentials) {
+      await db
+        .update(schema.conversionEvent)
+        .set({
+          status: "skipped",
+          attributionId: attribution?.id ?? null,
+          error: !attribution?.ctwaClid ? NO_CLID_REASON : NOT_CONFIGURED_REASON,
+        })
+        .where(eq(schema.conversionEvent.id, event.id));
+      return "skipped";
+    }
+
+    try {
+      const ack = await sendBusinessMessagingEvent({
+        datasetId: settings.datasetId,
+        token: settings.token,
+        event: {
+          eventName,
+          eventTime: Math.floor(Date.now() / 1000),
+          ctwaClid: attribution.ctwaClid,
+          wabaId: credentials.wabaId,
+          customData,
+        },
+      });
+      await db
+        .update(schema.conversionEvent)
+        .set({
+          status: "sent",
+          attributionId: attribution.id,
+          sentAt: new Date(),
+          fbTraceId: ack.fbTraceId,
+          error: null,
+        })
+        .where(eq(schema.conversionEvent.id, event.id));
+      return "sent";
+    } catch (err) {
+      await db
+        .update(schema.conversionEvent)
+        .set({
+          status: "failed",
+          attributionId: attribution.id,
+          error: err instanceof Error ? err.message : String(err),
+        })
+        .where(eq(schema.conversionEvent.id, event.id));
+      console.warn(
+        `[capi] fallo al reportar ${eventName} de ${conversationId}: ${err}`
+      );
+      return "failed";
+    }
+  } catch (err) {
+    // Best-effort absoluto: ni siquiera un fallo de la base puede tumbar a
+    // quien nos llamó (mover un lead de etapa).
+    console.warn(`[capi] emitConversion(${eventName}) falló: ${err}`);
+    return "error";
+  }
+}
+
+/**
+ * `custom_data` de un `Purchase` a partir del monto del trato. Pura y exportada
+ * para fijar en un test la conversión centavos → unidades: Meta espera unidades
+ * de la moneda (450.50) y la base guarda centavos enteros (45050).
+ *
+ * Sin monto (o en cero) devuelve solo la etapa: la venta se cuenta igual, pero
+ * sin precio. Mandar `value: 0` no significa "no sé cuánto" — le enseña al
+ * optimizador que las ventas de este negocio valen nada.
+ */
+export function purchaseCustomData(amount: {
+  amountCents: number | null;
+  currency: string | null;
+}): Record<string, unknown> {
+  const base = { lead_stage: "won" };
+  if (amount.amountCents === null || amount.amountCents <= 0) return base;
+  return {
+    ...base,
+    value: amount.amountCents / 100,
+    ...(amount.currency ? { currency: amount.currency } : {}),
+  };
+}
+
+/**
+ * Punto de entrada desde la puerta única de etapas.
+ *
+ * Vive aquí y no en `stage-history.ts` para que aquel archivo siga siendo lo
+ * que dice ser: la puerta que escribe `stage_id`. Y cuelga de esa puerta —y no
+ * de donde el bot escribe la ficha, como en el fork del que viene esta idea—
+ * porque así reportan IGUAL los cuatro caminos que mueven un lead: el dueño
+ * arrastrando, el agente incluido, un cerebro externo por `/api/bot/*` y
+ * cualquier quinto camino que alguien agregue mañana.
+ */
+export async function reportStageChange(input: {
+  organizationId: string;
+  leadId: string;
+  contactId: string;
+  toStageId: string;
+  toStageKind: "open" | "won" | "lost";
+}): Promise<void> {
+  if (!atribucionEnabled()) return;
+
+  try {
+    const settings = await getCapiSettings(input.organizationId);
+    const isQualified =
+      settings?.qualifiedStageId != null &&
+      settings.qualifiedStageId === input.toStageId;
+    const isWon = input.toStageKind === "won";
+    if (!isQualified && !isWon) return;
+
+    const db = getDb();
+    // La conversación REAL del contacto (índice único parcial: una por
+    // contacto). Las del Laboratorio (`is_test`) no entran aquí — mismo
+    // guardrail que el sender: una conversación de prueba jamás toca el
+    // mundo real.
+    const rows = await db
+      .select({
+        conversationId: schema.conversation.id,
+        amountCents: schema.lead.amountCents,
+        currency: schema.lead.currency,
+      })
+      .from(schema.lead)
+      .innerJoin(
+        schema.conversation,
+        and(
+          eq(schema.conversation.organizationId, schema.lead.organizationId),
+          eq(schema.conversation.contactId, schema.lead.contactId),
+          eq(schema.conversation.isTest, false)
+        )
+      )
+      .where(
+        scoped(
+          schema.lead.organizationId,
+          input.organizationId,
+          eq(schema.lead.id, input.leadId)
+        )
+      )
+      .limit(1);
+
+    const row = rows[0];
+    // Sin conversación de WhatsApp no hay `ctwa_clid` posible ni nada que
+    // atribuir (p. ej. un prospecto capturado a mano que nunca escribió).
+    if (!row) return;
+
+    if (isWon) {
+      await emitConversion(
+        input.organizationId,
+        row.conversationId,
+        PURCHASE_EVENT,
+        purchaseCustomData(row)
+      );
+      return;
+    }
+
+    await emitConversion(
+      input.organizationId,
+      row.conversationId,
+      QUALIFIED_EVENT,
+      { lead_stage: "qualified" }
+    );
+  } catch (err) {
+    console.warn(`[capi] reportStageChange(${input.leadId}) falló: ${err}`);
+  }
+}
+
+/* ---------------- Actividad reciente (solo lectura) ---------------- */
+
+export type ConversionActivityRow = {
+  id: string;
+  conversationId: string;
+  eventName: string;
+  /** Nombre del contacto; null si la conversación ya no existe. */
+  contactName: string | null;
+  /** Titular del anuncio de origen, si se capturó. */
+  adHeadline: string | null;
+  status: "pending" | "sent" | "failed" | "skipped";
+  /** Momento a mostrar: el envío si ocurrió, si no la creación. */
+  at: string;
+  fbTraceId: string | null;
+  error: string | null;
+};
+
+/** Tope duro: es un panel de monitoreo, no un export. */
+const ACTIVITY_MAX_LIMIT = 50;
+export const ACTIVITY_DEFAULT_LIMIT = 25;
+
+/** Pura y exportada para probar el fallback de fecha sin tocar la base. */
+export function toConversionActivityRow(row: {
+  id: string;
+  conversationId: string;
+  eventName: string;
+  status: "pending" | "sent" | "failed" | "skipped";
+  error: string | null;
+  fbTraceId: string | null;
+  sentAt: Date | null;
+  createdAt: Date;
+  contactName: string | null;
+  adHeadline: string | null;
+}): ConversionActivityRow {
+  return {
+    id: row.id,
+    conversationId: row.conversationId,
+    eventName: row.eventName,
+    contactName: row.contactName,
+    adHeadline: row.adHeadline,
+    status: row.status,
+    at: (row.sentAt ?? row.createdAt).toISOString(),
+    fbTraceId: row.fbTraceId,
+    error: row.error,
+  };
+}
+
+/** Últimas conversiones de la organización, la más reciente primero. */
+export async function listConversionActivity(
+  organizationId: string,
+  limit = ACTIVITY_DEFAULT_LIMIT
+): Promise<ConversionActivityRow[]> {
+  const db = getDb();
+  const rows = await db
+    .select({
+      id: schema.conversionEvent.id,
+      conversationId: schema.conversionEvent.conversationId,
+      eventName: schema.conversionEvent.eventName,
+      status: schema.conversionEvent.status,
+      error: schema.conversionEvent.error,
+      fbTraceId: schema.conversionEvent.fbTraceId,
+      sentAt: schema.conversionEvent.sentAt,
+      createdAt: schema.conversionEvent.createdAt,
+      contactName: schema.contact.name,
+      adHeadline: schema.adAttribution.headline,
+    })
+    .from(schema.conversionEvent)
+    .leftJoin(
+      schema.conversation,
+      eq(schema.conversation.id, schema.conversionEvent.conversationId)
+    )
+    .leftJoin(
+      schema.contact,
+      eq(schema.contact.id, schema.conversation.contactId)
+    )
+    .leftJoin(
+      schema.adAttribution,
+      eq(schema.adAttribution.conversationId, schema.conversionEvent.conversationId)
+    )
+    .where(scoped(schema.conversionEvent.organizationId, organizationId))
+    .orderBy(desc(schema.conversionEvent.createdAt))
+    .limit(Math.min(Math.max(limit, 1), ACTIVITY_MAX_LIMIT));
+
+  return rows.map(toConversionActivityRow);
+}

--- a/src/server/attribution/flag.ts
+++ b/src/server/attribution/flag.ts
@@ -1,0 +1,49 @@
+/**
+ * 016 — Si esta instancia atribuye anuncios y le reporta conversiones a Meta.
+ *
+ * Mismo trato que los canales opcionales (ADR-001) y la agenda (ADR-002): el
+ * código viaja siempre en `main` y lo que decide si EXISTE para el usuario es
+ * una variable de despliegue. Una instancia que no anuncia no ve esto por
+ * ningún lado: ni pestaña de Ajustes, ni rutas, ni una credencial que pedir.
+ *
+ * La bandera también apaga la CAPTURA, no solo el envío. El `ctwa_clid` llega
+ * gratis en el webhook y guardarlo "por si acaso" haría que encender la
+ * bandera meses después tuviera historia que reportar — pero llenar una tabla
+ * con identificadores de clic de Meta en una instancia que nunca pidió esa
+ * función rompe la promesa de ADR-001 por el lado que más importa, el de los
+ * datos. El costo (encender atribuye de ahí en adelante) es menor de lo que
+ * parece: la ventana de atribución de Meta se mide en días, no en meses.
+ *
+ * La migración se aplica siempre: unas tablas vacías son inertes, y a cambio
+ * todas las instancias comparten la misma estructura.
+ */
+
+/** Valores que cuentan como "encendida". Cualquier otra cosa, apagada. */
+const ON_VALUES = new Set(["on", "1", "true", "si", "sí", "yes"]);
+
+export function parseAtribucionFlag(raw: string | undefined): boolean {
+  return ON_VALUES.has((raw ?? "").trim().toLowerCase());
+}
+
+/**
+ * Se lee de `process.env` directo, no por `getEnv()`, igual que
+ * `agendaEnabled()` e `isMockEnabled()`: preguntar si una feature existe no
+ * puede depender de que TODO el entorno valide. La ingesta de un mensaje
+ * consulta esta bandera, y un entorno a medio configurar debe degradar —no
+ * reventar— justo ahí.
+ *
+ * `ATRIBUCION` sí está declarada en el esquema de `lib/env.ts`: ahí viven su
+ * documentación y su tipo. Lo que no pasa por el validador es esta consulta.
+ */
+export function atribucionEnabled(): boolean {
+  return parseAtribucionFlag(process.env.ATRIBUCION);
+}
+
+/**
+ * Respuesta para una superficie apagada. 404 y no 403 a propósito: si la
+ * bandera está apagada, ese endpoint no existe en esta instancia — no hay nada
+ * que revelar sobre él.
+ */
+export function atribucionDisabledResponse(): Response {
+  return new Response(null, { status: 404 });
+}

--- a/src/server/attribution/settings.ts
+++ b/src/server/attribution/settings.ts
@@ -1,0 +1,128 @@
+import { and, eq } from "drizzle-orm";
+import { getDb, schema } from "@/lib/db";
+import { newId } from "@/lib/db/ids";
+import { decryptSecret, encryptSecret } from "@/lib/crypto";
+import { scoped } from "@/lib/db/tenant";
+
+/**
+ * 016 — La conexión del negocio con su dataset de Meta.
+ *
+ * El token se cifra con el MISMO mecanismo que el de WhatsApp (`lib/crypto`,
+ * AES-256-GCM), no con un segundo: dos formas de guardar un secreto es una de
+ * más que auditar.
+ */
+
+export type CapiSettings = {
+  datasetId: string;
+  token: string;
+  qualifiedStageId: string | null;
+  status: "connected" | "error";
+};
+
+/** Lo que puede ver el cliente. El token NUNCA sale: solo sus últimos 4. */
+export type CapiSettingsView = {
+  datasetId: string;
+  status: "connected" | "error";
+  tokenLast4: string;
+  qualifiedStageId: string | null;
+};
+
+export async function getCapiSettings(
+  organizationId: string
+): Promise<CapiSettings | null> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(schema.capiSettings)
+    .where(scoped(schema.capiSettings.organizationId, organizationId))
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    datasetId: row.datasetId,
+    token: decryptSecret({
+      cipher: row.tokenCipher,
+      iv: row.tokenIv,
+      tag: row.tokenTag,
+    }),
+    qualifiedStageId: row.qualifiedStageId,
+    status: row.status,
+  };
+}
+
+export async function getCapiSettingsView(
+  organizationId: string
+): Promise<CapiSettingsView | null> {
+  const settings = await getCapiSettings(organizationId);
+  if (!settings) return null;
+  return {
+    datasetId: settings.datasetId,
+    status: settings.status,
+    tokenLast4: settings.token.slice(-4),
+    qualifiedStageId: settings.qualifiedStageId,
+  };
+}
+
+export async function saveCapiSettings(input: {
+  organizationId: string;
+  datasetId: string;
+  token: string;
+  qualifiedStageId: string | null;
+}): Promise<void> {
+  const db = getDb();
+  const enc = encryptSecret(input.token);
+  await db
+    .insert(schema.capiSettings)
+    .values({
+      id: newId("capiSettings"),
+      organizationId: input.organizationId,
+      datasetId: input.datasetId,
+      tokenCipher: enc.cipher,
+      tokenIv: enc.iv,
+      tokenTag: enc.tag,
+      qualifiedStageId: input.qualifiedStageId,
+      status: "connected",
+    })
+    .onConflictDoUpdate({
+      target: [schema.capiSettings.organizationId],
+      set: {
+        datasetId: input.datasetId,
+        tokenCipher: enc.cipher,
+        tokenIv: enc.iv,
+        tokenTag: enc.tag,
+        qualifiedStageId: input.qualifiedStageId,
+        status: "connected",
+        updatedAt: new Date(),
+      },
+    });
+}
+
+export async function deleteCapiSettings(
+  organizationId: string
+): Promise<void> {
+  const db = getDb();
+  // Los eventos ya registrados NO se borran: son la bitácora de lo que se le
+  // dijo a Meta, y eso no deja de ser cierto porque el negocio desconecte.
+  await db
+    .delete(schema.capiSettings)
+    .where(scoped(schema.capiSettings.organizationId, organizationId));
+}
+
+/** ¿Esa etapa es de esta organización? (multi-tenancy: III). */
+export async function stageBelongsToOrg(
+  organizationId: string,
+  stageId: string
+): Promise<boolean> {
+  const db = getDb();
+  const rows = await db
+    .select({ id: schema.pipelineStage.id })
+    .from(schema.pipelineStage)
+    .where(
+      and(
+        eq(schema.pipelineStage.organizationId, organizationId),
+        eq(schema.pipelineStage.id, stageId)
+      )
+    )
+    .limit(1);
+  return rows.length > 0;
+}

--- a/src/server/attribution/store.ts
+++ b/src/server/attribution/store.ts
@@ -1,0 +1,67 @@
+import { and, eq } from "drizzle-orm";
+import { getDb, schema } from "@/lib/db";
+import { newId } from "@/lib/db/ids";
+import type { WebhookReferral } from "@/server/inbox/webhook";
+
+/**
+ * 016 — Captura del origen del anuncio.
+ *
+ * El `referral` solo llega cuando el mensaje viene de un anuncio
+ * Click-to-WhatsApp, y normalmente solo en el PRIMER mensaje de la
+ * conversación. Su `ctwa_clid` es la llave de todo lo demás: sin él no hay nada
+ * que reportarle a Meta después.
+ */
+
+export async function recordAttribution(input: {
+  organizationId: string;
+  contactId: string;
+  conversationId: string;
+  referral: WebhookReferral;
+}): Promise<void> {
+  const db = getDb();
+  const r = input.referral;
+  await db
+    .insert(schema.adAttribution)
+    .values({
+      id: newId("adAttribution"),
+      organizationId: input.organizationId,
+      contactId: input.contactId,
+      conversationId: input.conversationId,
+      ctwaClid: r.ctwa_clid ?? null,
+      sourceId: r.source_id ?? null,
+      sourceType: r.source_type ?? null,
+      sourceUrl: r.source_url ?? null,
+      headline: r.headline ?? null,
+      body: r.body ?? null,
+      mediaType: r.media_type ?? null,
+      raw: r,
+    })
+    // El primer referral gana. `ON CONFLICT DO NOTHING` sobre el UNIQUE de
+    // (org, conversación) —y no un "consulta y luego inserta"— porque Meta
+    // reintenta el webhook y dos entregas simultáneas ganarían la carrera las
+    // dos (Constitución IV).
+    .onConflictDoNothing({
+      target: [
+        schema.adAttribution.organizationId,
+        schema.adAttribution.conversationId,
+      ],
+    });
+}
+
+export async function getAttributionForConversation(
+  organizationId: string,
+  conversationId: string
+) {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(schema.adAttribution)
+    .where(
+      and(
+        eq(schema.adAttribution.organizationId, organizationId),
+        eq(schema.adAttribution.conversationId, conversationId)
+      )
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}

--- a/src/server/dev/wa-mock-inbound.ts
+++ b/src/server/dev/wa-mock-inbound.ts
@@ -63,6 +63,14 @@ function applyMockContent(
   }
 }
 
+/** 016 — Campos para simular que el mensaje vino de un anuncio CTWA. */
+type MockReferralInput = {
+  /** Identificador del clic. Sin él no hay nada que reportarle a Meta. */
+  ctwaClid?: string;
+  adHeadline?: string;
+  adSourceId?: string;
+};
+
 export function buildInboundPayload(input: {
   wabaId: string;
   phoneNumberId: string;
@@ -75,7 +83,8 @@ export function buildInboundPayload(input: {
   text?: string;
   waMessageId?: string;
   timestamp?: number;
-} & MockMediaInput) {
+} & MockMediaInput &
+  MockReferralInput) {
   const type = input.type ?? "text";
   const message: Record<string, unknown> = {
     id: input.waMessageId ?? `wamid.mock.in.${nextN()}`,
@@ -85,6 +94,21 @@ export function buildInboundPayload(input: {
   if (input.from) message.from = input.from;
   if (input.fromUserId) message.from_user_id = input.fromUserId;
   applyMockContent(message, type, input);
+
+  // 016 — El referral solo viaja cuando la conversación nació de un anuncio, y
+  // normalmente solo en el primer mensaje. Se arma igual que el real para que
+  // la ingesta no sepa que habla con un mock.
+  if (input.ctwaClid || input.adHeadline || input.adSourceId) {
+    message.referral = {
+      source_type: "ad",
+      source_id: input.adSourceId ?? "1200000000000",
+      source_url: "https://fb.me/anuncio-de-prueba",
+      headline: input.adHeadline ?? "Anuncio de prueba",
+      body: "Escríbenos por WhatsApp",
+      media_type: "image",
+      ...(input.ctwaClid ? { ctwa_clid: input.ctwaClid } : {}),
+    };
+  }
 
   const contactEntry: Record<string, unknown> = {
     profile: { name: input.name ?? "Cliente" },

--- a/src/server/dev/wa-mock-state.ts
+++ b/src/server/dev/wa-mock-state.ts
@@ -29,9 +29,26 @@ export type MockTemplate = {
   components?: unknown[];
 };
 
+/**
+ * 016 — Un evento de Conversions API que el CRM le mandó al mock. El self-test
+ * lo inspecciona para verificar la FORMA del payload: el modo de fallar de ese
+ * endpoint es un 200 con `events_received: 0`, donde un campo mal puesto se ve
+ * idéntico a uno bien puesto.
+ */
+export type CapiMockEvent = {
+  n: number;
+  datasetId: string;
+  eventName: string;
+  ctwaClid: string | null;
+  customData: Record<string, unknown> | null;
+  body: unknown;
+  at: string;
+};
+
 type WaMockState = {
   outbox: OutboxEntry[];
   templates: MockTemplate[];
+  capiEvents: CapiMockEvent[];
   counter: number;
 };
 
@@ -39,13 +56,23 @@ const globalForMock = globalThis as unknown as { __waMockState?: WaMockState };
 
 export function getWaMockState(): WaMockState {
   if (!globalForMock.__waMockState) {
-    globalForMock.__waMockState = { outbox: [], templates: [], counter: 0 };
+    globalForMock.__waMockState = {
+      outbox: [],
+      templates: [],
+      capiEvents: [],
+      counter: 0,
+    };
   }
   return globalForMock.__waMockState;
 }
 
 export function resetWaMockState(): void {
-  globalForMock.__waMockState = { outbox: [], templates: [], counter: 0 };
+  globalForMock.__waMockState = {
+    outbox: [],
+    templates: [],
+    capiEvents: [],
+    counter: 0,
+  };
 }
 
 export function nextN(): number {

--- a/src/server/inbox/ingest.ts
+++ b/src/server/inbox/ingest.ts
@@ -8,6 +8,7 @@ import { ensureAssetAvailable } from "@/server/whatsapp/media";
 import type {
   WebhookMediaPayload,
   WebhookMessage,
+  WebhookReferral,
   WebhookValue,
 } from "@/server/inbox/webhook";
 import {
@@ -16,6 +17,8 @@ import {
   type ResolvedIdentity,
 } from "@/server/inbox/identity";
 import { applyStatusUpdate } from "@/server/inbox/status";
+import { atribucionEnabled } from "@/server/attribution/flag";
+import { recordAttribution } from "@/server/attribution/store";
 import { onLeadActivity } from "@/server/inbox/lead-activity";
 import { maybeRunAgentTurn } from "@/server/ai/trigger";
 
@@ -248,6 +251,7 @@ export async function processMessagesValue(value: WebhookValue): Promise<void> {
       text: msg.text?.body ?? null,
       timestamp: msg.timestamp,
       media: mediaInputFrom(msg),
+      referral: msg.referral ?? null,
     });
   }
 }
@@ -381,6 +385,8 @@ export async function ingestInboundMessage(input: {
   media?: MediaInput | null;
   /** 014: hilo en la plataforma de origen (Zernio); null en WhatsApp. */
   threadRef?: string | null;
+  /** 016: origen del anuncio, si el mensaje vino de uno. */
+  referral?: WebhookReferral | null;
 }): Promise<void> {
   const db = getDb();
   const { organizationId } = input;
@@ -394,6 +400,20 @@ export async function ingestInboundMessage(input: {
     contact.id,
     { channel: contact.channel, threadRef: input.threadRef ?? null }
   );
+
+  // 016 — Si el mensaje viene de un anuncio, capturar su origen ANTES del
+  // dedup de mensaje: es idempotente por sí mismo (el primer referral gana) y
+  // así un reintento de Meta que llegue con el referral no lo pierde por
+  // haberse cortado antes en el dedup. Solo con la bandera encendida: una
+  // instancia que no atribuye no guarda identificadores de clic (ADR-001).
+  if (input.referral && atribucionEnabled()) {
+    await recordAttribution({
+      organizationId,
+      contactId: contact.id,
+      conversationId: conversation.id,
+      referral: input.referral,
+    });
+  }
 
   const waTimestamp = toDate(input.timestamp);
 

--- a/src/server/inbox/webhook.ts
+++ b/src/server/inbox/webhook.ts
@@ -58,6 +58,25 @@ export type WebhookLocation = {
   address?: string;
 };
 
+/**
+ * 016 — Objeto `referral`: SOLO llega cuando el mensaje viene de un anuncio
+ * Click-to-WhatsApp, y normalmente solo en el PRIMER mensaje de la
+ * conversación. Su `ctwa_clid` es lo que permite devolverle a Meta el
+ * desenlace de ese lead; el resto son datos del creativo.
+ */
+export type WebhookReferral = {
+  source_url?: string;
+  source_id?: string;
+  source_type?: string;
+  headline?: string;
+  body?: string;
+  media_type?: string;
+  image_url?: string;
+  video_url?: string;
+  thumbnail_url?: string;
+  ctwa_clid?: string;
+};
+
 export type WebhookMessage = {
   /** Teléfono del remitente. OPCIONAL desde la migración de Meta a BSUID (003). */
   from?: string;
@@ -76,6 +95,8 @@ export type WebhookMessage = {
   sticker?: WebhookMediaPayload;
   location?: WebhookLocation;
   contacts?: unknown[];
+  /** 016: origen del anuncio, cuando la conversación nació de uno. */
+  referral?: WebhookReferral;
 };
 
 export type WebhookStatus = {

--- a/src/server/leads/stage-history.ts
+++ b/src/server/leads/stage-history.ts
@@ -3,6 +3,7 @@ import { getDb, schema } from "@/lib/db";
 import { newId } from "@/lib/db/ids";
 import { scoped } from "@/lib/db/tenant";
 import type { LossReason, StageChangeSource } from "@/lib/types";
+import { reportStageChange } from "@/server/attribution/conversions";
 
 /**
  * La ÚNICA puerta que escribe `lead.stage_id`.
@@ -54,7 +55,12 @@ export async function moveLeadToStage(input: MoveInput): Promise<MoveResult> {
   const db = getDb();
   const occurredAt = input.occurredAt ?? new Date();
 
-  return db.transaction(async (tx) => {
+  // 016: se anota aquí dentro y se reporta a Meta DESPUÉS del commit. Una
+  // llamada de red dentro de la transacción la mantendría abierta mientras
+  // Meta piensa, y una conversión jamás vale una transacción larga.
+  let toStageKind: "open" | "won" | "lost" | null = null;
+
+  const result = await db.transaction(async (tx) => {
     const leadRows = await tx
       .select({ lead: schema.lead, stage: schema.pipelineStage })
       .from(schema.lead)
@@ -90,6 +96,7 @@ export async function moveLeadToStage(input: MoveInput): Promise<MoveResult> {
     if (!target) return { ok: false as const, reason: "stage_not_found" as const };
 
     const changed = current.lead.stageId !== target.id;
+    toStageKind = target.kind;
 
     // El motivo se exige al ENTRAR a la etapa perdida. Reordenar una tarjeta
     // que ya estaba ahí no vuelve a preguntar.
@@ -139,6 +146,22 @@ export async function moveLeadToStage(input: MoveInput): Promise<MoveResult> {
 
     return { ok: true as const, lead: leadRow, changed };
   });
+
+  // 016 — Atribución: si esta instancia la tiene encendida, entrar a la etapa
+  // que el negocio marcó como "lead calificado" o a una etapa ganada se le
+  // reporta a Meta. Best-effort y ya fuera de la transacción: un fallo aquí
+  // jamás puede costar el movimiento del lead, que ya está en firme.
+  if (result.ok && result.changed && toStageKind !== null) {
+    await reportStageChange({
+      organizationId: input.organizationId,
+      leadId: result.lead.id,
+      contactId: result.lead.contactId,
+      toStageId: result.lead.stageId,
+      toStageKind,
+    });
+  }
+
+  return result;
 }
 
 /**

--- a/tests/e2e/us-atribucion.md
+++ b/tests/e2e/us-atribucion.md
@@ -1,0 +1,73 @@
+# E2E — Atribución de anuncios y Conversions API (016)
+
+Guion de comportamiento observable. Automatizado en la sección `016` de
+`scripts/e2e-selftest.mjs`: con la app viva y los mocks encendidos,
+`pnpm test:e2e` lo conduce y sale distinto de cero si algo falla.
+
+**Preparación**: app en `localhost` con `WA_MOCK_ENABLED=true`,
+`META_GRAPH_BASE_URL` → wa-mock, `BOT_API_KEY` y la BD migrada. La bandera
+`ATRIBUCION` decide qué mitad del guion corre: **las dos se ejercitan**, porque
+una feature opcional que solo se prueba encendida no está probada.
+
+Nada de esto toca Meta. No es comodidad: Meta valida el `ctwa_clid` contra un
+clic real y rechaza cualquier valor inventado (`code 100 / error_subcode
+2804087`), así que un evento sintético contra la API real es imposible por
+diseño. El mock imita las tres cosas que importan: el catálogo cerrado, la
+exigencia del clid, y el **200 que descarta el evento**.
+
+---
+
+## US1 — La instancia decide si esto existe
+
+Con `ATRIBUCION` ausente:
+
+1. `GET`/`PUT`/`DELETE /api/settings/capi` y `GET /api/settings/capi/events`
+   responden **404** (no 403: aquí ese endpoint no existe).
+2. La pantalla `/settings/ads` responde 404 y Ajustes no la menciona.
+3. Un mensaje que **sí** viene de un anuncio se atiende como cualquier otro: la
+   conversación se crea, el mensaje se ve, y no se guarda ninguna atribución.
+
+Con `ATRIBUCION=on`, las mismas rutas responden con normalidad.
+
+## US2 — Conectar el dataset
+
+1. Sin configurar, `GET /api/settings/capi` responde **200 con `capi: null`**:
+   no es un error, es una instancia que aún no conectó.
+2. Guardar **sin token** reusa el de la conexión de WhatsApp; el `GET` posterior
+   muestra solo los **últimos 4** y el token completo no aparece por ningún lado.
+3. Una `qualifiedStageId` que no es de este negocio se rechaza con
+   **`422 etapa_invalida`**.
+4. Desconectar borra la configuración pero **no** los eventos ya reportados: eso
+   ya se le dijo a Meta y sigue siendo cierto.
+
+## US3 — Capturar el anuncio
+
+1. Un inbound con `referral` deja el origen guardado junto a la conversación.
+2. Un segundo mensaje del mismo contacto con **otro** `ctwa_clid` no lo
+   sobreescribe: **el primer referral gana**, y se comprueba mirando con qué
+   clid salió el evento después.
+
+## US4 — El lead calificado
+
+1. Mover el lead a la etapa marcada como calificada reporta `QualifiedLead`, y
+   la actividad lo muestra **enviado** con su `fbtrace_id`.
+2. El payload que recibió Meta lleva el `ctwa_clid` correcto y
+   `custom_data.lead_stage = "qualified"` — sin ese parámetro, ninguna
+   conversión personalizada de Meta podría casar jamás.
+3. La fila de actividad dice **de qué anuncio** vino (su titular).
+4. Sacar el lead de esa etapa y volverlo a meter **no** reporta dos veces.
+
+## US5 — La venta
+
+1. Mover el trato a la etapa ganada con monto reporta `Purchase` con
+   `value: 450.5` y su moneda — **unidades, no centavos**.
+2. Re-ganar el mismo trato no manda una segunda compra.
+
+## Caminos infelices (los que de verdad importan)
+
+1. **Lead sin anuncio**: la fila queda **omitida** con el motivo escrito
+   (`sin ctwa_clid…`) y nada falla.
+2. **Meta rechazando** (dataset `-fail`, que responde 200 con
+   `events_received: 0`): el lead **se mueve igual** y se queda en su etapa
+   nueva; la fila queda **fallida** con lo que dijo Meta. Ninguna conversión
+   vale un movimiento de lead bloqueado.

--- a/tests/unit/atribucion-flag.test.ts
+++ b/tests/unit/atribucion-flag.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { parseAtribucionFlag } from "@/server/attribution/flag";
+
+/**
+ * 016 — La bandera de la atribución. El caso que importa es el DEFAULT: una
+ * instancia que no la pidió no debe acabar guardando identificadores de clic
+ * de Meta ni mandándole eventos por un despiste de configuración.
+ */
+
+describe("parseAtribucionFlag", () => {
+  it("sin variable, la atribución no existe", () => {
+    expect(parseAtribucionFlag(undefined)).toBe(false);
+    expect(parseAtribucionFlag("")).toBe(false);
+    expect(parseAtribucionFlag("   ")).toBe(false);
+  });
+
+  it("`on` la enciende, con espacios y mayúsculas de por medio", () => {
+    expect(parseAtribucionFlag("on")).toBe(true);
+    expect(parseAtribucionFlag("ON")).toBe(true);
+    expect(parseAtribucionFlag("  On  ")).toBe(true);
+  });
+
+  it("acepta las otras formas de decir que sí", () => {
+    expect(parseAtribucionFlag("1")).toBe(true);
+    expect(parseAtribucionFlag("true")).toBe(true);
+    expect(parseAtribucionFlag("si")).toBe(true);
+    expect(parseAtribucionFlag("sí")).toBe(true);
+    expect(parseAtribucionFlag("yes")).toBe(true);
+  });
+
+  it("cualquier otra cosa la deja apagada, incluido `off` y `false`", () => {
+    expect(parseAtribucionFlag("off")).toBe(false);
+    expect(parseAtribucionFlag("false")).toBe(false);
+    expect(parseAtribucionFlag("0")).toBe(false);
+    expect(parseAtribucionFlag("no")).toBe(false);
+    // Un typo no enciende nada: apagada es el estado seguro.
+    expect(parseAtribucionFlag("onn")).toBe(false);
+  });
+});

--- a/tests/unit/capi-payload.test.ts
+++ b/tests/unit/capi-payload.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * 016 — El evento que sale hacia Meta.
+ *
+ * Estos tests existen por un motivo muy concreto: el modo de fallar de
+ * `POST {dataset}/events` es un **200 con `events_received: 0`**. Un campo mal
+ * puesto se ve exactamente igual que uno bien puesto, así que la forma del
+ * payload y la lectura del acuse se fijan aquí, donde sí se puede afirmar.
+ */
+
+const graphRequest = vi.fn();
+
+vi.mock("@/lib/meta/client", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/meta/client")>();
+  return { ...original, graphRequest };
+});
+
+const { buildEventPayload, sendBusinessMessagingEvent, isMetaBusinessMessagingEvent } =
+  await import("@/lib/meta/capi");
+
+const EVENT = {
+  eventName: "QualifiedLead",
+  eventTime: 1787000000,
+  ctwaClid: "ARAaB_clic",
+  wabaId: "WABA-1",
+};
+
+beforeEach(() => {
+  graphRequest.mockReset();
+});
+
+describe("buildEventPayload", () => {
+  it("arma el evento de mensajería con los campos que Meta exige", () => {
+    const body = buildEventPayload(EVENT) as {
+      data: Record<string, unknown>[];
+      partner_agent: string;
+    };
+    const event = body.data[0]!;
+
+    expect(event.event_name).toBe("QualifiedLead");
+    expect(event.event_time).toBe(1787000000);
+    expect(event.action_source).toBe("business_messaging");
+    expect(event.messaging_channel).toBe("whatsapp");
+    expect(event.user_data).toEqual({
+      ctwa_clid: "ARAaB_clic",
+      whatsapp_business_account_id: "WABA-1",
+    });
+    // Quién integró el evento: el proyecto, no el negocio ni una agencia.
+    expect(body.partner_agent).toBe("vocero-crm");
+  });
+
+  it("hacia Meta no viaja NADA personal del contacto", () => {
+    const body = buildEventPayload(EVENT) as {
+      data: Record<string, unknown>[];
+    };
+    const userData = body.data[0]!.user_data as Record<string, unknown>;
+    // `user_data` es el sobre donde Meta espera datos de persona: aquí solo
+    // lleva el identificador del clic y el de la cuenta del negocio.
+    expect(Object.keys(userData).sort()).toEqual([
+      "ctwa_clid",
+      "whatsapp_business_account_id",
+    ]);
+    const raw = JSON.stringify(body);
+    expect(raw).not.toContain("phone");
+    expect(raw).not.toContain("email");
+    expect(raw).not.toContain("\"name\"");
+  });
+
+  it("incluye custom_data cuando lo hay, y lo omite cuando está vacío", () => {
+    const con = buildEventPayload({
+      ...EVENT,
+      customData: { lead_stage: "qualified" },
+    }) as { data: Record<string, unknown>[] };
+    expect(con.data[0]!.custom_data).toEqual({ lead_stage: "qualified" });
+
+    const sin = buildEventPayload({ ...EVENT, customData: {} }) as {
+      data: Record<string, unknown>[];
+    };
+    // Un `custom_data: {}` no aporta nada reglable y ensucia el payload que
+    // uno inspecciona cuando algo falla.
+    expect(sin.data[0]!.custom_data).toBeUndefined();
+  });
+
+  it("el valor de una venta viaja en unidades de la moneda", () => {
+    const body = buildEventPayload({
+      ...EVENT,
+      eventName: "Purchase",
+      customData: { lead_stage: "won", value: 450.5, currency: "MXN" },
+    }) as { data: Record<string, unknown>[] };
+    expect(body.data[0]!.custom_data).toEqual({
+      lead_stage: "won",
+      value: 450.5,
+      currency: "MXN",
+    });
+  });
+});
+
+describe("catálogo cerrado", () => {
+  it("reconoce los nombres de Meta y rechaza los inventados", () => {
+    expect(isMetaBusinessMessagingEvent("QualifiedLead")).toBe(true);
+    expect(isMetaBusinessMessagingEvent("Purchase")).toBe(true);
+    // El nombre de dominio del fork del que viene esta idea: NO existe en Meta.
+    expect(isMetaBusinessMessagingEvent("LeadQualified")).toBe(false);
+    expect(isMetaBusinessMessagingEvent("SessionBooked")).toBe(false);
+  });
+
+  it("un nombre fuera del catálogo falla ANTES de salir a la red", async () => {
+    await expect(
+      sendBusinessMessagingEvent({
+        datasetId: "ds_1",
+        token: "tok",
+        event: { ...EVENT, eventName: "LeadQualified" },
+      })
+    ).rejects.toThrow(/catálogo/);
+    expect(graphRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe("el acuse de Meta", () => {
+  it("con events_received >= 1 el evento cuenta como enviado", async () => {
+    graphRequest.mockResolvedValue({
+      events_received: 1,
+      fbtrace_id: "Aki123",
+    });
+    const ack = await sendBusinessMessagingEvent({
+      datasetId: "ds_1",
+      token: "tok",
+      event: EVENT,
+    });
+    expect(ack.eventsReceived).toBe(1);
+    expect(ack.fbTraceId).toBe("Aki123");
+    expect(graphRequest).toHaveBeenCalledWith(
+      "ds_1/events",
+      expect.objectContaining({ method: "POST", token: "tok" })
+    );
+  });
+
+  it("un 200 con events_received: 0 es un FALLO, no un envío", async () => {
+    // Meta responde 200 aunque descarte el evento. Sin mirar el acuse,
+    // "enviado" solo significaría "no hubo error HTTP".
+    graphRequest.mockResolvedValue({
+      events_received: 0,
+      fbtrace_id: "AkiZZZ",
+    });
+    await expect(
+      sendBusinessMessagingEvent({
+        datasetId: "ds_1",
+        token: "tok",
+        event: EVENT,
+      })
+    ).rejects.toThrow(/events_received=0/);
+  });
+
+  it("una respuesta sin el campo tampoco se toma por buena", async () => {
+    graphRequest.mockResolvedValue({});
+    await expect(
+      sendBusinessMessagingEvent({
+        datasetId: "ds_1",
+        token: "tok",
+        event: EVENT,
+      })
+    ).rejects.toThrow(/events_received=0/);
+  });
+});

--- a/tests/unit/conversions.test.ts
+++ b/tests/unit/conversions.test.ts
@@ -1,0 +1,107 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  purchaseCustomData,
+  toConversionActivityRow,
+} from "@/server/attribution/conversions";
+
+/**
+ * 016 — Las piezas puras del reporte de conversiones y dos guardarraíles que
+ * se leen del código fuente porque afirman AUSENCIA (que algo no se llama),
+ * y eso no se observa desde fuera.
+ */
+
+describe("purchaseCustomData", () => {
+  it("convierte centavos a unidades de la moneda", () => {
+    // La base protege el dinero en centavos enteros; Meta espera unidades.
+    expect(purchaseCustomData({ amountCents: 45050, currency: "MXN" })).toEqual({
+      lead_stage: "won",
+      value: 450.5,
+      currency: "MXN",
+    });
+  });
+
+  it("sin monto, la venta se cuenta pero SIN precio", () => {
+    // `value: 0` no significa "no sé cuánto": le enseñaría al optimizador que
+    // las ventas de este negocio valen nada.
+    expect(purchaseCustomData({ amountCents: null, currency: "MXN" })).toEqual({
+      lead_stage: "won",
+    });
+    expect(purchaseCustomData({ amountCents: 0, currency: "MXN" })).toEqual({
+      lead_stage: "won",
+    });
+  });
+
+  it("un monto negativo tampoco inventa un valor", () => {
+    expect(purchaseCustomData({ amountCents: -100, currency: "MXN" })).toEqual({
+      lead_stage: "won",
+    });
+  });
+
+  it("sin moneda capturada, manda el valor sin moneda antes que inventarla", () => {
+    expect(purchaseCustomData({ amountCents: 12300, currency: null })).toEqual({
+      lead_stage: "won",
+      value: 123,
+    });
+  });
+});
+
+describe("toConversionActivityRow", () => {
+  const base = {
+    id: "cve_1",
+    conversationId: "cv_1",
+    eventName: "QualifiedLead",
+    error: null,
+    fbTraceId: "Aki1",
+    contactName: "Marina",
+    adHeadline: "Kit de verano",
+    createdAt: new Date("2026-08-28T10:00:00.000Z"),
+  };
+
+  it("muestra el momento del ENVÍO cuando lo hubo", () => {
+    const row = toConversionActivityRow({
+      ...base,
+      status: "sent",
+      sentAt: new Date("2026-08-28T10:05:00.000Z"),
+    });
+    expect(row.at).toBe("2026-08-28T10:05:00.000Z");
+    expect(row.adHeadline).toBe("Kit de verano");
+  });
+
+  it("y el de creación cuando no salió", () => {
+    const row = toConversionActivityRow({
+      ...base,
+      status: "skipped",
+      sentAt: null,
+      error: "sin ctwa_clid",
+    });
+    expect(row.at).toBe("2026-08-28T10:00:00.000Z");
+    // El motivo se conserva tal cual: es la respuesta a "¿por qué este lead no
+    // aparece en Meta?".
+    expect(row.error).toBe("sin ctwa_clid");
+  });
+});
+
+describe("guardarraíles del reporte", () => {
+  const source = readFileSync("src/server/attribution/conversions.ts", "utf8");
+
+  it("una conversación de prueba jamás puede producir un evento", () => {
+    // Mismo guardrail que el sender: el Laboratorio no toca el mundo real.
+    expect(source).toContain("eq(schema.conversation.isTest, false)");
+  });
+
+  it("el dedup es el UNIQUE de la base, no un chequeo previo", () => {
+    // A Meta no se le puede des-enviar una compra: dos movimientos simultáneos
+    // del mismo lead tienen que chocar en la base, no en un `if`.
+    expect(source).toContain("onConflictDoNothing");
+  });
+
+  it("la emisión cuelga de la puerta única de etapas", () => {
+    const gate = readFileSync("src/server/leads/stage-history.ts", "utf8");
+    expect(gate).toContain("reportStageChange");
+    // Y ocurre DESPUÉS del commit: una llamada de red dentro de la transacción
+    // la mantendría abierta mientras Meta piensa.
+    const txEnd = gate.indexOf("  });");
+    expect(gate.indexOf("reportStageChange(", txEnd)).toBeGreaterThan(txEnd);
+  });
+});


### PR DESCRIPTION
## El problema

Un negocio que anuncia con **Click-to-WhatsApp** paga por conversaciones. Meta sabe cuáles **empezaron**; no sabe cuáles **sirvieron**. Sin nadie que se lo diga, el algoritmo optimiza hacia lo único que ve —que alguien abra el chat— y entrega el público más barato de hacer escribir, que rara vez es el que compra. El dueño lo vive como *"me llegan muchos mensajes y no cierro ninguno"*.

Vocero está en el único lugar donde esa verdad existe: sabe que esta conversación vino del anuncio A, que se calificó el martes y que se ganó el viernes por $12,000. Este PR le devuelve a Meta ese desenlace por la **Conversions API** (`business_messaging`), detrás de la bandera `ATRIBUCION`, apagada por defecto.

## Qué entra

Con la bandera encendida:

- **Captura** el `ctwa_clid` del primer mensaje que viene de un anuncio (idempotente: el primer referral gana).
- **Reporta `QualifiedLead`** cuando el lead entra a la etapa que el negocio marcó como calificada, y **`Purchase`** cuando entra a una etapa ganada, con `value`/`currency` si el trato tiene monto.
- **Ajustes → Anuncios**: dataset, token (reusa el de WhatsApp), selector de etapa, y una tabla de actividad que dice qué se envió, con qué acuse y —cuando no salió— por qué.

Con la bandera apagada: 404 en toda la superficie, sin pestaña, **sin captura** y sin una sola fila en la base. Verificado, no prometido.

## Decisiones que vale la pena revisar

**1. Los dos eventos cuelgan de `moveLeadToStage`, la puerta única de etapas.** Así reportan igual el dueño arrastrando la tarjeta, el agente incluido y un cerebro externo por `/api/bot/*`. El fork del que sale esta idea emite desde donde el bot escribe la ficha, y ahí *arrastrar* un lead a "calificado" **no reportaba nada** — un hueco silencioso, que es lo peor que le puede pasar a una métrica. La llamada a Meta ocurre **fuera** de la transacción y envuelta: un fallo jamás cuesta el movimiento del lead.

**2. Qué significa "calificado" lo elige cada negocio** (`capi_settings.qualified_stage_id`). Las etapas sembradas de Vocero no incluyen ninguna con ese nombre y cada quien renombra las suyas: inferirlo sería adivinar. La venta no se configura — cuelga del `kind = "won"` que ya existe.

**3. `events_received >= 1` es el único acuse válido.** Meta responde **200 aunque descarte el evento**. Sin mirar el acuse, "enviado" solo significaría "no hubo error HTTP" y un evento tirado a la basura se vería idéntico a uno bueno.

**4. Cada evento lleva `custom_data.lead_stage`.** Es lo único contra lo que una conversión personalizada de Meta puede escribir reglas: `event_name` y el origen de acción **no son parámetros reglables**. Sin ese campo, una conversión personalizada se queda en cero para siempre sin decir por qué (tres días de producción costó descubrirlo).

**5. El dedup es un UNIQUE en base, no un `if`.** A Meta no se le puede des-enviar una compra. Y sin monto no se manda `value`: un `Purchase` en 0 le enseñaría al optimizador que las ventas de este negocio valen nada.

## Qué NO sube, a propósito

El fork tiene además backfill, un laboratorio para disparar eventos a voluntad y un **espejo de venta** (duplicar cada calificado como `InitiateCheckout` para poder optimizar una campaña de ventas). Los tres son **decisiones de operación de una agencia**, no verdades de un CRM. El espejo queda documentado como receta de tres líneas en `docs/atribucion-capi.md` —`emitConversion` es público justamente para eso—, con sus dos advertencias ganadas a golpes.

Tampoco sube el `partner_agent` del fork: aquí dice `vocero-crm`.

## Constitución

- **Soberanía (II)**: no entra ningún tercero nuevo — es la **misma Graph API** del canal permitido, como el canal de Instagram. Aun así viaja con el traje completo de módulo opcional (ADR-001): apagado por defecto, aislado en `lib/meta/capi.ts` con contrato público, degradación definida, credenciales del negocio cifradas y CI en las dos configuraciones. **Cero dependencias de runtime nuevas.**
- **Seguridad (I)**: token cifrado con `lib/crypto`; hacia el cliente solo `last4`. Hacia Meta **no viaja teléfono, nombre ni texto** del contacto: solo el identificador del clic y el id del WABA.
- **Idempotencia (IV)**: dedup y captura por UNIQUE + `ON CONFLICT DO NOTHING`; migración `0010` aditiva y re-ejecutable (probada aplicándola dos veces seguidas).
- **Sandbox**: una conversación `is_test` jamás produce un evento.

## Verificación

| | |
|---|---|
| Gate técnico | `typecheck` · `lint` · `build` · **371 unit** (22 nuevas) |
| Arnés E2E, `ATRIBUCION=on` | **120/120 checks** |
| Arnés E2E, sin la bandera | **103/103 checks** (6 prueban que no existe) |

El arnés corre contra la app viva con mocks, incluidos los caminos infelices: lead sin anuncio → omitido con motivo; **Meta rechazando → el lead se mueve igual** y la fila queda fallida con lo que dijo Meta.

Contra la base, que es donde vive la promesa de ADR-001: con la bandera apagada y tras un inbound **con** anuncio, `ad_attribution` y `conversion_event` quedan en **0 filas**.

Nada de esto toca Meta, y no es comodidad: Meta valida el `ctwa_clid` contra un clic real (`code 100 / error_subcode 2804087` con cualquier valor inventado), así que **el evento sintético no existe**. El mock de Graph imita las tres cosas que importan: el catálogo cerrado, la exigencia del clid y el 200 que descarta.

## Archivos

Diseño en `specs/016-atribucion-capi/` (carril ciclo completo: spec, plan, research con las 11 decisiones y su evidencia, data-model, 2 contratos, quickstart, checklist, tasks). Guía del dueño con los gotchas de Meta en `docs/atribucion-capi.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
