### PR TITLE
fix(docker): mantener /data escribible cuando se monta como volumen nombrado

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,11 @@ FROM node:22-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
+# su-exec: bajar de root a `vocero` DESPUÉS de arreglar permisos del volumen
+# (Railway/Coolify montan volúmenes nombrados como root y el chown del build
+# no persiste sobre el mount; hay que hacerlo en el arranque).
+RUN apk add --no-cache su-exec
 RUN addgroup -S vocero && adduser -S vocero -G vocero
-# 008: punto de montaje del volumen de adjuntos, propiedad del usuario de la
-# app — el volumen nombrado hereda este dueño al montarse vacío (sin esto,
-# monta como root y el guardado de adjuntos falla con EACCES).
 RUN mkdir -p /data/media && chown -R vocero:vocero /data
 
 COPY --from=builder --chown=vocero:vocero /app/.next/standalone ./
@@ -47,14 +48,13 @@ COPY --from=builder --chown=vocero:vocero /app/migrate.bundle.mjs ./migrate.mjs
 COPY --from=builder --chown=vocero:vocero /app/seed-demo.bundle.mjs ./seed-demo.mjs
 COPY --from=builder --chown=vocero:vocero /app/drizzle ./drizzle
 
-USER vocero
+# Arranca como root SOLO para arreglar el owner del volumen montado
+# (idempotente: si ya está bien no hace nada). Luego baja a `vocero`.
 EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
 
-# start-period amplio: cubre las migraciones del arranque
 HEALTHCHECK --interval=15s --timeout=5s --start-period=40s --retries=5 \
   CMD wget -q -O /dev/null http://127.0.0.1:3000/api/health || exit 1
 
-# Migrar al BOOT del contenedor nuevo y arrancar el server standalone
-CMD ["sh", "-c", "node migrate.mjs && node server.js"]
+CMD ["sh", "-c", "mkdir -p /data/media && chown -R vocero:vocero /data && su-exec vocero node migrate.mjs && exec su-exec vocero node server.js"]


### PR DESCRIPTION
## Problema

En Coolify/Railway (y cualquier plataforma que monte un volumen nombrado en `/data`), el owner del punto de montaje se sobrescribe a `root:root` al montar, ignorando el `chown -R vocero:vocero /data` que hace la imagen en el build.

Como el proceso corre como usuario `vocero`, los adjuntos entrantes fallan al guardarse en disco:

```
[media] descarga del asset ma_gyx3rbgf6u6rhem08xqr falló: EACCES: permission denied, mkdir '/data/media'
[api] error no controlado: Error: EACCES: permission denied, mkdir '/data/media'
```

Efecto en la UI: todos los adjuntos aparecen como **"contenido no disponible"** — Meta los expira a los ~5 min de su lado, así que quedan irrecuperables incluso después de arreglar el permiso.

## Reproducir

Desplegar Vocero con un volumen nombrado montado en `/data` (setup típico en Coolify y Railway) y enviar cualquier imagen/audio/PDF al número WhatsApp conectado. En logs aparece el `EACCES`, en la bandeja aparece "contenido no disponible".

## Fix

- Instalar `su-exec` en la imagen alpine
- Quitar la instrucción `USER vocero` para que el contenedor arranque como root
- En el `CMD`, aplicar `mkdir -p /data/media && chown -R vocero:vocero /data` (idempotente) y bajar a `vocero` con `su-exec` antes de correr `migrate.mjs` y `server.js`
- Se usa `exec su-exec vocero node server.js` para que Node reciba las señales del contenedor directamente

## Efecto

Los adjuntos entrantes se persisten correctamente y la bandeja los renderiza con el `<img>`/`<video>`/`<audio>` que ya existe en el frontend.