### PR TITLE
3 mejoras operativas: reaping de casos del Lab, logger JSON y export de datos

### DIFF
--- a/src/app/(app)/settings/data/page.tsx
+++ b/src/app/(app)/settings/data/page.tsx
@@ -1,0 +1,7 @@
+import { DataClient } from "@/components/settings/data-client";
+
+export const dynamic = "force-dynamic";
+
+export default function DataSettingsPage() {
+  return <DataClient />;
+}

--- a/src/app/api/bot/reset/route.ts
+++ b/src/app/api/bot/reset/route.ts
@@ -5,6 +5,9 @@ import { apiError, parseBody } from "@/lib/api";
 import { requireBotKey, resolveInstanceOrg } from "@/server/bot/auth";
 import { publish } from "@/server/events/bus";
 import { moveLeadToStage } from "@/server/leads/stage-history";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("bot/reset");
 
 export const dynamic = "force-dynamic";
 
@@ -86,7 +89,7 @@ export async function POST(req: Request) {
       });
     }
   } catch (err) {
-    console.warn(`[bot/reset] reinicio de etapa falló: ${err}`);
+    log.warn("reinicio de etapa falló", { err });
   }
 
   publish(organizationId, {

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -1,0 +1,36 @@
+import { withAuth } from "@/lib/api";
+import { buildOrganizationExport } from "@/server/export/org-export";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("export");
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/export — dump JSON de los datos del negocio de la sesión.
+ * Solo lectura, solo la organización autenticada. Sin credenciales y sin
+ * datos de prueba del Laboratorio (ver org-export.ts).
+ *
+ * Se sirve siempre como adjunto con nombre fechado: el botón de Ajustes lo
+ * descarga con un <a href> plano, sin fetch/JS extra.
+ */
+export const GET = withAuth(async (session) => {
+  try {
+    const dump = await buildOrganizationExport(session.organizationId);
+    const body = JSON.stringify(dump, null, 2);
+    const date = new Date().toISOString().slice(0, 10);
+    return new Response(body, {
+      status: 200,
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+        "content-disposition": `attachment; filename="vocero-export-${date}.json"`,
+      },
+    });
+  } catch (err) {
+    log.error("export falló", { err });
+    return Response.json(
+      { error: { code: "export_failed", message: "No se pudo generar el export" } },
+      { status: 500 }
+    );
+  }
+});

--- a/src/app/api/webhooks/ig/[webhookToken]/route.ts
+++ b/src/app/api/webhooks/ig/[webhookToken]/route.ts
@@ -11,6 +11,9 @@ import {
   channelDisabledResponse,
   isChannelEnabled,
 } from "@/server/channels/enabled";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("ig");
 
 /**
  * 014 — Webhook público del canal de Instagram.
@@ -98,7 +101,7 @@ export async function POST(req: Request, { params }: Params) {
         await processZernioEvent(payload);
       }
     } catch (err) {
-      console.error("[ig] error procesando payload:", err);
+      log.error("error procesando payload", { err });
     }
   });
 

--- a/src/app/api/webhooks/wa/[webhookToken]/route.ts
+++ b/src/app/api/webhooks/wa/[webhookToken]/route.ts
@@ -7,6 +7,9 @@ import {
 } from "@/server/inbox/webhook";
 import { processEchoesValue, processMessagesValue } from "@/server/inbox/ingest";
 import { processTemplateStatusValue } from "@/server/whatsapp/template-events";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("webhook");
 
 /**
  * Webhook público de WhatsApp (contrato webhook.md).
@@ -61,7 +64,7 @@ export async function POST(req: Request, { params }: Params) {
     try {
       await processPayload(payload);
     } catch (err) {
-      console.error("[webhook] error procesando payload:", err);
+      log.error("error procesando payload", { err });
     }
   });
 

--- a/src/components/settings/data-client.tsx
+++ b/src/components/settings/data-client.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+import { Download } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+/**
+ * Tus datos son tuyos: descarga completa del negocio en un JSON. Sin
+ * credenciales y sin las conversaciones de prueba del Laboratorio.
+ */
+export function DataClient() {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function download() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/export");
+      if (!res.ok) {
+        setError("No se pudo generar el export. Revisa los logs del servidor.");
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `vocero-export-${new Date().toISOString().slice(0, 10)}.json`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch {
+      setError("No se pudo generar el export. Revisa los logs del servidor.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="max-w-2xl space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Exportar tus datos</CardTitle>
+          <CardDescription>
+            Descarga un JSON con TODO lo de tu negocio: contactos, leads con su
+            etapa, conversaciones completas con sus mensajes, citas y corridas
+            del Laboratorio. Sin credenciales de WhatsApp u otros conectores
+            (esos secretos no salen del servidor) y sin las conversaciones de
+            prueba.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Button onClick={download} disabled={busy}>
+            <Download className="mr-2 size-4" />
+            {busy ? "Generando…" : "Descargar export (JSON)"}
+          </Button>
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          <p className="text-xs text-muted-foreground">
+            El archivo se genera al vuelo con los datos de este momento.
+            Guárdalo en un lugar seguro: contiene el historial completo de tus
+            conversaciones.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/settings/settings-nav.tsx
+++ b/src/components/settings/settings-nav.tsx
@@ -11,6 +11,7 @@ const TABS: Tab[] = [
   { href: "/settings/branding", label: "Marca" },
   { href: "/settings/templates", label: "Plantillas" },
   { href: "/settings/team", label: "Equipo" },
+  { href: "/settings/data", label: "Datos" },
 ];
 
 /** 015 — "Agenda" solo existe si esta instancia encendió la bandera. */

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -1,9 +1,15 @@
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { getDb, schema } from "@/lib/db";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("boot");
 
 /**
  * Limpieza al arranque (FR-034): corridas del Laboratorio que quedaron
- * "running" tras un reinicio → fallidas. Solo corre en el runtime Node.
+ * "running" tras un reinicio → fallidas, con SUS casos individuales
+ * sacados de pending/running (si no, la UI del Lab muestra personas
+ * "corriendo" para siempre en una corrida que ya no existe en memoria).
+ * Solo corre en el runtime Node.
  */
 export async function cleanupOrphanRuns(): Promise<void> {
   try {
@@ -18,12 +24,25 @@ export async function cleanupOrphanRuns(): Promise<void> {
       .where(eq(schema.agentTestRun.status, "running"))
       .returning({ id: schema.agentTestRun.id });
     if (updated.length > 0) {
-      console.log(
-        `[boot] ${updated.length} corrida(s) del Laboratorio huérfana(s) marcada(s) como fallida(s)`
-      );
+      // Los casos quedan judge_failed: con el enum cerrado
+      // [pending, running, done, judge_failed] es el único estado terminal
+      // que ya usa la UI para "sin veredicto", y computeScore lo excluye
+      // del denominador — una corrida interrumpida no infla ni hunde el score.
+      await db
+        .update(schema.agentTestCase)
+        .set({ status: "judge_failed" })
+        .where(
+          inArray(
+            schema.agentTestCase.runId,
+            updated.map((r) => r.id)
+          )
+        );
+      log.info("corridas del Laboratorio huérfanas marcadas como fallidas", {
+        count: updated.length,
+      });
     }
   } catch (err) {
     // La BD puede no estar lista aún (migraciones corren antes del server).
-    console.error("[boot] limpieza de corridas huérfanas falló:", err);
+    log.error("limpieza de corridas huérfanas falló", { err });
   }
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 import { requireSession, UnauthorizedError, type SessionContext } from "@/lib/auth/session";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("api");
 
 /** Respuesta de error estándar de la API interna (contrato api.md). */
 export function apiError(
@@ -30,7 +33,7 @@ export function withAuth<Args extends unknown[]>(
     try {
       return await handler(session, ...args);
     } catch (err) {
-      console.error("[api] error no controlado:", err);
+      log.error("error no controlado", { err });
       return apiError(500, "internal", "Error interno");
     }
   };

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,81 @@
+/**
+ * Logger estructurado de una línea de JSON por evento (zero-dependency).
+ *
+ * Por qué existe: el núcleo logueaba con `console.*` plano, así que un
+ * operador self-hosted no podía greppear por nivel ni ingerir los logs en
+ * Loki/Docker sin parsear texto libre. Este módulo emite JSON en stdout
+ * (donde `docker logs` / Coolify ya recogen), sin dependencias nuevas ni
+ * servicios externos — la soberanía del núcleo queda intacta.
+ *
+ * Contrato:
+ * - `logger.info("webhook", { id })` →
+ *   `{"ts":"…","level":"info","scope":"webhook","msg":"…","id":"…"}`
+ * - Campos extra van aplanados al objeto raíz (no anidados bajo "data").
+ * - `err` es la clave reservada para errores: se serializa con mensaje y
+ *   stack recortado, jamás el objeto completo (que en Node vota [object Object]).
+ * - LOG_LEVEL (opcional): debug | info | warn | error (default info).
+ *   Sin variable, todo excepto debug se emite — cero configuración para
+ *   operar, como el resto de las banderas del proyecto.
+ */
+
+const LEVELS = { debug: 10, info: 20, warn: 30, error: 40 } as const;
+
+type Level = keyof typeof LEVELS;
+
+function configuredLevel(): number {
+  const raw = process.env.LOG_LEVEL?.toLowerCase();
+  if (raw && raw in LEVELS) return LEVELS[raw as Level];
+  return LEVELS.info;
+}
+
+/** Stack a string corto: las primeras líneas bastan para ubicar el fallo. */
+function serializeError(err: unknown): string {
+  if (err instanceof Error) {
+    const stack = err.stack?.split("\n").slice(0, 6).join(" | ");
+    return stack ?? `${err.name}: ${err.message}`;
+  }
+  return String(err);
+}
+
+function emit(level: Level, scope: string, msg: string, extra?: Record<string, unknown>): void {
+  if (LEVELS[level] < configuredLevel()) return;
+  const entry: Record<string, unknown> = {
+    ts: new Date().toISOString(),
+    level,
+    scope,
+    msg,
+  };
+  if (extra) {
+    for (const [key, value] of Object.entries(extra)) {
+      entry[key] = key === "err" ? serializeError(value) : value;
+    }
+  }
+  // Una línea por evento: los recolectores parten por \n.
+  process.stdout.write(`${JSON.stringify(entry)}\n`);
+}
+
+export type Logger = {
+  debug: (msg: string, extra?: Record<string, unknown>) => void;
+  info: (msg: string, extra?: Record<string, unknown>) => void;
+  warn: (msg: string, extra?: Record<string, unknown>) => void;
+  error: (msg: string, extra?: Record<string, unknown>) => void;
+};
+
+/** Logger con scope fijo (`createLogger("webhook").warn(...)`) — el estilo [webhook] de antes, tipado. */
+export function createLogger(scope: string): Logger {
+  return {
+    debug: (msg, extra) => emit("debug", scope, msg, extra),
+    info: (msg, extra) => emit("info", scope, msg, extra),
+    warn: (msg, extra) => emit("warn", scope, msg, extra),
+    error: (msg, extra) => emit("error", scope, msg, extra),
+  };
+}
+
+/**
+ * Migra una llamada `console.warn("[scope] …", err)` a logger sin tocar el
+ * call-site más que el prefijo. Pensado para la transición: los archivos van
+ * migrando de a poco y ambos estilos conviven sin romper nada.
+ */
+export function logAt(level: Level, scope: string, msg: string, extra?: Record<string, unknown>): void {
+  emit(level, scope, msg, extra);
+}

--- a/src/server/agenda/service.ts
+++ b/src/server/agenda/service.ts
@@ -24,6 +24,9 @@ import {
 import { ConnectorError } from "@/server/agenda/connectors/types";
 import { moveLeadToStage } from "@/server/leads/stage-history";
 import { publish } from "@/server/events/bus";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("agenda");
 
 /**
  * 015 — Ciclo de vida de la cita y las dos reglas INNEGOCIABLES:
@@ -221,7 +224,7 @@ export async function createSessionBooking(input: {
   if (input.conversationId) {
     await clearOffers(input.organizationId, input.conversationId).catch(
       (err) => {
-        console.warn(`[agenda] no pude limpiar la oferta: ${err}`);
+        log.warn("no pude limpiar la oferta", { err });
       }
     );
   }
@@ -233,7 +236,7 @@ export async function createSessionBooking(input: {
     contactId,
     input.source === "ai" ? "bot" : "dueno"
   ).catch((err) => {
-    console.warn(`[agenda] avance de etapa falló: ${err}`);
+    log.warn("avance de etapa falló", { err });
   });
 
   publish(input.organizationId, {
@@ -546,9 +549,7 @@ async function deliverMeeting(
       linkPending: CONNECTOR_META[connectorId].perBookingLink && !meeting.joinUrl,
     });
   } catch (err) {
-    console.warn(
-      `[agenda] el conector ${connectorId} no pudo entregar la reunión: ${err}`
-    );
+    log.warn("el conector no pudo entregar la reunión", { connectorId, err });
     if (err instanceof ConnectorError && err.isAuthError) {
       await markConnectorAuthError(booking.organizationId, connectorId).catch(
         () => {}
@@ -605,7 +606,7 @@ async function withConnector(
     );
     await run(conn, booking.externalRef);
   } catch (err) {
-    console.warn(`[agenda] efecto en ${connectorId} falló: ${err}`);
+    log.warn("efecto en conector falló", { connectorId, err });
     if (err instanceof ConnectorError && err.isAuthError) {
       await markConnectorAuthError(booking.organizationId, connectorId).catch(
         () => {}
@@ -631,7 +632,7 @@ async function refreshOffer(
       FRESH_ALTERNATIVES
     );
   } catch (err) {
-    console.warn(`[agenda] no pude calcular alternativas: ${err}`);
+    log.warn("no pude calcular alternativas", { err });
     return [];
   }
   const offers: OfferedSlot[] = fresh.map((s) => ({
@@ -640,7 +641,7 @@ async function refreshOffer(
   }));
   if (conversationId && offers.length > 0) {
     await replaceOffers(organizationId, conversationId, offers).catch((err) => {
-      console.warn(`[agenda] no pude registrar la nueva oferta: ${err}`);
+      log.warn("no pude registrar la nueva oferta", { err });
     });
   }
   return offers;

--- a/src/server/ai/pipeline.ts
+++ b/src/server/ai/pipeline.ts
@@ -17,6 +17,9 @@ import {
 import { matchesHandoffIntent } from "@/server/ai/handoff";
 import { buildAgentSystemPrompt } from "@/server/ai/prompts";
 import { agendaEnabled } from "@/server/agenda/flag";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("agente");
 import { bookSlot, offerSlots } from "@/server/agenda/agent";
 
 /**
@@ -75,7 +78,7 @@ async function executeTurn(conversationId: string): Promise<void> {
   try {
     await runAgentTurn(conversationId);
   } catch (err) {
-    console.error("[agente] turno falló:", err);
+    log.error("turno falló", { err, conversationId });
   } finally {
     entry.running = false;
     if (entry.pending) {
@@ -169,7 +172,7 @@ export async function runAgentTurn(conversationId: string): Promise<void> {
   if (!result.ok) {
     if (result.error === "not_configured") return;
     // Fallo persistente del proveedor o salida imposible → escalar (FR-022).
-    console.error(`[agente] fallo del proveedor (raw): ${result.detail}`);
+    log.error("fallo del proveedor (raw)", { detail: result.detail });
     await applyHandoff(conversationId, organizationId, "error");
     return;
   }
@@ -205,7 +208,7 @@ export async function runAgentTurn(conversationId: string): Promise<void> {
         }
         return;
       } catch (err) {
-        console.error(`[agente] el motor de agenda falló: ${err}`);
+        log.error("el motor de agenda falló", { err, conversationId });
         action = degradeAction(action);
       }
     }

--- a/src/server/attribution/conversions.ts
+++ b/src/server/attribution/conversions.ts
@@ -7,6 +7,9 @@ import { getCredentialsByOrg } from "@/server/whatsapp/credentials";
 import { atribucionEnabled } from "@/server/attribution/flag";
 import { getCapiSettings } from "@/server/attribution/settings";
 import { getAttributionForConversation } from "@/server/attribution/store";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("capi");
 
 /**
  * 016 — Reporte de conversiones a Meta.
@@ -121,15 +124,13 @@ export async function emitConversion(
           error: err instanceof Error ? err.message : String(err),
         })
         .where(eq(schema.conversionEvent.id, event.id));
-      console.warn(
-        `[capi] fallo al reportar ${eventName} de ${conversationId}: ${err}`
-      );
+      log.warn("fallo al reportar conversión", { eventName, conversationId, err });
       return "failed";
     }
   } catch (err) {
     // Best-effort absoluto: ni siquiera un fallo de la base puede tumbar a
     // quien nos llamó (mover un lead de etapa).
-    console.warn(`[capi] emitConversion(${eventName}) falló: ${err}`);
+    log.warn("emitConversion falló", { eventName, err });
     return "error";
   }
 }
@@ -234,7 +235,7 @@ export async function reportStageChange(input: {
       { lead_stage: "qualified" }
     );
   } catch (err) {
-    console.warn(`[capi] reportStageChange(${input.leadId}) falló: ${err}`);
+    log.warn("reportStageChange falló", { leadId: input.leadId, err });
   }
 }
 

--- a/src/server/export/org-export.ts
+++ b/src/server/export/org-export.ts
@@ -1,0 +1,222 @@
+import { asc, inArray } from "drizzle-orm";
+import { getDb, schema } from "@/lib/db";
+import { scoped } from "@/lib/db/tenant";
+
+/**
+ * Export de los datos del negocio, por organización (franja "tus datos son
+ * tuyos"). Devuelve un objeto plano serializable a JSON: contactos, leads con
+ * su etapa, conversaciones con sus mensajes, etapas del pipeline, citas y
+ * corridas del Laboratorio.
+ *
+ * Qué NO se exporta, a propósito:
+ * - Credenciales (metaCredentials, instagramCredentials, zoom/google, capi):
+ *   secretos cifrados en reposo; un export que los revele sería un fuga, no
+ *   una copia de seguridad. El token de WhatsApp ni siquiera se muestra en la
+ *   UI completa — menos aún saldría en un dump.
+ * - Sesiones/usuarios/miembros: pertenecen a la plataforma, no al negocio.
+ * - Conversaciones del Laboratorio (isTest) y sus contactos sintéticos: son
+ *   artefactos de prueba, no datos del cliente.
+ *
+ * El dump es UNA respuesta JSON (no streaming): acotado por el tamaño real
+ * de una organización (miles de mensajes, no millones). Una instancia que
+ * crezca a tamaños donde esto duela ya necesita otra conversación.
+ */
+
+export type ExportContact = {
+  id: string;
+  name: string | null;
+  phone: string | null;
+  waIdentity: string | null;
+  channel: string;
+  notes: string | null;
+  ficha: Record<string, unknown> | null;
+  createdAt: string;
+};
+
+export type ExportLead = {
+  id: string;
+  contactId: string;
+  stage: string;
+  amountCents: number | null;
+  currency: string | null;
+  priority: string | null;
+  createdAt: string;
+};
+
+export type ExportMessage = {
+  id: string;
+  conversationId: string;
+  direction: string;
+  type: string;
+  text: string | null;
+  status: string;
+  waTimestamp: string | null;
+};
+
+export type ExportConversation = {
+  id: string;
+  contactId: string;
+  channel: string;
+  aiEnabled: boolean;
+  handoffReason: string | null;
+  createdAt: string;
+  messages: ExportMessage[];
+};
+
+export type ExportBooking = {
+  id: string;
+  conversationId: string | null;
+  kind: string;
+  scheduledAt: string;
+  status: string;
+  createdAt: string;
+};
+
+export type ExportRun = {
+  id: string;
+  status: string;
+  score: number | null;
+  startedAt: string;
+  finishedAt: string | null;
+};
+
+export type OrganizationExport = {
+  exportedAt: string;
+  version: number;
+  stages: { id: string; name: string; position: number }[];
+  contacts: ExportContact[];
+  leads: ExportLead[];
+  conversations: ExportConversation[];
+  bookings: ExportBooking[];
+  labRuns: ExportRun[];
+};
+
+const iso = (d: Date | null): string | null => (d ? d.toISOString() : null);
+
+/** Construye el dump completo de la organización. Solo lectura. */
+export async function buildOrganizationExport(
+  organizationId: string
+): Promise<OrganizationExport> {
+  const db = getDb();
+
+  const stages = await db
+    .select()
+    .from(schema.pipelineStage)
+    .where(scoped(schema.pipelineStage.organizationId, organizationId))
+    .orderBy(asc(schema.pipelineStage.position));
+
+  const contacts = await db
+    .select()
+    .from(schema.contact)
+    .where(scoped(schema.contact.organizationId, organizationId))
+    .orderBy(asc(schema.contact.createdAt));
+
+  // Los contactos sintéticos del Laboratorio viajan ARCHIVADOS y con teléfono
+  // prefijado; se excluyen aquí para no entregar datos de prueba como si
+  // fueran del negocio.
+  const realContacts = contacts.filter((c) => !c.archivedAt);
+
+  const leads = await db
+    .select()
+    .from(schema.lead)
+    .where(scoped(schema.lead.organizationId, organizationId))
+    .orderBy(asc(schema.lead.createdAt));
+
+  const conversations = await db
+    .select()
+    .from(schema.conversation)
+    .where(scoped(schema.conversation.organizationId, organizationId))
+    .orderBy(asc(schema.conversation.createdAt));
+
+  const realConversations = conversations.filter((c) => !c.isTest);
+
+  const messages = realConversations.length
+    ? await db
+        .select()
+        .from(schema.message)
+        .where(
+          inArray(
+            schema.message.conversationId,
+            realConversations.map((c) => c.id)
+          )
+        )
+        .orderBy(asc(schema.message.createdAt))
+    : [];
+
+  const bookings = await db
+    .select()
+    .from(schema.booking)
+    .where(scoped(schema.booking.organizationId, organizationId))
+    .orderBy(asc(schema.booking.createdAt));
+
+  const labRuns = await db
+    .select()
+    .from(schema.agentTestRun)
+    .where(scoped(schema.agentTestRun.organizationId, organizationId))
+    .orderBy(asc(schema.agentTestRun.startedAt));
+
+  const stageName = new Map(stages.map((s) => [s.id, s.name]));
+
+  return {
+    exportedAt: new Date().toISOString(),
+    version: 1,
+    stages: stages.map((s) => ({
+      id: s.id,
+      name: s.name,
+      position: s.position,
+    })),
+    contacts: realContacts.map((c) => ({
+      id: c.id,
+      name: c.name,
+      phone: c.phone,
+      waIdentity: c.waIdentity,
+      channel: c.channel,
+      notes: c.notes,
+      ficha: c.ficha,
+      createdAt: c.createdAt.toISOString(),
+    })),
+    leads: leads.map((l) => ({
+      id: l.id,
+      contactId: l.contactId,
+      stage: stageName.get(l.stageId) ?? l.stageId,
+      amountCents: l.amountCents,
+      currency: l.currency,
+      priority: l.priority,
+      createdAt: l.createdAt.toISOString(),
+    })),
+    conversations: realConversations.map((c) => ({
+      id: c.id,
+      contactId: c.contactId,
+      channel: c.channel,
+      aiEnabled: c.aiEnabled,
+      handoffReason: c.handoffReason,
+      createdAt: c.createdAt.toISOString(),
+      messages: messages
+        .filter((m) => m.conversationId === c.id)
+        .map((m) => ({
+          id: m.id,
+          conversationId: m.conversationId,
+          direction: m.direction,
+          type: m.type,
+          text: m.text,
+          status: m.status,
+          waTimestamp: iso(m.waTimestamp),
+        })),
+    })),
+    bookings: bookings.map((b) => ({
+      id: b.id,
+      conversationId: b.conversationId,
+      kind: b.kind,
+      scheduledAt: b.scheduledAt.toISOString(),
+      status: b.status,
+      createdAt: b.createdAt.toISOString(),
+    })),
+    labRuns: labRuns.map((r) => ({
+      id: r.id,
+      status: r.status,
+      score: r.score,
+      startedAt: r.startedAt.toISOString(),
+      finishedAt: iso(r.finishedAt),
+    })),
+  };
+}

--- a/src/server/inbox/ingest.ts
+++ b/src/server/inbox/ingest.ts
@@ -21,6 +21,9 @@ import { atribucionEnabled } from "@/server/attribution/flag";
 import { recordAttribution } from "@/server/attribution/store";
 import { onLeadActivity } from "@/server/inbox/lead-activity";
 import { maybeRunAgentTurn } from "@/server/ai/trigger";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("webhook");
 
 /** Tipos de contenido soportados; el resto se ignora sin error. */
 const SUPPORTED_TYPES = new Set([
@@ -139,7 +142,7 @@ async function attachMediaAsset(
     }
     return asset;
   } catch (err) {
-    console.warn(`[media] no se pudo registrar el adjunto de ${messageId}:`, err);
+    log.warn("no se pudo registrar el adjunto", { messageId, err });
     return null;
   }
 }
@@ -219,9 +222,9 @@ export async function processMessagesValue(value: WebhookValue): Promise<void> {
   if (!credentials) {
     // Caso típico: webhook/override configurado ANTES de guardar la conexión
     // en el wizard — el evento llega pero no hay a qué organización enrutarlo.
-    console.warn(
-      `[webhook] evento para phone_number_id desconocido (${phoneNumberId}): ` +
-        "guarda la conexión en Configuración → WhatsApp para recibir mensajes"
+    log.warn(
+      "evento para phone_number_id desconocido — guarda la conexión en Configuración → WhatsApp para recibir mensajes",
+      { phoneNumberId }
     );
     return;
   }
@@ -238,9 +241,9 @@ export async function processMessagesValue(value: WebhookValue): Promise<void> {
     if (!resolved) {
       // Mensaje sin NINGUNA identidad utilizable (ni teléfono ni BSUID):
       // registrar y descartar — jamás reventar el webhook (003).
-      console.warn(
-        `[webhook] mensaje ${msg.id} sin identidad utilizable (sin from ni from_user_id): descartado`
-      );
+      log.warn("mensaje sin identidad utilizable (sin from ni from_user_id): descartado", {
+        messageId: msg.id,
+      });
       continue;
     }
     await ingestInboundMessage({
@@ -268,9 +271,7 @@ export async function processEchoesValue(value: WebhookValue): Promise<void> {
 
   const credentials = await getCredentialsByPhoneNumberId(phoneNumberId);
   if (!credentials) {
-    console.warn(
-      `[webhook] echo para phone_number_id desconocido (${phoneNumberId}): descartado`
-    );
+    log.warn("echo para phone_number_id desconocido: descartado", { phoneNumberId });
     return;
   }
 
@@ -279,14 +280,14 @@ export async function processEchoesValue(value: WebhookValue): Promise<void> {
   for (const echo of echoes) {
     if (!SUPPORTED_TYPES.has(echo.type)) continue;
     if (!echo.to) {
-      console.warn(`[webhook] echo ${echo.id} sin destinatario: descartado`);
+      log.warn("echo sin destinatario: descartado", { echoId: echo.id });
       continue;
     }
     try {
       await ingestManualEcho(credentials.organizationId, echo);
     } catch (err) {
       // Un echo malformado jamás tumba el webhook (edge case del spec).
-      console.error(`[webhook] error procesando echo ${echo.id}:`, err);
+      log.error("error procesando echo", { echoId: echo.id, err });
     }
   }
 }
@@ -357,9 +358,9 @@ async function ingestManualEcho(
     )
     .returning();
   if (paused[0]) {
-    console.log(
-      `[webhook] respuesta manual del dueño en ${conversation.id} — IA pausada (manual_reply)`
-    );
+    log.info("respuesta manual del dueño — IA pausada (manual_reply)", {
+      conversationId: conversation.id,
+    });
   }
 
   publish(organizationId, {

--- a/src/server/instagram/ingest.ts
+++ b/src/server/instagram/ingest.ts
@@ -5,6 +5,9 @@ import {
   getInstagramCredentialsByAccountRef,
   getInstagramCredentialsByIgUserId,
 } from "@/server/instagram/credentials";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("ig");
 
 /**
  * 014 — Adaptadores de entrada del canal de Instagram.
@@ -78,9 +81,9 @@ export async function processZernioEvent(payload: unknown): Promise<void> {
 
   const creds = await getInstagramCredentialsByAccountRef(accountRef);
   if (!creds) {
-    console.warn(
-      `[ig] evento para accountId desconocido (${accountRef}): ` +
-        "guarda la conexion en Configuracion -> Instagram para recibir mensajes"
+    log.warn(
+      "evento para accountId desconocido — guarda la conexion en Configuracion -> Instagram para recibir mensajes",
+      { accountRef }
     );
     return;
   }
@@ -88,22 +91,22 @@ export async function processZernioEvent(payload: unknown): Promise<void> {
     // Defensa en profundidad: esta instancia no habla con Zernio, asi que un
     // payload con su forma no puede ser legitimo aunque llegue por la URL
     // correcta. Sin esto, la unica barrera de la forma ajena es la URL.
-    console.warn(
-      `[ig] payload de Zernio en una instancia configurada como '${creds.source}': descartado`
-    );
+    log.warn("payload de Zernio en instancia con otra fuente: descartado", {
+      source: creds.source,
+    });
     return;
   }
 
   const igsid = evt.message?.sender?.id;
   if (!igsid) {
-    console.warn(`[ig] evento ${evt.id ?? "?"} sin sender.id: descartado`);
+    log.warn("evento sin sender.id: descartado", { eventId: evt.id ?? null });
     return;
   }
 
   const text = evt.message?.text ?? null;
   const platformMessageId = evt.message?.id;
   if (!platformMessageId) {
-    console.warn(`[ig] evento ${evt.id ?? "?"} sin id de mensaje: descartado`);
+    log.warn("evento sin id de mensaje: descartado", { eventId: evt.id ?? null });
     return;
   }
 
@@ -160,9 +163,9 @@ export async function processMetaInstagramPayload(
 
     const creds = await getInstagramCredentialsByIgUserId(igUserId);
     if (!creds) {
-      console.warn(
-        `[ig] evento para IG_ID desconocido (${igUserId}): ` +
-          "guarda la conexion en Configuracion -> Instagram para recibir mensajes"
+      log.warn(
+        "evento para IG_ID desconocido — guarda la conexion en Configuracion -> Instagram para recibir mensajes",
+        { igUserId }
       );
       continue;
     }
@@ -170,9 +173,9 @@ export async function processMetaInstagramPayload(
       // Idem: sin app propia de Meta, un payload con su forma no puede venir
       // de Meta. Cierra la inyeccion en instancias que solo usan Zernio, donde
       // META_APP_SECRET no existe y la firma no se puede verificar.
-      console.warn(
-        `[ig] payload de Meta en una instancia configurada como '${creds.source}': descartado`
-      );
+      log.warn("payload de Meta en instancia con otra fuente: descartado", {
+        source: creds.source,
+      });
       continue;
     }
 

--- a/src/server/lab/judge.ts
+++ b/src/server/lab/judge.ts
@@ -1,10 +1,9 @@
 import { z } from "zod";
 import { chatJson } from "@/lib/ai";
-
+import { buildJudgePrompt } from "@/server/ai/prompts";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("lab");
-import { buildJudgePrompt } from "@/server/ai/prompts";
 
 /** Veredicto estructurado del juez (FR-032, contrato ai.md). */
 export const Verdict = z.object({

--- a/src/server/lab/judge.ts
+++ b/src/server/lab/judge.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
 import { chatJson } from "@/lib/ai";
+
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("lab");
 import { buildJudgePrompt } from "@/server/ai/prompts";
 
 /** Veredicto estructurado del juez (FR-032, contrato ai.md). */
@@ -50,9 +54,11 @@ export async function judgeCase(input: {
   if (!result.ok) {
     // Diagnóstico operativo: el caso queda visible como judge_failed y aquí
     // queda el porqué (incluye el raw= truncado del proveedor).
-    console.error(
-      `[lab] juez falló para ${input.personaKey}: ${result.error} — ${result.detail}`
-    );
+    log.error("juez falló", {
+      persona: input.personaKey,
+      error: result.error,
+      detail: result.detail,
+    });
     return { status: "judge_failed", detail: result.detail };
   }
   return { status: "done", verdict: result.data };

--- a/src/server/lab/runner.ts
+++ b/src/server/lab/runner.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, inArray } from "drizzle-orm";
 import { getDb, schema } from "@/lib/db";
 import { newId } from "@/lib/db/ids";
 import { publish } from "@/server/events/bus";
@@ -6,6 +6,9 @@ import { runAgentTurn } from "@/server/ai/pipeline";
 import { renderKb } from "@/server/ai/prompts";
 import { computeScore, judgeCase } from "@/server/lab/judge";
 import { PERSONAS, type Persona } from "@/server/lab/personas";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("lab");
 
 /**
  * Runner del Laboratorio (FR-030/FR-034): corrida en segundo plano DENTRO del
@@ -51,7 +54,7 @@ export async function startRun(organizationId: string): Promise<string> {
 
   // Fire-and-forget in-process: el POST regresa ya; el progreso va por SSE.
   void executeRun(runId, organizationId).catch(async (err) => {
-    console.error("[lab] corrida falló:", err);
+    log.error("corrida falló", { err });
     await failRun(runId, organizationId, String(err));
   });
 
@@ -282,6 +285,18 @@ async function failRun(
     .update(schema.agentTestRun)
     .set({ status: "failed", error, finishedAt: new Date() })
     .where(eq(schema.agentTestRun.id, runId));
+  // Los casos sin terminar no quedan "running" para siempre: mismo estado
+  // terminal que usa el arranque para corridas huérfanas (ver
+  // instrumentation-node.ts). computeScore ya excluye judge_failed.
+  await db
+    .update(schema.agentTestCase)
+    .set({ status: "judge_failed" })
+    .where(
+      and(
+        eq(schema.agentTestCase.runId, runId),
+        inArray(schema.agentTestCase.status, ["pending", "running"])
+      )
+    );
   publishProgress(organizationId, runId, "failed", 0, PERSONAS.length);
 }
 

--- a/src/server/whatsapp/connect.ts
+++ b/src/server/whatsapp/connect.ts
@@ -1,4 +1,7 @@
 import { graphRequest, MetaApiError } from "@/lib/meta/client";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("connect");
 
 export type ConnectionCheck =
   | {
@@ -75,9 +78,6 @@ export async function subscribeAppToWaba(
       token,
     });
   } catch (err) {
-    console.warn(
-      "[connect] subscribed_apps falló (esperado en modo agencia):",
-      err instanceof Error ? err.message : err
-    );
+    log.warn("subscribed_apps falló (esperado en modo agencia)", { err });
   }
 }

--- a/src/server/whatsapp/media.ts
+++ b/src/server/whatsapp/media.ts
@@ -8,6 +8,9 @@ import {
   getCredentialsByOrg,
   type Credentials,
 } from "@/server/whatsapp/credentials";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("media");
 
 /**
  * 008 — Única frontera de media con la Graph API (constitución II: todo el
@@ -227,7 +230,7 @@ export async function ensureAssetAvailable(
       .update(schema.mediaAsset)
       .set({ fetchStatus: "failed", fetchError: message, updatedAt: new Date() })
       .where(eq(schema.mediaAsset.id, assetId));
-    console.warn(`[media] descarga del asset ${assetId} falló: ${message}`);
+    log.warn("descarga del asset falló", { assetId, message });
     return null;
   }
 }

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * El logger estructurado: una línea de JSON por evento, nivel filtrable por
+ * LOG_LEVEL, y `err` serializado a string (un Error crudo en JSON se vuelve
+ * {} — el caso de uso número uno de "log inútil en producción").
+ */
+
+const writes: string[] = [];
+import { createLogger } from "@/lib/logger";
+
+function lines(): Record<string, unknown>[] {
+  return writes.map((w) => JSON.parse(w) as Record<string, unknown>);
+}
+
+describe("createLogger", () => {
+  afterEach(() => {
+    writes.length = 0;
+    delete process.env.LOG_LEVEL;
+  });
+
+  it("emite una línea JSON con ts/level/scope/msg y campos aplanados", () => {
+    const spy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(((chunk: string | Uint8Array) => {
+        writes.push(typeof chunk === "string" ? chunk : "");
+        return true;
+      }) as typeof process.stdout.write);
+    const log = createLogger("webhook");
+    log.warn("echo sin destinatario", { echoId: "wamid.X" });
+    spy.mockRestore();
+
+    const entry = lines()[0]!;
+    expect(entry).toMatchObject({
+      level: "warn",
+      scope: "webhook",
+      msg: "echo sin destinatario",
+      echoId: "wamid.X",
+    });
+    expect(typeof entry.ts).toBe("string");
+  });
+
+  it("serializa `err` (Error) a string con mensaje — no a {}", () => {
+    const spy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(((chunk: string | Uint8Array) => {
+        writes.push(typeof chunk === "string" ? chunk : "");
+        return true;
+      }) as typeof process.stdout.write);
+    const log = createLogger("lab");
+    log.error("corrida falló", { err: new Error("timeout de 10 minutos") });
+    spy.mockRestore();
+
+    const entry = lines()[0]!;
+    expect(entry.err).toBeTypeOf("string");
+    expect(entry.err as string).toContain("timeout de 10 minutos");
+  });
+
+  it("LOG_LEVEL=error silencia info y warn", () => {
+    process.env.LOG_LEVEL = "error";
+    const spy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(((chunk: string | Uint8Array) => {
+        writes.push(typeof chunk === "string" ? chunk : "");
+        return true;
+      }) as typeof process.stdout.write);
+    const log = createLogger("x");
+    log.debug("d");
+    log.info("i");
+    log.warn("w");
+    log.error("e");
+    spy.mockRestore();
+
+    const levels = lines().map((l) => l.level);
+    expect(levels).toEqual(["error"]);
+  });
+});

--- a/tests/unit/org-export.test.ts
+++ b/tests/unit/org-export.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Export de datos por organización ("tus datos son tuyos"):
+ * - incluye contactos, leads, conversaciones REALES con mensajes, citas y
+ *   corridas del Lab;
+ * - excluye contactos archivados (los sintéticos del Laboratorio) y las
+ *   conversaciones is_test;
+ * - nunca consulta tablas de credenciales: el mock de schema REVIENTA si el
+ *   export intenta tocarlas — la privacidad se prueba por construcción.
+ */
+
+const tables = vi.hoisted(() => new Map<string, Record<string, unknown>[]>());
+
+vi.mock("@/lib/db", () => ({
+  getDb: () => ({
+    select: () => ({
+      from: (t: { col?: string }) => ({
+        where: () => ({
+          orderBy: () => Promise.resolve(tables.get(t.col ?? "?") ?? []),
+        }),
+      }),
+    }),
+  }),
+  schema: new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const name = String(prop);
+        if (/credentials/i.test(name)) {
+          throw new Error(`el export NO debe tocar la tabla ${name}`);
+        }
+        return { col: name };
+      },
+    }
+  ),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (a: unknown, b: unknown) => ({ op: "eq", a, b }),
+  inArray: (a: unknown, b: unknown) => ({ op: "inArray", a, b }),
+  asc: (c: unknown) => ({ asc: c }),
+}));
+
+vi.mock("@/lib/db/tenant", () => ({
+  scoped: (col: unknown, org: string) => ({ op: "scoped", col, org }),
+}));
+
+import { buildOrganizationExport } from "@/server/export/org-export";
+
+const d = (n: number) => new Date(Date.UTC(2026, 7, n));
+
+describe("buildOrganizationExport", () => {
+  beforeEach(() => {
+    tables.clear();
+  });
+
+  it("arma el dump completo y excluye lo sintético del Laboratorio", async () => {
+    tables.set("pipelineStage", [
+      { id: "st_new", name: "Nuevo", position: 0 },
+    ]);
+    tables.set("contact", [
+      { id: "ct_1", name: "Ana", phone: "57300111", waIdentity: "57300111", channel: "whatsapp", notes: null, ficha: null, archivedAt: null, createdAt: d(1) },
+      // contacto sintético del Lab (archivado): NO debe salir
+      { id: "ct_test", name: "[Prueba] Comprador", phone: "5210000000001", waIdentity: "5210000000001", channel: "whatsapp", notes: null, ficha: null, archivedAt: d(2), createdAt: d(2) },
+    ]);
+    tables.set("lead", [
+      { id: "ld_1", contactId: "ct_1", stageId: "st_new", amountCents: 150000, currency: "COP", priority: "alta", createdAt: d(1) },
+    ]);
+    tables.set("conversation", [
+      { id: "cv_1", contactId: "ct_1", channel: "whatsapp", aiEnabled: true, handoffReason: null, isTest: false, createdAt: d(1) },
+      // conversación de prueba: NO debe salir (ni consultar sus mensajes)
+      { id: "cv_test", contactId: "ct_test", channel: "whatsapp", aiEnabled: true, handoffReason: null, isTest: true, createdAt: d(2) },
+    ]);
+    tables.set("message", [
+      { id: "m1", conversationId: "cv_1", direction: "in", type: "text", text: "hola", status: "delivered", waTimestamp: d(1), createdAt: d(1) },
+    ]);
+    tables.set("booking", [
+      { id: "bk_1", conversationId: "cv_1", kind: "session", scheduledAt: d(3), status: "agendada", createdAt: d(1) },
+    ]);
+    tables.set("agentTestRun", [
+      { id: "run_1", status: "done", score: 83, startedAt: d(1), finishedAt: d(1) },
+    ]);
+
+    const dump = await buildOrganizationExport("org_1");
+
+    expect(dump.version).toBe(1);
+    expect(dump.contacts.map((c) => c.id)).toEqual(["ct_1"]);
+    expect(dump.leads[0]?.stage).toBe("Nuevo"); // nombre de etapa, no id
+    expect(dump.leads[0]?.amountCents).toBe(150000);
+    expect(dump.conversations.map((c) => c.id)).toEqual(["cv_1"]);
+    expect(dump.conversations[0]?.messages[0]?.text).toBe("hola");
+    expect(dump.bookings[0]?.status).toBe("agendada");
+    expect(dump.labRuns[0]?.score).toBe(83);
+    expect(typeof dump.exportedAt).toBe("string");
+  });
+
+  it("sin conversaciones reales no consulta mensajes y devuelve vacíos", async () => {
+    for (const t of ["pipelineStage", "contact", "lead", "conversation", "booking", "agentTestRun"]) {
+      tables.set(t, []);
+    }
+    // La tabla message solo se consulta si hay conversaciones reales:
+    tables.set("message", []);
+    const dump = await buildOrganizationExport("org_x");
+    expect(dump.conversations).toEqual([]);
+    expect(dump.contacts).toEqual([]);
+  });
+});

--- a/tests/unit/orphan-runs.test.ts
+++ b/tests/unit/orphan-runs.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * FR-034 endurecido: cuando una corrida del Laboratorio queda huérfana (por
+ * reinicio —cleanupOrphanRuns al boot— o por fallo en ejecución —failRun),
+ * SUS CASOS también salen de pending/running. Si no, la UI del Lab muestra
+ * personas "corriendo" para siempre dentro de una corrida que ya no existe
+ * en memoria.
+ *
+ * Estado terminal elegido: judge_failed — el único "sin veredicto" del enum,
+ * y computeScore ya lo excluye del denominador: una corrida interrumpida ni
+ * infla ni hunde el score histórico.
+ */
+
+const state = vi.hoisted(() => ({
+  orphanRuns: 1,
+  updates: [] as { table: string; set: Record<string, unknown> }[],
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDb: () => ({
+    update: (table: { col?: string }) => ({
+      set: (v: Record<string, unknown>) => ({
+        // La corrida usa .where().returning(); los casos solo .where() con
+        // await directo — el thenable cubre ambos caminos.
+        where: () => {
+          const name = table.col ?? "?";
+          state.updates.push({ table: name, set: v });
+          const result =
+            name === "agentTestRun"
+              ? Array.from({ length: state.orphanRuns }, (_, i) => ({
+                  id: `run_orphan_${i}`,
+                }))
+              : [];
+          return {
+            returning: () => Promise.resolve(result),
+            then: (onF: (r: unknown[]) => unknown) =>
+              Promise.resolve(result).then(onF),
+          };
+        },
+      }),
+    }),
+  }),
+  schema: new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        return { col: String(prop) };
+      },
+    }
+  ),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (a: unknown, b: unknown) => ({ op: "eq", a, b }),
+  inArray: (a: unknown, b: unknown) => ({ op: "inArray", a, b }),
+}));
+
+import { cleanupOrphanRuns } from "@/instrumentation-node";
+
+describe("cleanupOrphanRuns (FR-034: casos de corridas huérfanas)", () => {
+  beforeEach(() => {
+    state.updates.length = 0;
+    state.orphanRuns = 1;
+  });
+
+  it("marca la corrida como fallida y TAMBIÉN sus casos como judge_failed", async () => {
+    await cleanupOrphanRuns();
+
+    const tables = state.updates.map((u) => u.table);
+    expect(tables).toContain("agentTestRun");
+
+    const run = state.updates.find((u) => u.table === "agentTestRun");
+    expect(run?.set.status).toBe("failed");
+    expect(run?.set.error).toBe("Interrumpida por un reinicio del servidor");
+
+    const cases = state.updates.find((u) => u.table === "agentTestCase");
+    expect(cases?.set.status).toBe("judge_failed");
+  });
+
+  it("sin corridas huérfanas no toca casos: el segundo update depende del returning", async () => {
+    state.orphanRuns = 0;
+    await cleanupOrphanRuns();
+
+    expect(state.updates.map((u) => u.table)).toEqual(["agentTestRun"]);
+  });
+});


### PR DESCRIPTION
Kevin — después de tu video del agente sin n8n me puse a leer el repo completo (specs, ADRs, CLAUDE.md) y le encontré tres bordes que me faltan operando. Los armé siguiendo tus reglas: cada uno extiende una decisión tuya, no la corrige.

**1. Casos huérfanos del Lab (FR-034).** Tu `cleanupOrphanRuns` marca la corrida huérfana al boot, y `failRun` en timeout — pero los `agent_test_case` quedan en pending/running para siempre: la UI muestra personas "corriendo" dentro de corridas que ya no existen. Ambos caminos ahora también cierran los casos, con `judge_failed` (el único "sin veredicto" del enum; `computeScore` ya lo excluye — sin migración ni UI nueva).

**2. Logger JSON (`src/lib/logger.ts`).** Zero-dependency por tu constitución: pino/Sentry no entraban al núcleo. Una línea JSON por evento, `err` serializado (adiós `JSON.stringify(Error)` → `{}`), `LOG_LEVEL` opcional. Migré los 33 `console.*` del server. Para quien self-hostea: logs greppeables por nivel en `docker logs` sin configurar nada.

**3. Export de datos (`GET /api/export` + Configuración → Datos).** "Tus datos son tuyos" pasa de promesa a botón: JSON completo del negocio (contactos, leads, conversaciones, citas, corridas del Lab). Sin credenciales — mismo espíritu que tu "últimos 4 del token" — y sin `is_test`. Todo `scoped()`, solo lectura, `withAuth`. La objeción #1 del cliente al que le instalas esto ("¿y mis datos?") muere en la pestaña.

Gates: `typecheck` ✓ `lint` ✓ **378/378** (371 tuyos + 7 nuevos: logger, reaping y export con el mock de schema que revienta si el export toca una tabla de credenciales — la privacidad probada por construcción) ✓ `build` ✓.

Si los quieres por separado, los parto en tres sin problema.