### PR TITLE
fix(templates): sincronizar importa plantillas creadas fuera de la UI

### DIFF
--- a/src/server/whatsapp/templates.ts
+++ b/src/server/whatsapp/templates.ts
@@ -186,7 +186,16 @@ export async function syncTemplates(organizationId: string): Promise<number> {
   }
 
   let data: {
-    data?: { id?: string; name?: string; language?: string; status?: string; category?: string; quality_score?: unknown; rejected_reason?: string }[];
+    data?: {
+      id?: string;
+      name?: string;
+      language?: string;
+      status?: string;
+      category?: string;
+      quality_score?: unknown;
+      rejected_reason?: string;
+      components?: { type?: string; text?: string }[];
+    }[];
   };
   try {
     data = await graphRequest(`${creds.wabaId}/message_templates`, {
@@ -218,10 +227,35 @@ export async function syncTemplates(organizationId: string): Promise<number> {
         (remote.id && t.waTemplateId === remote.id) ||
         (t.name === remote.name && t.language === remote.language)
     );
-    if (!match) continue;
     // Meta reclasifica la categoría al aprobar (una UTILITY puede volverse
     // MARKETING, lo que cambia el costo por conversación): es autoridad.
-    const category = remote.category ?? match.category;
+    const category = remote.category ?? match?.category ?? "UTILITY";
+
+    if (!match) {
+      // Plantilla creada directamente en Meta (vía Graph API o WhatsApp
+      // Manager) sin pasar por Vocero: la importamos para que aparezca en
+      // la UI y se pueda enviar desde el composer. El body se reconstruye
+      // desde el componente BODY (si trae header/footer/buttons, esos no
+      // se muestran en la UI pero se envían igual — Meta usa la plantilla
+      // aprobada de su lado).
+      if (!remote.name || !remote.language) continue;
+      const body =
+        remote.components?.find((c) => c.type === "BODY")?.text ?? "";
+      await db.insert(schema.template).values({
+        id: newId("template"),
+        organizationId,
+        name: remote.name,
+        language: remote.language,
+        category,
+        body,
+        status,
+        rejectionReason: remote.rejected_reason ?? null,
+        waTemplateId: remote.id ?? null,
+      });
+      updated += 1;
+      continue;
+    }
+
     if (match.status === status && match.category === category) continue;
     await db
       .update(schema.template)


### PR DESCRIPTION
## Problema

`syncTemplates` en `src/server/whatsapp/templates.ts` recorre las plantillas remotas en Meta y para cada una busca un match local (por `waTemplateId` o por `name + language`). Cuando no encuentra el match hace `continue` — así que plantillas creadas directamente por Graph API o desde WhatsApp Manager **nunca aparecen** en la lista local, aunque Meta las tenga aprobadas.

## Escenario común (visto en producción)

La UI de Vocero solo permite crear plantillas de **texto puro** (body sin header/footer/buttons). Cuando una agencia necesita:
- Plantilla con **header DOCUMENT** para adjuntar catálogo PDF
- Plantilla con **header IMAGE** para banner promocional
- Plantilla con **buttons** de CTA

Tiene que crearla por Graph API directa o desde WhatsApp Manager. Luego, cuando el operador clickea *"Sincronizar"* en Vocero esperando verla en la bandeja, **la plantilla nunca aparece** — el sync la trae de Meta, no la encuentra local, y la descarta con `continue` en silencio.

En Bahari se creó por API una plantilla `catalogo_havaianas` con document header (PDF del catálogo Havaianas). Sync corrió, dijo `{updated: 0}`, la plantilla nunca apareció en la UI. Debug del código reveló el bug.

## Fix

Cuando no hay match local pero la remota tiene `name + language + status` mapeable, insertar la plantilla en `schema.template`:
- `name`, `language`, `category`, `status` del remoto
- `body` reconstruido desde el componente `BODY` (los headers/footers/buttons no se guardan localmente)
- `waTemplateId` para futuras actualizaciones

Cuando el operador la envíe desde el composer, Meta usa la versión aprobada de su lado con los componentes completos, así que el mensaje sale bien con el header/footer/buttons — la preview de la UI solo muestra el body, que es lo que Vocero renderiza actualmente.

## Efecto

El sync se vuelve **simétrico**: cualquier plantilla aprobada en Meta aparece en la bandeja para poder enviarse desde el composer, independientemente de dónde fue creada.

Cambio localizado en el loop de `syncTemplates`, ~30 líneas.

## Consideración de diseño (a evaluar por el maintainer)

La UI de crear plantilla sigue soportando solo texto puro — este fix no cambia eso, solo el flujo de importación. Si en el futuro se quiere que la UI muestre indicador de "tiene header DOCUMENT" al enviar, se puede persistir también un `metadata` con los componentes remotos. En este PR se mantuvo el cambio mínimo para no ampliar el schema.