### PR TITLE
feat(017): Messenger también por Zernio, con el transporte compartido

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,11 @@ META_GRAPH_API_VERSION=v25.0
 # de los demas canales responden 404 y no se piden sus credenciales.
 # Para encender Instagram y/o Messenger (ver README - Canales opcionales):
 # CHANNELS=whatsapp,instagram,messenger
+#
+# Instagram y Messenger pueden llegar por Zernio (API unificada). Las
+# credenciales de cada cuenta se guardan cifradas desde la interfaz, no aqui;
+# esta variable solo existe para apuntar a otra base de la API (pruebas).
+# ZERNIO_BASE_URL=https://zernio.com/api/v1
 
 # --- Atribucion de anuncios (opcional) -----------------------
 # Conversions API de Meta: reporta el lead calificado y la venta cerrada de las

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ externas: el trabajo en segundo plano (agente, Laboratorio) es in-process.
 | Las acciones que puede tomar el agente | `src/server/ai/actions.ts` + ejecución en `src/server/ai/pipeline.ts` |
 | Las personas o el juez del Laboratorio | `src/server/lab/personas.ts` · `src/server/lab/judge.ts` |
 | El canal WhatsApp (Graph API) | `src/lib/meta/` (cliente único) + `src/server/whatsapp/` |
-| Los canales opcionales (Instagram, Messenger; ADR-001) | `src/lib/channels.ts` (catálogo) · `src/server/channels/` (capacidades y bandera `CHANNELS`) · `src/server/instagram/` · `src/server/messenger/` |
+| Los canales opcionales (Instagram, Messenger; ADR-001) | `src/lib/channels.ts` (catálogo) · `src/server/channels/` (capacidades y bandera `CHANNELS`) · `src/server/instagram/` · `src/server/messenger/` · `src/server/zernio/` (transporte y firma de la API unificada, compartido) |
 | Campos/tablas | `src/lib/db/schema.ts` → `pnpm db:generate` → migración nueva en `drizzle/` |
 | La ingesta/envío de mensajes | `src/server/inbox/` (ingest idempotente, send con guard de sandbox, ventana 24h) |
 | Cómo se identifica a un contacto | `src/server/inbox/identity.ts` (teléfono normalizado o `bsuid:<id>`) |

--- a/README.md
+++ b/README.md
@@ -293,12 +293,28 @@ y el agente son los mismos: un lead es un lead, escriba por donde escriba.
 
 ### Messenger (página de Facebook)
 
+Dos formas de traer los mensajes; se elige en **Configuración → Messenger**.
+
+**Con Zernio** (API unificada, la misma que puede servir Instagram):
+
+1. Vincula la página de Facebook en el panel de [Zernio](https://zernio.com) y
+   copia el `accountId` de esa cuenta. Crea una API key (Settings → API Keys;
+   se muestra una sola vez).
+2. En Vocero, **Configuración → Messenger**: elige *Zernio*, pega el
+   `accountId`, la API key y —recomendado— un secreto de webhook. Pulsa
+   *Probar y guardar*: la llave se valida contra Zernio antes de guardarse
+   cifrada, y la pantalla te enseña la URL de callback.
+3. En Zernio, da de alta ese endpoint con el evento `message.received` y el
+   mismo secreto. El webhook de Zernio entrega todas tus plataformas por la
+   misma URL; Vocero solo ingiere aquí lo de Facebook.
+
+**Con una app propia de Meta**:
+
 1. En [developers.facebook.com](https://developers.facebook.com) crea (o usa)
    una app con el producto **Messenger** y genera el **token de acceso de la
    página** con el permiso `pages_messaging`. Anota el **ID de la página**.
-2. En Vocero, **Configuración → Messenger**: pega el ID y el token y pulsa
-   *Probar y guardar*. Vocero valida el token contra Meta antes de guardarlo
-   (cifrado en reposo) y te enseña la URL del webhook.
+2. En Vocero, **Configuración → Messenger**: elige *App propia de Meta*, pega
+   el ID y el token y pulsa *Probar y guardar*.
 3. En la app de Meta, **Messenger → Webhooks**: objeto `page`, campo
    `messages`, esa URL de callback y el token de verificación que enseña la
    pantalla. Suscribe la página a la app.
@@ -310,8 +326,9 @@ con la etiqueta `HUMAN_AGENT` de Meta (hasta 7 días); no hay plantillas.
 Hoy el canal es de texto: los adjuntos que te manden se ven como
 «📎 Imagen» para que sepas que llegaron, y los adjuntos salientes no están.
 
-Sin App Review, la página solo recibe mensajes de cuentas con un rol en la
-app; para atender al público hay que aprobar `pages_messaging`.
+Con app propia y sin App Review, la página solo recibe mensajes de cuentas con
+un rol en la app; para atender al público hay que aprobar `pages_messaging`.
+Por Zernio ese trámite ya está resuelto del lado de ellos.
 
 ### Instagram (DMs del perfil profesional)
 

--- a/drizzle/0012_messenger_zernio.sql
+++ b/drizzle/0012_messenger_zernio.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "messenger_credentials" ALTER COLUMN "page_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "messenger_credentials" ADD COLUMN IF NOT EXISTS "source" text DEFAULT 'meta' NOT NULL;--> statement-breakpoint
+ALTER TABLE "messenger_credentials" ADD COLUMN IF NOT EXISTS "account_ref" text;--> statement-breakpoint
+ALTER TABLE "messenger_credentials" ADD COLUMN IF NOT EXISTS "webhook_secret" text;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "messenger_credentials_account_ref_idx" ON "messenger_credentials" USING btree ("account_ref");

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,3917 @@
+{
+  "id": "ca0f2eef-f906-49b1-b2a2-c74c9a1491b5",
+  "prevId": "0029fdd2-01a3-4260-972e-585f39b5f208",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ad_attribution": {
+      "name": "ad_attribution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ctwa_clid": {
+          "name": "ctwa_clid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headline": {
+          "name": "headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ad_attribution_org_conversation_uq": {
+          "name": "ad_attribution_org_conversation_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ad_attribution_org_contact_idx": {
+          "name": "ad_attribution_org_contact_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ad_attribution_organization_id_organization_id_fk": {
+          "name": "ad_attribution_organization_id_organization_id_fk",
+          "tableFrom": "ad_attribution",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ad_attribution_contact_id_contact_id_fk": {
+          "name": "ad_attribution_contact_id_contact_id_fk",
+          "tableFrom": "ad_attribution",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ad_attribution_conversation_id_conversation_id_fk": {
+          "name": "ad_attribution_conversation_id_conversation_id_fk",
+          "tableFrom": "ad_attribution",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_profile": {
+      "name": "agent_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asistente'"
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalation_rules": {
+          "name": "escalation_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_profile_org_uq": {
+          "name": "agent_profile_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_profile_organization_id_organization_id_fk": {
+          "name": "agent_profile_organization_id_organization_id_fk",
+          "tableFrom": "agent_profile",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_case": {
+      "name": "agent_test_case",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "veredicto": {
+          "name": "veredicto",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hallazgos": {
+          "name": "hallazgos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_case_run_idx": {
+          "name": "test_case_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_case_organization_id_organization_id_fk": {
+          "name": "agent_test_case_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_run_id_agent_test_run_id_fk": {
+          "name": "agent_test_case_run_id_agent_test_run_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "agent_test_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_case_conversation_id_conversation_id_fk": {
+          "name": "agent_test_case_conversation_id_conversation_id_fk",
+          "tableFrom": "agent_test_case",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_run": {
+      "name": "agent_test_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "test_run_org_running_uq": {
+          "name": "test_run_org_running_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_test_run\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_run_org_idx": {
+          "name": "test_run_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_run_organization_id_organization_id_fk": {
+          "name": "agent_test_run_organization_id_organization_id_fk",
+          "tableFrom": "agent_test_run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking": {
+      "name": "booking",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'session'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'agendada'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector": {
+          "name": "connector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_link": {
+          "name": "meeting_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_pending": {
+          "name": "link_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_test": {
+          "name": "is_test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "booking_org_when_idx": {
+          "name": "booking_org_when_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_org_status_idx": {
+          "name": "booking_org_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_org_active_slot_uq": {
+          "name": "booking_org_active_slot_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"booking\".\"status\" in ('agendada','realizada') and \"booking\".\"is_test\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_organization_id_organization_id_fk": {
+          "name": "booking_organization_id_organization_id_fk",
+          "tableFrom": "booking",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "booking_contact_id_contact_id_fk": {
+          "name": "booking_contact_id_contact_id_fk",
+          "tableFrom": "booking",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "booking_conversation_id_conversation_id_fk": {
+          "name": "booking_conversation_id_conversation_id_fk",
+          "tableFrom": "booking",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "booking_lead_id_lead_id_fk": {
+          "name": "booking_lead_id_lead_id_fk",
+          "tableFrom": "booking",
+          "tableTo": "lead",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_settings": {
+      "name": "calendar_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_hours": {
+          "name": "weekly_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_minutes": {
+          "name": "slot_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "buffer_minutes": {
+          "name": "buffer_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "min_notice_hours": {
+          "name": "min_notice_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "max_days_ahead": {
+          "name": "max_days_ahead",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/Mexico_City'"
+        },
+        "connector": {
+          "name": "connector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enlace-fijo'"
+        },
+        "meeting_link": {
+          "name": "meeting_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_settings_org_uq": {
+          "name": "calendar_settings_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_settings_organization_id_organization_id_fk": {
+          "name": "calendar_settings_organization_id_organization_id_fk",
+          "tableFrom": "calendar_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capi_settings": {
+      "name": "capi_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_cipher": {
+          "name": "token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qualified_stage_id": {
+          "name": "qualified_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "capi_settings_org_uq": {
+          "name": "capi_settings_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capi_settings_organization_id_organization_id_fk": {
+          "name": "capi_settings_organization_id_organization_id_fk",
+          "tableFrom": "capi_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "capi_settings_qualified_stage_id_pipeline_stage_id_fk": {
+          "name": "capi_settings_qualified_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "capi_settings",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "qualified_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact": {
+      "name": "contact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'whatsapp'"
+        },
+        "wa_identity": {
+          "name": "wa_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_user_id": {
+          "name": "wa_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ficha": {
+          "name": "ficha",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_org_channel_identity_uq": {
+          "name": "contact_org_channel_identity_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_wa_user_id_idx": {
+          "name": "contact_org_wa_user_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wa_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_org_name_idx": {
+          "name": "contact_org_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_organization_id_organization_id_fk": {
+          "name": "contact_organization_id_organization_id_fk",
+          "tableFrom": "contact",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_test": {
+          "name": "is_test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'whatsapp'"
+        },
+        "channel_thread_ref": {
+          "name": "channel_thread_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_enabled": {
+          "name": "ai_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handoff_at": {
+          "name": "handoff_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_reason": {
+          "name": "handoff_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_inbound_at": {
+          "name": "last_inbound_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_org_contact_real_uq": {
+          "name": "conversation_org_contact_real_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation\".\"is_test\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_org_last_idx": {
+          "name": "conversation_org_last_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_organization_id_organization_id_fk": {
+          "name": "conversation_organization_id_organization_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_contact_id_contact_id_fk": {
+          "name": "conversation_contact_id_contact_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversion_event": {
+      "name": "conversion_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribution_id": {
+          "name": "attribution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fb_trace_id": {
+          "name": "fb_trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversion_event_org_conv_name_uq": {
+          "name": "conversion_event_org_conv_name_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversion_event_org_created_idx": {
+          "name": "conversion_event_org_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversion_event_organization_id_organization_id_fk": {
+          "name": "conversion_event_organization_id_organization_id_fk",
+          "tableFrom": "conversion_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversion_event_conversation_id_conversation_id_fk": {
+          "name": "conversion_event_conversation_id_conversation_id_fk",
+          "tableFrom": "conversion_event",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversion_event_attribution_id_ad_attribution_id_fk": {
+          "name": "conversion_event_attribution_id_ad_attribution_id_fk",
+          "tableFrom": "conversion_event",
+          "tableTo": "ad_attribution",
+          "columnsFrom": [
+            "attribution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_credentials": {
+      "name": "google_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_cipher": {
+          "name": "client_secret_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_iv": {
+          "name": "client_secret_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_tag": {
+          "name": "client_secret_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_cipher": {
+          "name": "refresh_token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_iv": {
+          "name": "refresh_token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_tag": {
+          "name": "refresh_token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "google_credentials_org_uq": {
+          "name": "google_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_credentials_organization_id_organization_id_fk": {
+          "name": "google_credentials_organization_id_organization_id_fk",
+          "tableFrom": "google_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instagram_credentials": {
+      "name": "instagram_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ig_user_id": {
+          "name": "ig_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_ref": {
+          "name": "account_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_cipher": {
+          "name": "token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instagram_credentials_org_uq": {
+          "name": "instagram_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instagram_credentials_ig_user_uq": {
+          "name": "instagram_credentials_ig_user_uq",
+          "columns": [
+            {
+              "expression": "ig_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instagram_credentials_account_ref_idx": {
+          "name": "instagram_credentials_account_ref_idx",
+          "columns": [
+            {
+              "expression": "account_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instagram_credentials_organization_id_organization_id_fk": {
+          "name": "instagram_credentials_organization_id_organization_id_fk",
+          "tableFrom": "instagram_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_entry": {
+      "name": "kb_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kb_org_idx": {
+          "name": "kb_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_entry_organization_id_organization_id_fk": {
+          "name": "kb_entry_organization_id_organization_id_fk",
+          "tableFrom": "kb_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead": {
+      "name": "lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_updated_at": {
+          "name": "priority_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lead_contact_uq": {
+          "name": "lead_contact_uq",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lead_org_stage_idx": {
+          "name": "lead_org_stage_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_organization_id_organization_id_fk": {
+          "name": "lead_organization_id_organization_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_contact_id_contact_id_fk": {
+          "name": "lead_contact_id_contact_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead_stage_event": {
+      "name": "lead_stage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_stage_id": {
+          "name": "from_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_stage_name": {
+          "name": "from_stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage_id": {
+          "name": "to_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage_name": {
+          "name": "to_stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_stage_kind": {
+          "name": "to_stage_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dueno'"
+        },
+        "approximate": {
+          "name": "approximate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "loss_reason": {
+          "name": "loss_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loss_note": {
+          "name": "loss_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lse_org_occurred_idx": {
+          "name": "lse_org_occurred_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lse_lead_occurred_idx": {
+          "name": "lse_lead_occurred_idx",
+          "columns": [
+            {
+              "expression": "lead_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lse_org_kind_occurred_idx": {
+          "name": "lse_org_kind_occurred_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_stage_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_stage_event_organization_id_organization_id_fk": {
+          "name": "lead_stage_event_organization_id_organization_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_lead_id_lead_id_fk": {
+          "name": "lead_stage_event_lead_id_lead_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "lead",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_contact_id_contact_id_fk": {
+          "name": "lead_stage_event_contact_id_contact_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "contact",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_from_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_event_from_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "from_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_to_stage_id_pipeline_stage_id_fk": {
+          "name": "lead_stage_event_to_stage_id_pipeline_stage_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "pipeline_stage",
+          "columnsFrom": [
+            "to_stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lead_stage_event_actor_user_id_user_id_fk": {
+          "name": "lead_stage_event_actor_user_id_user_id_fk",
+          "tableFrom": "lead_stage_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lse_loss_reason_ck": {
+          "name": "lse_loss_reason_ck",
+          "value": "\"lead_stage_event\".\"to_stage_kind\" <> 'lost' OR \"lead_stage_event\".\"approximate\" = true OR \"lead_stage_event\".\"loss_reason\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_asset": {
+      "name": "media_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_media_id": {
+          "name": "wa_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_status": {
+          "name": "fetch_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_asset_org_idx": {
+          "name": "media_asset_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_asset_wa_media_idx": {
+          "name": "media_asset_wa_media_idx",
+          "columns": [
+            {
+              "expression": "wa_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_asset_organization_id_organization_id_fk": {
+          "name": "media_asset_organization_id_organization_id_fk",
+          "tableFrom": "media_asset",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wa_message_id": {
+          "name": "wa_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated": {
+          "name": "ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'operator'"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_timestamp": {
+          "name": "wa_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_org_conv_idx": {
+          "name": "message_org_conv_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_organization_id_organization_id_fk": {
+          "name": "message_organization_id_organization_id_fk",
+          "tableFrom": "message",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_media_asset_id_media_asset_id_fk": {
+          "name": "message_media_asset_id_media_asset_id_fk",
+          "tableFrom": "message",
+          "tableTo": "media_asset",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_wa_message_id_unique": {
+          "name": "message_wa_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wa_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messenger_credentials": {
+      "name": "messenger_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'meta'"
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_name": {
+          "name": "page_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_ref": {
+          "name": "account_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_cipher": {
+          "name": "token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messenger_credentials_org_uq": {
+          "name": "messenger_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messenger_credentials_page_uq": {
+          "name": "messenger_credentials_page_uq",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messenger_credentials_account_ref_idx": {
+          "name": "messenger_credentials_account_ref_idx",
+          "columns": [
+            {
+              "expression": "account_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messenger_credentials_organization_id_organization_id_fk": {
+          "name": "messenger_credentials_organization_id_organization_id_fk",
+          "tableFrom": "messenger_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_credentials": {
+      "name": "meta_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waba_id": {
+          "name": "waba_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number_id": {
+          "name": "phone_number_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_phone_number": {
+          "name": "display_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_name": {
+          "name": "verified_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_cipher": {
+          "name": "token_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meta_credentials_org_uq": {
+          "name": "meta_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meta_credentials_phone_uq": {
+          "name": "meta_credentials_phone_uq",
+          "columns": [
+            {
+              "expression": "phone_number_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meta_credentials_organization_id_organization_id_fk": {
+          "name": "meta_credentials_organization_id_organization_id_fk",
+          "tableFrom": "meta_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.offered_slot": {
+      "name": "offered_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_utc": {
+          "name": "start_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offered_at": {
+          "name": "offered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "offered_slot_conv_idx": {
+          "name": "offered_slot_conv_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "offered_slot_organization_id_organization_id_fk": {
+          "name": "offered_slot_organization_id_organization_id_fk",
+          "tableFrom": "offered_slot",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "offered_slot_conversation_id_conversation_id_fk": {
+          "name": "offered_slot_conversation_id_conversation_id_fk",
+          "tableFrom": "offered_slot",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_stage": {
+      "name": "pipeline_stage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stage_org_pos_idx": {
+          "name": "stage_org_pos_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_stage_organization_id_organization_id_fk": {
+          "name": "pipeline_stage_organization_id_organization_id_fk",
+          "tableFrom": "pipeline_stage",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wa_template_id": {
+          "name": "wa_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_org_name_lang_uq": {
+          "name": "template_org_name_lang_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_organization_id_organization_id_fk": {
+          "name": "template_organization_id_organization_id_fk",
+          "tableFrom": "template",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zoom_credentials": {
+      "name": "zoom_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_cipher": {
+          "name": "secret_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_iv": {
+          "name": "secret_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_tag": {
+          "name": "secret_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "zoom_credentials_org_uq": {
+          "name": "zoom_credentials_org_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zoom_credentials_organization_id_organization_id_fk": {
+          "name": "zoom_credentials_organization_id_organization_id_fk",
+          "tableFrom": "zoom_credentials",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1788309200954,
       "tag": "0011_canal_messenger",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1788310823966,
+      "tag": "0012_messenger_zernio",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/e2e-messenger.mjs
+++ b/scripts/e2e-messenger.mjs
@@ -1,22 +1,27 @@
 /**
  * Self-test E2E de comportamiento — 017: canal de Messenger.
  *
- * Conduce la app real en localhost con el mock de Graph: conecta una página,
- * mete mensajes por el webhook como lo haría Meta y responde desde la bandeja,
- * comprobando cada paso por las mismas superficies que usa el operador.
+ * Conduce la app real en localhost con los mocks: conecta la página por las
+ * DOS fuentes (Meta directo y Zernio), mete mensajes por el webhook como lo
+ * haría cada proveedor y responde desde la bandeja, comprobando cada paso por
+ * las mismas superficies que usa el operador.
  *
  * Uso:
  *   1) app corriendo con WA_MOCK_ENABLED=true, META_GRAPH_BASE_URL → wa-mock,
- *      CHANNELS incluyendo messenger, y BD migrada
+ *      ZERNIO_BASE_URL → zernio-mock, CHANNELS con messenger, y BD migrada
  *   2) node --env-file=.env scripts/e2e-messenger.mjs
  *
  * Sale con código 1 si algún check falla.
  */
+import { createHmac } from "node:crypto";
 
 const BASE = process.env.APP_BASE_URL ?? "http://localhost:3000";
 const VERIFY_TOKEN = process.env.META_WEBHOOK_VERIFY_TOKEN;
 const PAGE = "page-demo-001";
-const PSID = `psid-${Date.now()}`;
+const ACCOUNT = "zernio-account-001";
+const SECRET = "secreto-del-webhook-de-zernio";
+const PSID_META = `psid-meta-${Date.now()}`;
+const PSID_ZERNIO = `psid-zernio-${Date.now()}`;
 
 let cookie = "";
 let failures = 0;
@@ -50,23 +55,47 @@ async function api(path, opts = {}) {
   return { res, json };
 }
 
-/** Meta entrega por POST sin cookies; la ruta lleva el segmento secreto. */
-async function webhook(payload, token = VERIFY_TOKEN) {
+/** El proveedor entrega por POST sin cookies; la ruta lleva el segmento secreto. */
+async function webhook(payload, { token = VERIFY_TOKEN, signature } = {}) {
+  const body = JSON.stringify(payload);
   return fetch(`${BASE}/api/webhooks/messenger/${token}`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(payload),
+    headers: {
+      "content-type": "application/json",
+      ...(signature ? { "x-zernio-signature": signature } : {}),
+    },
+    body,
   });
 }
 
-function pageEvent(messaging) {
+const sign = (payload, secret = SECRET) =>
+  createHmac("sha256", secret).update(JSON.stringify(payload)).digest("hex");
+
+function metaEvent(messaging) {
   return { object: "page", entry: [{ id: PAGE, time: Date.now(), messaging }] };
+}
+
+function zernioEvent(over = {}) {
+  return {
+    id: `evt-${Math.random().toString(36).slice(2)}`,
+    event: "message.received",
+    message: {
+      id: `zmsg-${Math.random().toString(36).slice(2)}`,
+      conversationId: "zconv-001",
+      direction: "incoming",
+      text: "Hola desde Facebook",
+      sender: { id: PSID_ZERNIO, name: "Jane Doe", username: "jane_doe" },
+      ...(over.message ?? {}),
+    },
+    account: { id: ACCOUNT, platform: "facebook", ...(over.account ?? {}) },
+    ...Object.fromEntries(Object.entries(over).filter(([k]) => !["message", "account"].includes(k))),
+  };
 }
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 /** La ingesta corre tras responder el webhook: se espera a que aparezca. */
-async function waitForConversation(pred, tries = 20) {
+async function waitForConversation(pred, tries = 25) {
   for (let i = 0; i < tries; i++) {
     const { json } = await api("/api/conversations");
     const found = (json?.conversations ?? []).find(pred);
@@ -97,23 +126,38 @@ async function main() {
   }
   ok("registro o login del propietario", su.res.ok);
 
+  console.log("\n== Webhook: capas de seguridad ==");
+  const wrong = await webhook(metaEvent([]), { token: "token-equivocado" });
+  ok("segmento secreto equivocado → 404 sin efectos", wrong.status === 404, String(wrong.status));
+  const hs = await fetch(
+    `${BASE}/api/webhooks/messenger/${VERIFY_TOKEN}?hub.mode=subscribe&hub.verify_token=${VERIFY_TOKEN}&hub.challenge=reto-123`
+  );
+  ok("handshake de Meta devuelve el challenge", hs.status === 200 && (await hs.text()) === "reto-123");
+
+  // ------------------------------------------------------------------
+  console.log("\n===== FUENTE: META DIRECTO =====");
   console.log("\n== Conexión de la página (validada contra Graph) ==");
   const bad = await api("/api/settings/messenger", {
     method: "PUT",
-    body: JSON.stringify({ pageId: PAGE, token: "token-invalid" }),
+    body: JSON.stringify({ source: "meta", pageId: PAGE, token: "token-invalid" }),
   });
   ok("un token que Meta rechaza NO se guarda → 422", bad.res.status === 422, String(bad.res.status));
 
   const conn = await api("/api/settings/messenger", {
     method: "PUT",
-    body: JSON.stringify({ pageId: PAGE, token: "token-pagina-demo" }),
+    body: JSON.stringify({ source: "meta", pageId: PAGE, token: "token-pagina-demo" }),
   });
-  ok("PUT con token válido → 200 con el nombre de la página", conn.res.ok && conn.json?.pageName === "Página de prueba Vocero", JSON.stringify(conn.json));
+  ok(
+    "PUT con token válido → 200 con el nombre de la página",
+    conn.res.ok && conn.json?.pageName === "Página de prueba Vocero",
+    JSON.stringify(conn.json)
+  );
 
   const state = await api("/api/settings/messenger");
   ok(
     "GET enseña la conexión sin el token entero (solo su cola)",
     state.json?.connection?.status === "connected" &&
+      state.json?.connection?.source === "meta" &&
       state.json?.connection?.tokenLast4 === "demo" &&
       !JSON.stringify(state.json).includes("token-pagina-demo")
   );
@@ -121,88 +165,200 @@ async function main() {
   const wh = await api("/api/settings/webhook");
   ok(
     "la pantalla tiene la URL del webhook de Messenger con el segmento secreto",
-    typeof wh.json?.messengerUrl === "string" && wh.json.messengerUrl.endsWith(`/api/webhooks/messenger/${VERIFY_TOKEN}`)
+    typeof wh.json?.messengerUrl === "string" &&
+      wh.json.messengerUrl.endsWith(`/api/webhooks/messenger/${VERIFY_TOKEN}`)
   );
 
-  console.log("\n== Webhook: capas de seguridad ==");
-  const wrong = await webhook(pageEvent([]), "token-equivocado");
-  ok("segmento secreto equivocado → 404 sin efectos", wrong.status === 404, String(wrong.status));
-  const hs = await fetch(
-    `${BASE}/api/webhooks/messenger/${VERIFY_TOKEN}?hub.mode=subscribe&hub.verify_token=${VERIFY_TOKEN}&hub.challenge=reto-123`
-  );
-  ok("handshake de Meta devuelve el challenge", hs.status === 200 && (await hs.text()) === "reto-123");
-
-  console.log("\n== Entrante: un texto crea contacto y conversación con su canal ==");
+  console.log("\n== Entrante por Meta ==");
   const first = await webhook(
-    pageEvent([
+    metaEvent([
       {
-        sender: { id: PSID },
+        sender: { id: PSID_META },
         recipient: { id: PAGE },
         timestamp: Date.now(),
-        message: { mid: `m_${PSID}_1`, text: "Hola, ¿tienen envíos a Guadalajara?" },
+        message: { mid: `m_${PSID_META}_1`, text: "Hola, ¿tienen envíos a Guadalajara?" },
       },
     ])
   );
-  ok("Meta recibe 200 de inmediato", first.status === 200);
-  const conv = await waitForConversation((c) => c.contact?.name === "Cliente de Messenger" || c.preview?.includes("Guadalajara"));
-  ok("la conversación aparece en la bandeja", Boolean(conv));
-  ok("con canal messenger", conv?.channel === "messenger", conv?.channel);
-  ok("el contacto tiene nombre de perfil, no el PSID crudo", conv?.contact?.name === "Cliente de Messenger", conv?.contact?.name);
-  ok("el contacto no tiene teléfono (Messenger no lo da)", conv?.contact?.phone == null);
-  ok("la ventana de 24 h abre con el entrante", conv?.windowOpen === true);
+  ok("el proveedor recibe 200 de inmediato", first.status === 200);
+  const convMeta = await waitForConversation((c) => c.preview?.includes("Guadalajara"));
+  ok("la conversación aparece en la bandeja", Boolean(convMeta));
+  ok("con canal messenger", convMeta?.channel === "messenger", convMeta?.channel);
+  ok(
+    "el contacto tiene nombre de perfil (consultado a Graph), no el PSID crudo",
+    convMeta?.contact?.name === "Cliente de Messenger",
+    convMeta?.contact?.name
+  );
+  ok("el contacto no tiene teléfono", convMeta?.contact?.phone == null);
+  ok("la ventana de 24 h abre con el entrante", convMeta?.windowOpen === true);
 
-  console.log("\n== Idempotencia y ruido ==");
+  console.log("\n== Idempotencia y ruido (Meta) ==");
   await webhook(
-    pageEvent([{ sender: { id: PSID }, message: { mid: `m_${PSID}_1`, text: "Hola, ¿tienen envíos a Guadalajara?" } }])
+    metaEvent([{ sender: { id: PSID_META }, message: { mid: `m_${PSID_META}_1`, text: "Hola, ¿tienen envíos a Guadalajara?" } }])
   );
   await webhook(
-    pageEvent([
-      { sender: { id: PAGE }, recipient: { id: PSID }, message: { mid: `m_${PSID}_echo`, text: "eco", is_echo: true } },
-      { sender: { id: PSID }, delivery: { mids: [`m_${PSID}_1`], watermark: Date.now() } },
-      { sender: { id: PSID }, read: { watermark: Date.now() } },
+    metaEvent([
+      { sender: { id: PAGE }, recipient: { id: PSID_META }, message: { mid: `m_echo`, text: "eco", is_echo: true } },
+      { sender: { id: PSID_META }, delivery: { mids: ["m_1"], watermark: Date.now() } },
+      { sender: { id: PSID_META }, read: { watermark: Date.now() } },
     ])
   );
   await webhook(
-    pageEvent([
-      { sender: { id: PSID }, message: { mid: `m_${PSID}_img`, attachments: [{ type: "image", payload: { url: "https://cdn.example/x.jpg" } }] } },
+    metaEvent([
+      { sender: { id: PSID_META }, message: { mid: `m_${PSID_META}_img`, attachments: [{ type: "image", payload: { url: "https://cdn.example/x.jpg" } }] } },
     ])
   );
-  await sleep(1200);
-  const msgs = await api(`/api/conversations/${conv?.id}/messages`);
+  await sleep(1500);
+  const msgs = await api(`/api/conversations/${convMeta?.id}/messages`);
   const inbound = (msgs.json?.messages ?? []).filter((m) => m.direction === "in");
-  ok("el webhook repetido NO duplica el mensaje", inbound.filter((m) => m.text?.includes("Guadalajara")).length === 1, `in=${inbound.length}`);
+  ok(
+    "el webhook repetido NO duplica el mensaje",
+    inbound.filter((m) => m.text?.includes("Guadalajara")).length === 1,
+    `in=${inbound.length}`
+  );
   ok("echo, acuses y lectura no crean mensajes", inbound.every((m) => m.text !== "eco"));
-  ok("un adjunto entra con su tipo (imagen) para que se vea que llegó", inbound.some((m) => m.type === "image"), inbound.map((m) => m.type).join(","));
-  const all = await api("/api/conversations");
-  ok("sigue habiendo UNA conversación para ese PSID", (all.json?.conversations ?? []).filter((c) => c.contact?.name === "Cliente de Messenger" && c.id === conv?.id).length === 1);
+  ok("un adjunto entra con su tipo (imagen)", inbound.some((m) => m.type === "image"), inbound.map((m) => m.type).join(","));
 
-  console.log("\n== Salida: responder desde la bandeja llega a la página ==");
-  const before = await fetch(`${BASE}/api/dev/wa-mock/outbox`).then((r) => r.json());
-  const reply = await api(`/api/conversations/${conv?.id}/messages`, {
+  console.log("\n== Salida por Meta ==");
+  const beforeWa = await fetch(`${BASE}/api/dev/wa-mock/outbox`).then((r) => r.json());
+  const replyMeta = await api(`/api/conversations/${convMeta?.id}/messages`, {
     method: "POST",
-    body: JSON.stringify({ text: "Sí, a toda la zona metropolitana. ¿Qué necesitas?" }),
+    body: JSON.stringify({ text: "Sí, a toda la zona metropolitana." }),
   });
-  ok("POST /messages → 200/201", reply.res.ok, JSON.stringify(reply.json));
-  const after = await fetch(`${BASE}/api/dev/wa-mock/outbox`).then((r) => r.json());
-  const sent = (after.outbox ?? after ?? []).slice((before.outbox ?? before ?? []).length);
-  const last = Array.isArray(sent) ? sent[sent.length - 1] : null;
-  ok("salió por la página (POST /{pageId}/messages), no por el número de WhatsApp", last?.phoneNumberId === PAGE, JSON.stringify(last));
-  ok("al PSID correcto y como RESPONSE dentro de la ventana", last?.body?.recipient?.id === PSID && last?.body?.messaging_type === "RESPONSE");
-  const msgs2 = await api(`/api/conversations/${conv?.id}/messages`);
-  const out = (msgs2.json?.messages ?? []).find((m) => m.direction === "out");
-  ok("el saliente queda en el hilo como 'sent' (Messenger no manda acuses)", out?.status === "sent", out?.status);
+  ok("POST /messages → 200/201", replyMeta.res.ok, JSON.stringify(replyMeta.json));
+  const afterWa = await fetch(`${BASE}/api/dev/wa-mock/outbox`).then((r) => r.json());
+  const sentWa = (afterWa.outbox ?? []).slice((beforeWa.outbox ?? []).length);
+  const lastWa = sentWa[sentWa.length - 1];
+  ok("salió por la página, no por el número de WhatsApp", lastWa?.phoneNumberId === PAGE, JSON.stringify(lastWa));
+  ok(
+    "al PSID correcto y como RESPONSE dentro de la ventana",
+    lastWa?.body?.recipient?.id === PSID_META && lastWa?.body?.messaging_type === "RESPONSE"
+  );
+  const msgsOut = await api(`/api/conversations/${convMeta?.id}/messages`);
+  const out = (msgsOut.json?.messages ?? []).find((m) => m.direction === "out");
+  ok("el saliente queda como 'sent' (Messenger no manda acuses)", out?.status === "sent", out?.status);
 
   console.log("\n== Lo que Messenger no admite falla claro ==");
-  const loc = await api(`/api/conversations/${conv?.id}/messages`, {
+  const loc = await api(`/api/conversations/${convMeta?.id}/messages`, {
     method: "POST",
     body: JSON.stringify({ type: "location", location: { latitude: 20.67, longitude: -103.35 } }),
   });
   ok("una ubicación por Messenger → error claro, no 500", loc.res.status >= 400 && loc.res.status < 500, String(loc.res.status));
-  const long = await api(`/api/conversations/${conv?.id}/messages`, {
+  const long = await api(`/api/conversations/${convMeta?.id}/messages`, {
     method: "POST",
     body: JSON.stringify({ text: "x".repeat(2001) }),
   });
   ok("un texto de más de 2000 bytes → rechazado antes de tocar Meta", long.res.status >= 400 && long.res.status < 500, String(long.res.status));
+
+  // ------------------------------------------------------------------
+  console.log("\n===== FUENTE: ZERNIO =====");
+  await fetch(`${BASE}/api/dev/zernio-mock/_reset`, { method: "POST" });
+
+  console.log("\n== Conexión por Zernio (validada contra su API) ==");
+  const badZ = await api("/api/settings/messenger", {
+    method: "PUT",
+    body: JSON.stringify({ source: "zernio", accountRef: ACCOUNT, token: "sk_test-invalid" }),
+  });
+  ok("una API key que Zernio rechaza NO se guarda → 422", badZ.res.status === 422, String(badZ.res.status));
+
+  const noAccount = await api("/api/settings/messenger", {
+    method: "PUT",
+    body: JSON.stringify({ source: "zernio", token: "sk_test-ok" }),
+  });
+  ok("sin accountId no se puede enrutar → 422", noAccount.res.status === 422, String(noAccount.res.status));
+
+  const connZ = await api("/api/settings/messenger", {
+    method: "PUT",
+    body: JSON.stringify({
+      source: "zernio",
+      accountRef: ACCOUNT,
+      token: "sk_test-ok",
+      webhookSecret: SECRET,
+    }),
+  });
+  ok("PUT con API key válida → 200", connZ.res.ok, JSON.stringify(connZ.json));
+  const stateZ = await api("/api/settings/messenger");
+  ok(
+    "la conexión queda en modo zernio con su cuenta",
+    stateZ.json?.connection?.source === "zernio" && stateZ.json?.connection?.accountRef === ACCOUNT,
+    JSON.stringify(stateZ.json?.connection)
+  );
+
+  console.log("\n== Firma del webhook de Zernio ==");
+  const evtFirma = zernioEvent();
+  const sinFirma = await webhook(evtFirma);
+  ok("sin firma con secreto configurado → 401", sinFirma.status === 401, String(sinFirma.status));
+  const malFirmada = await webhook(evtFirma, { signature: "deadbeef" });
+  ok("firma inválida → 401", malFirmada.status === 401, String(malFirmada.status));
+
+  console.log("\n== Entrante por Zernio ==");
+  const evt = zernioEvent();
+  const okFirma = await webhook(evt, { signature: sign(evt) });
+  ok("firma válida → 200", okFirma.status === 200, String(okFirma.status));
+  const convZ = await waitForConversation((c) => c.contact?.name === "Jane Doe");
+  ok("la conversación aparece en la bandeja", Boolean(convZ));
+  ok("con canal messenger", convZ?.channel === "messenger", convZ?.channel);
+  ok("el nombre viene del evento, sin consultar a nadie", convZ?.contact?.name === "Jane Doe", convZ?.contact?.name);
+
+  console.log("\n== Zernio: ruido de otras plataformas y duplicados ==");
+  const otra = zernioEvent({
+    account: { platform: "instagram" },
+    message: { id: "zmsg-ig", text: "esto es de instagram", sender: { id: "igsid-x", name: "Otro" } },
+  });
+  await webhook(otra, { signature: sign(otra) });
+  const dup = { ...evt };
+  await webhook(dup, { signature: sign(dup) });
+  const salida = zernioEvent({ message: { id: "zmsg-out", direction: "outgoing", text: "respuesta mía" } });
+  await webhook(salida, { signature: sign(salida) });
+  await sleep(1500);
+  const msgsZ = await api(`/api/conversations/${convZ?.id}/messages`);
+  const inZ = (msgsZ.json?.messages ?? []).filter((m) => m.direction === "in");
+  ok("el evento repetido NO duplica el mensaje", inZ.length === 1, `in=${inZ.length}`);
+  const todas = await api("/api/conversations");
+  ok(
+    "un mensaje de Instagram por el mismo webhook NO entra como Messenger",
+    !(todas.json?.conversations ?? []).some((c) => c.preview?.includes("esto es de instagram"))
+  );
+  ok(
+    "un `outgoing` de la bandeja de Zernio no se ingiere como entrante",
+    !inZ.some((m) => m.text === "respuesta mía")
+  );
+
+  console.log("\n== Zernio: defensa entre fuentes ==");
+  const metaMientrasZernio = await webhook(
+    metaEvent([{ sender: { id: "psid-intruso" }, message: { mid: "m_intruso", text: "payload de meta" } }])
+  );
+  await sleep(1000);
+  const trasIntruso = await api("/api/conversations");
+  ok(
+    "un payload de Meta con la instancia en modo Zernio se descarta",
+    metaMientrasZernio.status === 200 &&
+      !(trasIntruso.json?.conversations ?? []).some((c) => c.preview?.includes("payload de meta"))
+  );
+
+  console.log("\n== Salida por Zernio ==");
+  const replyZ = await api(`/api/conversations/${convZ?.id}/messages`, {
+    method: "POST",
+    body: JSON.stringify({ text: "Claro, te mando el catálogo" }),
+  });
+  ok("POST /messages → 200/201", replyZ.res.ok, JSON.stringify(replyZ.json));
+  const sentZ = await fetch(`${BASE}/api/dev/zernio-mock/_sent`).then((r) => r.json());
+  const lastZ = (sentZ.sent ?? [])[sentZ.sent.length - 1];
+  ok("salió por la API de Zernio", Boolean(lastZ), JSON.stringify(sentZ).slice(0, 200));
+  ok(
+    "a la conversación del evento (el conversationId opaco), con su accountId",
+    lastZ?.conversationId === "zconv-001" && lastZ?.accountId === ACCOUNT,
+    JSON.stringify(lastZ)
+  );
+  ok("con el texto que escribió el operador", lastZ?.message === "Claro, te mando el catálogo");
+  ok(
+    "dentro de la ventana NO va etiquetado como agente humano",
+    !lastZ?.messageTag,
+    JSON.stringify(lastZ?.messageTag)
+  );
+  const msgsZ2 = await api(`/api/conversations/${convZ?.id}/messages`);
+  const outZ = (msgsZ2.json?.messages ?? []).find((m) => m.direction === "out");
+  ok("el saliente queda como 'sent'", outZ?.status === "sent", outZ?.status);
 
   console.log(`\n===== ${checks - failures}/${checks} checks OK, ${failures} fallos =====`);
   process.exit(failures ? 1 : 0);

--- a/specs/017-canal-messenger/spec.md
+++ b/specs/017-canal-messenger/spec.md
@@ -40,20 +40,31 @@ las conversaciones.
   ID), guardada como `fb:<PSID>`, en la misma familia que `bsuid:` e `ig:`.
   Dos canales pueden compartir identidad sin colisionar (el índice único ya
   incluye el canal).
-- **FR-203** Las credenciales (ID de la página y token de acceso) se guardan
-  cifradas en reposo con el AES-256-GCM existente; hacia fuera solo viaja la
-  cola del token.
+- **FR-203** Las credenciales se guardan cifradas en reposo con el AES-256-GCM
+  existente; hacia fuera solo viaja la cola del token. Igual que Instagram,
+  admite **dos fuentes** (`source`): la API unificada de **Zernio** (llave +
+  `accountRef` + secreto de webhook) o una **app propia de Meta** (`pageId` +
+  token de página).
 - **FR-204** La ingesta entra por `/api/webhooks/messenger/[webhookToken]`
-  con las dos capas de siempre (segmento secreto + firma `x-hub-signature-256`
-  con `META_APP_SECRET`), es idempotente por `mid` y descarta echos, acuses
-  de entrega/lectura y postbacks. Un adjunto sin texto entra con su tipo para
-  que la bandeja enseñe qué llegó.
-- **FR-205** El nombre visible se consulta al perfil de Meta la primera vez
-  que se ve un PSID; si no se puede, cae a «Contacto de Messenger». Nunca se
-  bloquea un mensaje por un nombre.
-- **FR-206** La salida enruta por canal en `prepareSend`: Messenger envía por
-  `POST /{PAGE_ID}/messages` de Graph con el token de la página; no tiene
-  plantillas; fuera de la ventana de 24 h usa la etiqueta `HUMAN_AGENT`; el
+  con las dos capas de siempre: segmento secreto, y encima la firma — de Meta
+  (`x-hub-signature-256` con `META_APP_SECRET`) o de Zernio
+  (`X-Zernio-Signature`, HMAC del cuerpo crudo con el secreto de esa cuenta).
+  Acepta los dos formatos por la misma URL porque son inconfundibles: Meta
+  manda `object: "page"`, Zernio un evento plano con `account`. Es idempotente
+  por el id del mensaje y descarta echos, acuses de entrega/lectura, postbacks
+  y —en Zernio— **todo lo que no sea la plataforma de Facebook**, porque el
+  mismo webhook entrega Instagram, WhatsApp y X. Un adjunto sin texto entra
+  con su tipo para que la bandeja enseñe qué llegó.
+- **FR-205** El nombre visible sale del evento cuando la fuente lo entrega
+  (Zernio manda `name`/`username`); con Meta se consulta al perfil la primera
+  vez que se ve un PSID. Si no se puede, cae a «Contacto de Messenger». Nunca
+  se bloquea un mensaje por un nombre.
+- **FR-206** La salida enruta por canal en `prepareSend` y por fuente dentro
+  del canal: Meta envía por `POST /{PAGE_ID}/messages` de Graph con el token
+  de la página; Zernio por `POST /inbox/conversations/{id}/messages` con la
+  llave y el `conversationId` opaco que guardó la ingesta (con
+  `Idempotency-Key` para que un reintento no mande dos veces). No hay
+  plantillas; fuera de la ventana de 24 h se usa la etiqueta `HUMAN_AGENT`; el
   texto se limita a 2000 bytes; ubicaciones, contactos y adjuntos salientes
   fallan con un error claro (no un 500).
 - **FR-207** Con el canal apagado (`CHANNELS` sin `messenger`), la pantalla,
@@ -80,8 +91,10 @@ las conversaciones.
   webhook con segmento secreto + firma HMAC; solo el propietario conecta la
   página. Sin secretos en logs.
 - **II. Frontera de salida única**: el transporte vive en
-  `src/server/messenger/` y usa el cliente único de Graph (`graphRequest`); el
-  ruteo se decide en `prepareSend`.
+  `src/server/messenger/` y usa el cliente único de Graph (`graphRequest`) o el
+  de Zernio (`src/server/zernio/`, compartido con Instagram para que la
+  verificación de firma tenga UNA sola implementación); el ruteo se decide en
+  `prepareSend`.
 - **IV. Idempotencia**: dedupe por `fb_<mid>` en el índice único de mensajes;
   migración re-ejecutable.
 - **VI. Specs antes de código**: este documento.

--- a/src/app/api/dev/zernio-mock/[...path]/route.ts
+++ b/src/app/api/dev/zernio-mock/[...path]/route.ts
@@ -1,0 +1,81 @@
+import { mockGuard } from "@/lib/dev-guard";
+import {
+  resetZernioMock,
+  zernioMockState,
+  zernioTokenIsBad,
+} from "@/server/dev/zernio-mock-state";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * 017 — Zernio de mentira para el self-test. Tras `mockGuard()`: 404
+ * incondicional en producción, indistinguible de una ruta inexistente.
+ *
+ * Imita lo único que Vocero usa de esa API —listar conversaciones (que es como
+ * se valida la llave) y responder en una— y expone `_sent` y `_reset` para que
+ * el arnés pueda afirmar sobre lo que recibió.
+ */
+
+type Ctx = { params: Promise<{ path: string[] }> };
+
+function unauthorized(): Response {
+  return Response.json(
+    { error: { message: "Invalid API key" } },
+    { status: 401 }
+  );
+}
+
+export async function GET(req: Request, ctx: Ctx) {
+  const denied = mockGuard();
+  if (denied) return denied;
+  const { path } = await ctx.params;
+  const route = path.join("/");
+
+  if (route === "_sent") {
+    return Response.json({ sent: zernioMockState().sent });
+  }
+  if (zernioTokenIsBad(req.headers.get("authorization"))) return unauthorized();
+
+  // GET /inbox/conversations → lo que usa la validación de la llave.
+  if (route === "inbox/conversations") {
+    return Response.json({ data: [], hasMore: false });
+  }
+  return Response.json({});
+}
+
+export async function POST(req: Request, ctx: Ctx) {
+  const denied = mockGuard();
+  if (denied) return denied;
+  const { path } = await ctx.params;
+
+  if (path.join("/") === "_reset") {
+    resetZernioMock();
+    return Response.json({ ok: true });
+  }
+  if (zernioTokenIsBad(req.headers.get("authorization"))) return unauthorized();
+
+  // POST /inbox/conversations/{id}/messages
+  if (
+    path.length === 4 &&
+    path[0] === "inbox" &&
+    path[1] === "conversations" &&
+    path[3] === "messages"
+  ) {
+    const body = (await req.json().catch(() => ({}))) as Record<string, unknown>;
+    const state = zernioMockState();
+    const n = ++state.seq;
+    state.sent.push({
+      n,
+      conversationId: decodeURIComponent(path[2]!),
+      accountId: body.accountId ? String(body.accountId) : null,
+      message: String(body.message ?? ""),
+      ...(body.messagingType ? { messagingType: String(body.messagingType) } : {}),
+      ...(body.messageTag ? { messageTag: String(body.messageTag) } : {}),
+      idempotencyKey: req.headers.get("idempotency-key"),
+      at: new Date().toISOString(),
+    });
+    return Response.json({ message: { id: `zmock_${n}` } });
+  }
+
+  return Response.json({});
+}

--- a/src/app/api/settings/messenger/route.ts
+++ b/src/app/api/settings/messenger/route.ts
@@ -10,6 +10,7 @@ import {
   channelDisabledResponse,
   isChannelEnabled,
 } from "@/server/channels/enabled";
+import { verifyZernioToken } from "@/server/zernio";
 
 export const dynamic = "force-dynamic";
 
@@ -20,8 +21,10 @@ export const GET = withAuth(async (session) => {
   if (!creds) return Response.json({ connection: null });
   return Response.json({
     connection: {
+      source: creds.source,
       pageId: creds.pageId,
       pageName: creds.pageName,
+      accountRef: creds.accountRef,
       status: creds.status,
       tokenLast4: tokenLast4(creds.token),
     },
@@ -29,13 +32,16 @@ export const GET = withAuth(async (session) => {
 });
 
 const putSchema = z.object({
-  pageId: z.string().trim().min(1),
+  source: z.enum(["zernio", "meta"]).default("meta"),
+  pageId: z.string().trim().min(1).nullish(),
+  accountRef: z.string().trim().min(1).nullish(),
   token: z.string().trim().min(1),
+  webhookSecret: z.string().trim().min(1).nullish(),
 });
 
 /**
- * Guarda la conexión validando ANTES contra Meta, igual que el wizard de
- * WhatsApp: un token que no sirve no llega a la base. Solo el propietario
+ * Guarda la conexión validando ANTES contra la plataforma, igual que el wizard
+ * de WhatsApp: un token que no sirve no llega a la base. Solo el propietario
  * de la organización puede hacerlo.
  */
 export const PUT = withAuth(async (session, req: Request) => {
@@ -45,16 +51,36 @@ export const PUT = withAuth(async (session, req: Request) => {
   }
   const body = await parseBody(req, putSchema);
   if (!body.ok) return body.response;
-  const data = body.data;
+  // `.default()` deja el tipo opcional aunque Zod siempre lo rellene: se fija
+  // aquí para que el resto del handler trabaje con un valor cerrado.
+  const data = { ...body.data, source: body.data.source ?? "meta" };
 
-  const check = await verify(data.pageId, data.token);
+  if (data.source === "meta" && !data.pageId) {
+    return apiError(
+      422,
+      "invalid_body",
+      "En modo Meta hace falta el ID de la página"
+    );
+  }
+  if (data.source === "zernio" && !data.accountRef) {
+    return apiError(
+      422,
+      "invalid_body",
+      "En modo Zernio hace falta el accountId de la cuenta conectada"
+    );
+  }
+
+  const check = await verify(data);
   if (!check.ok) return apiError(check.status, check.code, check.message);
 
   await saveMessengerCredentials({
     organizationId: session.organizationId,
-    pageId: data.pageId,
+    source: data.source,
+    pageId: data.pageId ?? null,
     pageName: check.pageName,
+    accountRef: data.accountRef ?? null,
     token: data.token,
+    webhookSecret: data.webhookSecret ?? null,
   });
 
   return Response.json({ ok: true, pageName: check.pageName });
@@ -64,44 +90,55 @@ type Check =
   | { ok: true; pageName: string | null }
   | { ok: false; status: number; code: string; message: string };
 
-/**
- * El token debe ser de ESA página: se le pregunta a Graph quién es y se
- * compara el id. Un token de otra página guardaría credenciales que reciben
- * webhooks de una y contestan por otra.
- */
-async function verify(pageId: string, token: string): Promise<Check> {
+type VerifyInput = Omit<z.infer<typeof putSchema>, "source"> & {
+  source: "zernio" | "meta";
+};
+
+async function verify(data: VerifyInput): Promise<Check> {
+  if (data.source === "zernio") {
+    try {
+      await verifyZernioToken(data.token);
+      return { ok: true, pageName: null };
+    } catch (err) {
+      return translate(err, "La API key de Zernio no es válida");
+    }
+  }
+
+  // Meta: el token debe ser de ESA página. Un token de otra guardaría
+  // credenciales que reciben webhooks de una y contestan por otra.
   try {
     const res = await graphRequest<{ id?: string; name?: string }>(
-      `${pageId}?fields=id,name`,
-      { token }
+      `${data.pageId}?fields=id,name`,
+      { token: data.token }
     );
-    if (res.id && res.id !== pageId) {
+    if (res.id && res.id !== data.pageId) {
       return {
         ok: false,
         status: 422,
         code: "id_mismatch",
-        message: `El token pertenece a la página ${res.id}, no a ${pageId}`,
+        message: `El token pertenece a la página ${res.id}, no a ${data.pageId}`,
       };
     }
     return { ok: true, pageName: res.name?.trim() || null };
   } catch (err) {
-    if (err instanceof MetaApiError) {
-      if (err.status === 0 || err.status >= 500) {
-        return {
-          ok: false,
-          status: 503,
-          code: "platform_unavailable",
-          message: "No se pudo contactar a Meta; intenta de nuevo",
-        };
-      }
+    return translate(
+      err,
+      "El token de la página no es válido o no tiene permiso de mensajes (pages_messaging)"
+    );
+  }
+}
+
+function translate(err: unknown, invalidMessage: string): Check {
+  if (err instanceof MetaApiError) {
+    if (err.status === 0 || err.status >= 500) {
       return {
         ok: false,
-        status: 422,
-        code: "invalid_token",
-        message:
-          "El token de la página no es válido o no tiene permiso de mensajes (pages_messaging)",
+        status: 503,
+        code: "platform_unavailable",
+        message: "No se pudo contactar la plataforma; intenta de nuevo",
       };
     }
-    throw err;
+    return { ok: false, status: 422, code: "invalid_token", message: invalidMessage };
   }
+  throw err;
 }

--- a/src/app/api/webhooks/messenger/[webhookToken]/route.ts
+++ b/src/app/api/webhooks/messenger/[webhookToken]/route.ts
@@ -1,19 +1,25 @@
 import { after } from "next/server";
 import { getEnv } from "@/lib/env";
 import { isValidSignature, isValidWebhookToken } from "@/server/inbox/webhook";
-import { processMessengerPayload } from "@/server/messenger/ingest";
+import {
+  processMetaPagePayload,
+  processZernioMessengerEvent,
+  resolveZernioMessengerSecret,
+} from "@/server/messenger/ingest";
 import {
   channelDisabledResponse,
   isChannelEnabled,
 } from "@/server/channels/enabled";
+import { isValidZernioSignature, looksLikeMetaPayload, zernioSignatureFrom } from "@/server/zernio";
 
 /**
  * 017 — Webhook público del canal de Messenger.
  *
  * Mismo patrón de dos capas que los de WhatsApp e Instagram: el segmento
- * [webhookToken] debe coincidir (si no → 404 sin efectos) y encima la firma
- * de Meta con el App Secret. Se configura en la app de Meta, producto
- * Messenger → Webhooks: objeto `page`, campo `messages`.
+ * [webhookToken] debe coincidir (si no → 404 sin efectos) y encima la firma.
+ * Acepta las dos fuentes por la misma URL porque sus payloads son
+ * inconfundibles: Meta manda `object: "page"`, Zernio manda un evento plano
+ * con `account`.
  */
 export const dynamic = "force-dynamic";
 
@@ -27,7 +33,7 @@ export async function GET(req: Request, { params }: Params) {
     return new Response(null, { status: 404 });
   }
 
-  // Handshake de Meta: devuelve el challenge en texto plano.
+  // Handshake de Meta (Zernio no lo hace, pero responderlo no estorba).
   const url = new URL(req.url);
   const mode = url.searchParams.get("hub.mode");
   const token = url.searchParams.get("hub.verify_token");
@@ -49,33 +55,45 @@ export async function POST(req: Request, { params }: Params) {
 
   const rawBody = await req.text();
 
-  // Meta firma cada entrega con el App Secret. Sin esta capa, quien conozca
-  // la URL secreta puede inyectar mensajes falsos: el agente los contestaría
-  // enviando un mensaje REAL desde la página al destinatario que el atacante
-  // elija.
-  if (
-    !isValidSignature(
-      rawBody,
-      req.headers.get("x-hub-signature-256"),
-      env.META_APP_SECRET
-    )
-  ) {
-    return new Response(null, { status: 401 });
-  }
-
   let payload: unknown;
   try {
     payload = JSON.parse(rawBody);
   } catch {
-    // Cuerpo ilegible: 200 igualmente para que Meta no reintente en vano.
+    // Cuerpo ilegible: 200 igualmente para que la fuente no reintente en vano.
     return Response.json({ received: true });
   }
 
-  // Meta corta a los pocos segundos y reintenta: se acusa recibo YA y se
-  // procesa fuera de la ruta.
+  const isMeta = looksLikeMetaPayload(payload, "page");
+
+  if (isMeta) {
+    // Meta firma cada entrega con el App Secret. Sin esta capa, quien conozca
+    // la URL secreta puede inyectar mensajes falsos: el agente los contestaría
+    // enviando un mensaje REAL desde la página al destinatario que el atacante
+    // elija.
+    if (
+      !isValidSignature(
+        rawBody,
+        req.headers.get("x-hub-signature-256"),
+        env.META_APP_SECRET
+      )
+    ) {
+      return new Response(null, { status: 401 });
+    }
+  } else {
+    // Zernio: la firma se valida contra el secreto de ESTA cuenta, que hay que
+    // resolver leyendo el cuerpo primero.
+    const { secret } = await resolveZernioMessengerSecret(rawBody);
+    if (!isValidZernioSignature(rawBody, zernioSignatureFrom(req.headers), secret)) {
+      return new Response(null, { status: 401 });
+    }
+  }
+
+  // Zernio corta a los 5 segundos y reintenta; Meta también. Se acusa recibo
+  // YA y se procesa fuera de la ruta.
   after(async () => {
     try {
-      await processMessengerPayload(payload);
+      if (isMeta) await processMetaPagePayload(payload);
+      else await processZernioMessengerEvent(payload);
     } catch (err) {
       console.error("[messenger] error procesando payload:", err);
     }

--- a/src/components/settings/messenger-client.tsx
+++ b/src/components/settings/messenger-client.tsx
@@ -13,19 +13,25 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 
 /**
- * 017 — Conexión de la página de Facebook para la bandeja de Messenger.
+ * 017 — Conexión del canal de Messenger.
  *
- * Misma forma que el wizard de WhatsApp: se prueba contra Meta ANTES de
- * guardar, el token se cifra y hacia fuera solo se enseña su cola. Y la
- * misma regla que Instagram: la pantalla solo existe si el canal está
- * encendido con `CHANNELS` (ADR-001).
+ * Dos fuentes, como Instagram: la API unificada de Zernio o una app propia de
+ * Meta. Misma forma que el wizard de WhatsApp: se prueba contra la plataforma
+ * ANTES de guardar, el token se cifra y hacia fuera solo se enseña su cola. Y
+ * la misma regla que los demás canales: la pantalla solo existe si el canal
+ * está encendido con `CHANNELS` (ADR-001).
  */
 
+type Source = "zernio" | "meta";
+
 type Connection = {
-  pageId: string;
+  source: Source;
+  pageId: string | null;
   pageName: string | null;
+  accountRef: string | null;
   status: "connected" | "reconnect_required";
   tokenLast4: string;
 };
@@ -37,12 +43,35 @@ type WebhookInfo = {
   signatureLayer: boolean;
 };
 
+const HELP: Record<Source, { title: string; items: string[] }> = {
+  zernio: {
+    title: "Conecta la página en Zernio y pega aquí su cuenta y tu API key",
+    items: [
+      "La página se vincula en el panel de Zernio, no desde Vocero. Copia de ahí el accountId de la cuenta de Facebook conectada.",
+      "La API key se crea en Zernio → Settings → API Keys y se muestra una sola vez (empieza con sk_).",
+      "El mismo webhook de Zernio entrega Instagram, WhatsApp y X si esas cuentas están conectadas; Vocero filtra por plataforma y solo ingiere lo de Facebook aquí.",
+      "El secreto del webhook es opcional pero recomendado: con él se verifica la firma de cada entrega.",
+    ],
+  },
+  meta: {
+    title: "Crea una app en developers.facebook.com con el producto Messenger",
+    items: [
+      "El ID de la página está en la sección «Información» de la página, o en Messenger → Configuración → Tokens de acceso.",
+      "Genera ahí el token de la página con el permiso pages_messaging. Uno de larga duración evita reconectar cada dos meses.",
+      "Sin App Review, la página solo recibe mensajes de cuentas con un rol en la app (administradores, desarrolladores, testers).",
+    ],
+  },
+};
+
 export function MessengerClient() {
   const [connection, setConnection] = useState<Connection | null>(null);
   const [webhook, setWebhook] = useState<WebhookInfo | null>(null);
   const [loaded, setLoaded] = useState(false);
+  const [source, setSource] = useState<Source>("zernio");
   const [pageId, setPageId] = useState("");
+  const [accountRef, setAccountRef] = useState("");
   const [token, setToken] = useState("");
+  const [webhookSecret, setWebhookSecret] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState<string | null>(null);
@@ -55,7 +84,11 @@ export function MessengerClient() {
     ]).catch(() => [null, null]);
     if (c) {
       setConnection(c.connection);
-      if (c.connection?.pageId) setPageId(c.connection.pageId);
+      if (c.connection) {
+        setSource(c.connection.source);
+        if (c.connection.pageId) setPageId(c.connection.pageId);
+        if (c.connection.accountRef) setAccountRef(c.connection.accountRef);
+      }
     }
     if (w) setWebhook(w);
     setLoaded(true);
@@ -72,7 +105,13 @@ export function MessengerClient() {
     const res = await fetch("/api/settings/messenger", {
       method: "PUT",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ pageId: pageId.trim(), token: token.trim() }),
+      body: JSON.stringify({
+        source,
+        pageId: pageId.trim() || null,
+        accountRef: accountRef.trim() || null,
+        token: token.trim(),
+        webhookSecret: webhookSecret.trim() || null,
+      }),
     }).catch(() => null);
     setSaving(false);
     if (!res?.ok) {
@@ -84,11 +123,8 @@ export function MessengerClient() {
     }
     const data = (await res.json()) as { pageName?: string | null };
     setToken("");
-    setSaved(
-      data.pageName
-        ? `Página conectada: ${data.pageName}`
-        : "Página conectada"
-    );
+    setWebhookSecret("");
+    setSaved(data.pageName ? `Página conectada: ${data.pageName}` : "Conexión guardada");
     void refetch();
   }
 
@@ -98,13 +134,16 @@ export function MessengerClient() {
       setCopied(what);
       setTimeout(() => setCopied(null), 1500);
     } catch {
-      // sin portapapeles (contexto no seguro): el texto sigue visible para copiarlo a mano
+      // sin portapapeles (contexto no seguro): el texto sigue visible
     }
   }
 
-  if (!loaded) {
-    return <p className="text-sm text-muted-foreground">Cargando…</p>;
-  }
+  if (!loaded) return <p className="text-sm text-muted-foreground">Cargando…</p>;
+
+  const help = HELP[source];
+  const canSave =
+    token.trim().length > 0 &&
+    (source === "zernio" ? accountRef.trim().length > 0 : pageId.trim().length > 0);
 
   return (
     <div className="max-w-3xl space-y-6">
@@ -113,11 +152,11 @@ export function MessengerClient() {
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
           <div>
             <p className="font-medium text-danger-text">
-              El token de la página expiró o fue revocado.
+              El token expiró o fue revocado.
             </p>
             <p className="text-danger-text opacity-80">
-              Los envíos por Messenger están pausados. Pega un token nuevo abajo
-              para reconectar.
+              Los envíos por Messenger están pausados. Pega uno nuevo abajo para
+              reconectar.
             </p>
           </div>
         </div>
@@ -128,11 +167,14 @@ export function MessengerClient() {
           <CheckCircle2 className="h-5 w-5 text-success" />
           <div className="flex-1 text-sm">
             <p className="font-medium text-success-text">
-              Página conectada: {connection.pageName ?? connection.pageId}
+              Conectado por {connection.source === "zernio" ? "Zernio" : "Meta"}
+              {connection.pageName ? `: ${connection.pageName}` : ""}
             </p>
             <p className="text-success-text opacity-80">
-              ID {connection.pageId} · token que termina en ····
-              {connection.tokenLast4}
+              {connection.source === "zernio"
+                ? `Cuenta ${connection.accountRef}`
+                : `Página ${connection.pageId}`}{" "}
+              · token que termina en ····{connection.tokenLast4}
             </p>
           </div>
           <Badge variant="success">Messenger activo</Badge>
@@ -142,64 +184,98 @@ export function MessengerClient() {
       <Card>
         <CardHeader>
           <CardTitle>
-            {connection ? "Reconectar la página" : "Conectar la página de Facebook"}
+            {connection ? "Reconectar Messenger" : "Conectar Messenger"}
           </CardTitle>
           <CardDescription>
-            Los mensajes que la gente le escribe a tu página por Messenger
-            entran a la misma bandeja que WhatsApp, con su distintivo de canal.
-            Necesitas una app en developers.facebook.com con el producto
-            Messenger y el permiso <code>pages_messaging</code>.
+            Los mensajes que la gente le escribe a tu página entran a la misma
+            bandeja que WhatsApp, con su distintivo de canal. {help.title}.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label>¿De dónde llegan los mensajes?</Label>
+            <div className="flex flex-wrap gap-2">
+              {(["zernio", "meta"] as const).map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => setSource(s)}
+                  aria-pressed={source === s}
+                  className={cn(
+                    "rounded-full border px-3.5 py-1.5 text-[12.5px] font-semibold transition-colors",
+                    source === s
+                      ? "border-brand bg-brand-tint text-brand-text"
+                      : "border-border-strong hover:bg-accent"
+                  )}
+                >
+                  {s === "zernio" ? "Zernio (API unificada)" : "App propia de Meta"}
+                </button>
+              ))}
+            </div>
+          </div>
+
           <ul className="list-disc space-y-1 pl-5 text-xs text-text-2">
-            <li>
-              El ID de la página está en la sección «Información» de la página,
-              o en el panel de Messenger de tu app (Messenger → Configuración →
-              Tokens de acceso).
-            </li>
-            <li>
-              Genera ahí el token de la página. Uno de larga duración evita
-              reconectar cada dos meses.
-            </li>
-            <li>
-              Sin App Review, la página solo recibe mensajes de cuentas con un
-              rol en la app (administradores, desarrolladores, testers). Para
-              atender al público hay que aprobar <code>pages_messaging</code>.
-            </li>
+            {help.items.map((item, i) => (
+              <li key={i}>{item}</li>
+            ))}
           </ul>
 
           <div className="grid gap-4 sm:grid-cols-2">
+            {source === "zernio" ? (
+              <div className="space-y-1.5">
+                <Label htmlFor="fb-account">accountId de Zernio</Label>
+                <Input
+                  id="fb-account"
+                  value={accountRef}
+                  onChange={(e) => setAccountRef(e.target.value)}
+                  placeholder="665f1c2e8b3a4d0012345678"
+                  autoComplete="off"
+                />
+              </div>
+            ) : (
+              <div className="space-y-1.5">
+                <Label htmlFor="fb-page-id">ID de la página</Label>
+                <Input
+                  id="fb-page-id"
+                  value={pageId}
+                  onChange={(e) => setPageId(e.target.value)}
+                  placeholder="1234567890"
+                  autoComplete="off"
+                />
+              </div>
+            )}
             <div className="space-y-1.5">
-              <Label htmlFor="fb-page-id">ID de la página</Label>
-              <Input
-                id="fb-page-id"
-                value={pageId}
-                onChange={(e) => setPageId(e.target.value)}
-                placeholder="1234567890"
-                autoComplete="off"
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="fb-token">Token de acceso de la página</Label>
+              <Label htmlFor="fb-token">
+                {source === "zernio" ? "API key de Zernio" : "Token de la página"}
+              </Label>
               <Input
                 id="fb-token"
                 type="password"
                 value={token}
                 onChange={(e) => setToken(e.target.value)}
-                placeholder="EAAG…"
+                placeholder={source === "zernio" ? "sk_…" : "EAAG…"}
                 autoComplete="off"
               />
             </div>
+            {source === "zernio" && (
+              <div className="space-y-1.5">
+                <Label htmlFor="fb-secret">Secreto del webhook (opcional)</Label>
+                <Input
+                  id="fb-secret"
+                  type="password"
+                  value={webhookSecret}
+                  onChange={(e) => setWebhookSecret(e.target.value)}
+                  placeholder="el mismo que pusiste en Zernio"
+                  autoComplete="off"
+                />
+              </div>
+            )}
           </div>
 
           {error && <p className="text-sm text-destructive">{error}</p>}
           {saved && <p className="text-sm text-success-text">{saved} ✓</p>}
 
-          <Button
-            disabled={saving || !pageId.trim() || !token.trim()}
-            onClick={() => void save()}
-          >
+          <Button disabled={saving || !canSave} onClick={() => void save()}>
             {saving ? "Probando…" : "Probar y guardar"}
           </Button>
         </CardContent>
@@ -210,9 +286,19 @@ export function MessengerClient() {
           <CardHeader>
             <CardTitle>Webhook de Messenger</CardTitle>
             <CardDescription>
-              En tu app de Meta: Messenger → Configuración → Webhooks. Objeto{" "}
-              <code>page</code>, campo <code>messages</code>. Pega esta URL y
-              este token de verificación, y suscribe la página a la app.
+              {source === "zernio" ? (
+                <>
+                  En Zernio, da de alta este endpoint con el evento{" "}
+                  <code>message.received</code> y, si usas secreto, el mismo que
+                  pegaste arriba.
+                </>
+              ) : (
+                <>
+                  En tu app de Meta: Messenger → Configuración → Webhooks. Objeto{" "}
+                  <code>page</code>, campo <code>messages</code>. Pega esta URL y
+                  este token de verificación, y suscribe la página a la app.
+                </>
+              )}
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
@@ -230,25 +316,29 @@ export function MessengerClient() {
                 </Button>
               </div>
             </div>
-            <div className="space-y-1.5">
-              <Label>Token de verificación</Label>
-              <div className="flex gap-2">
-                <Input readOnly value={webhook.verifyToken} className="font-mono text-xs" />
-                <Button
-                  variant="outline"
-                  size="icon"
-                  aria-label="Copiar el token de verificación"
-                  onClick={() => void copy(webhook.verifyToken, "token")}
-                >
-                  {copied === "token" ? <CheckCircle2 className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-                </Button>
+            {source === "meta" && (
+              <div className="space-y-1.5">
+                <Label>Token de verificación</Label>
+                <div className="flex gap-2">
+                  <Input readOnly value={webhook.verifyToken} className="font-mono text-xs" />
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    aria-label="Copiar el token de verificación"
+                    onClick={() => void copy(webhook.verifyToken, "token")}
+                  >
+                    {copied === "token" ? <CheckCircle2 className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                  </Button>
+                </div>
               </div>
-            </div>
+            )}
             <p className="flex items-start gap-2 text-xs text-text-2">
               <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-              {webhook.signatureLayer
-                ? "Cada entrega se verifica con la firma del App Secret de tu app."
-                : "Define META_APP_SECRET en la instancia para que además se verifique la firma de cada entrega."}
+              {source === "zernio"
+                ? "Con secreto configurado, cada entrega se verifica con su firma HMAC; sin él, la protección es el segmento secreto de la URL."
+                : webhook.signatureLayer
+                  ? "Cada entrega se verifica con la firma del App Secret de tu app."
+                  : "Define META_APP_SECRET en la instancia para que además se verifique la firma de cada entrega."}
             </p>
           </CardContent>
         </Card>

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -544,12 +544,24 @@ export const messengerCredentials = pgTable(
     organizationId: text("organization_id")
       .notNull()
       .references(() => organization.id, { onDelete: "cascade" }),
-    /** ID de la página de Facebook: por él enruta el webhook (`entry[].id`). */
-    pageId: text("page_id").notNull(),
+    /** De donde vienen los mensajes: API unificada o app propia de Meta. */
+    source: text("source", { enum: ["zernio", "meta"] })
+      .notNull()
+      .default("meta"),
+    /**
+     * ID de la página de Facebook: por él enruta el webhook de Meta
+     * (`entry[].id`). En modo Zernio puede no conocerse — ahí enruta
+     * `account_ref` — así que es opcional.
+     */
+    pageId: text("page_id"),
     pageName: text("page_name"),
+    /** Zernio: accountId de la cuenta conectada. Meta directo: null. */
+    accountRef: text("account_ref"),
     tokenCipher: text("token_cipher").notNull(),
     tokenIv: text("token_iv").notNull(),
     tokenTag: text("token_tag").notNull(),
+    /** Secreto HMAC de las entregas (Zernio); null en modo Meta. */
+    webhookSecret: text("webhook_secret"),
     status: text("status", { enum: ["connected", "reconnect_required"] })
       .notNull()
       .default("connected"),
@@ -559,6 +571,7 @@ export const messengerCredentials = pgTable(
   (t) => [
     uniqueIndex("messenger_credentials_org_uq").on(t.organizationId),
     uniqueIndex("messenger_credentials_page_uq").on(t.pageId),
+    index("messenger_credentials_account_ref_idx").on(t.accountRef),
   ]
 );
 

--- a/src/server/dev/zernio-mock-state.ts
+++ b/src/server/dev/zernio-mock-state.ts
@@ -1,0 +1,43 @@
+/**
+ * 017 — Estado en memoria del mock de Zernio (solo dev/test). Vive en
+ * globalThis porque Next recarga módulos en dev; una instancia = un proceso,
+ * así que el outbox en memoria alcanza para las aserciones del self-test.
+ */
+
+export type ZernioSentMessage = {
+  n: number;
+  conversationId: string;
+  accountId: string | null;
+  message: string;
+  /** Presente solo fuera de la ventana de 24 h. */
+  messagingType?: string;
+  messageTag?: string;
+  /** Llave de idempotencia con la que llegó, si la hubo. */
+  idempotencyKey: string | null;
+  at: string;
+};
+
+type ZernioMockState = {
+  seq: number;
+  sent: ZernioSentMessage[];
+};
+
+const g = globalThis as unknown as { __voceroZernioMock?: ZernioMockState };
+
+export function zernioMockState(): ZernioMockState {
+  if (!g.__voceroZernioMock) g.__voceroZernioMock = { seq: 0, sent: [] };
+  return g.__voceroZernioMock;
+}
+
+export function resetZernioMock(): void {
+  g.__voceroZernioMock = { seq: 0, sent: [] };
+}
+
+/**
+ * Una llave que termina en `-invalid` se rechaza, igual que hace el mock de
+ * Graph: es como el arnés comprueba que unas credenciales malas NO se guardan.
+ */
+export function zernioTokenIsBad(authorization: string | null): boolean {
+  const token = (authorization ?? "").replace(/^Bearer\s+/i, "");
+  return token.length === 0 || token.endsWith("-invalid");
+}

--- a/src/server/inbox/send.ts
+++ b/src/server/inbox/send.ts
@@ -609,6 +609,9 @@ async function callMessengerSend(
     const res = await sendMessengerText({
       credentials: creds,
       recipient: target.recipient,
+      // Zernio responde dentro de SU conversación, no al PSID: sin esta
+      // referencia el envío no tiene a dónde ir.
+      threadRef: target.conversation.channelThreadRef,
       text,
       humanAgentTag,
     });

--- a/src/server/instagram/ingest.ts
+++ b/src/server/instagram/ingest.ts
@@ -1,10 +1,10 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
 import { IG_PREFIX } from "@/server/inbox/identity";
 import { ingestInboundMessage } from "@/server/inbox/ingest";
 import {
   getInstagramCredentialsByAccountRef,
   getInstagramCredentialsByIgUserId,
 } from "@/server/instagram/credentials";
+import { parseZernioEvent, type ZernioEvent } from "@/server/zernio";
 
 /**
  * 014 — Adaptadores de entrada del canal de Instagram.
@@ -15,33 +15,12 @@ import {
  * resuelve contacto, conversación, idempotencia y bus de eventos.
  */
 
-/** Firma de Zernio: HMAC-SHA256 hex del cuerpo CRUDO, con el secreto. */
-export function isValidZernioSignature(
-  rawBody: string,
-  signature: string | null,
-  secret: string | null
-): boolean {
-  if (!secret) return true; // sin secreto configurado, protege la URL secreta
-  if (!signature) return false;
-  const expected = createHmac("sha256", secret).update(rawBody).digest("hex");
-  const a = Buffer.from(expected, "utf8");
-  const b = Buffer.from(signature.trim().toLowerCase(), "utf8");
-  if (a.length !== b.length) return false;
-  return timingSafeEqual(a, b);
-}
-
-type ZernioEvent = {
-  id?: string;
-  event?: string;
-  message?: {
-    id?: string;
-    conversationId?: string;
-    direction?: string;
-    text?: string | null;
-    sender?: { id?: string; name?: string | null; username?: string | null };
-  };
-  account?: { id?: string; platform?: string };
-};
+/**
+ * 017: la verificación de la firma vive en `server/zernio` porque la comparten
+ * todos los canales que entran por esa API. Se re-exporta para no tocar a
+ * quien ya la importaba de aquí.
+ */
+export { isValidZernioSignature } from "@/server/zernio";
 
 /**
  * Evento de Zernio. Devuelve el secreto esperado para poder validar la firma
@@ -51,12 +30,8 @@ type ZernioEvent = {
 export async function resolveZernioSecret(
   rawBody: string
 ): Promise<{ secret: string | null; accountRef: string | null }> {
-  let parsed: ZernioEvent | null = null;
-  try {
-    parsed = JSON.parse(rawBody) as ZernioEvent;
-  } catch {
-    return { secret: null, accountRef: null };
-  }
+  const parsed: ZernioEvent | null = parseZernioEvent(rawBody);
+  if (!parsed) return { secret: null, accountRef: null };
   const accountRef = parsed.account?.id ?? null;
   if (!accountRef) return { secret: null, accountRef: null };
   const creds = await getInstagramCredentialsByAccountRef(accountRef);

--- a/src/server/messenger/credentials.ts
+++ b/src/server/messenger/credentials.ts
@@ -4,20 +4,24 @@ import { newId } from "@/lib/db/ids";
 import { decryptSecret, encryptSecret } from "@/lib/crypto";
 
 /**
- * 017 — Credenciales del canal de Messenger: la página de Facebook y su
- * token de acceso.
+ * 017 — Credenciales del canal de Messenger.
  *
- * Mismo contrato que las de WhatsApp e Instagram: el token viaja descifrado
- * solo en memoria y nunca sale en una respuesta de la API — hacia fuera se
- * expone únicamente su cola.
+ * Dos fuentes, como en Instagram: la API unificada de Zernio (una llave, y el
+ * enrutado por `accountRef`) o una app propia de Meta (token de la página, y
+ * el enrutado por `pageId`). El token viaja descifrado solo en memoria y nunca
+ * sale en una respuesta de la API — hacia fuera se expone su cola.
  */
 
 export type MessengerCredentials = {
   id: string;
   organizationId: string;
-  /** ID de la página de Facebook: por él enruta el webhook (`entry[].id`). */
-  pageId: string;
+  source: "zernio" | "meta";
+  /** ID de la página de Facebook. En modo Zernio puede no conocerse. */
+  pageId: string | null;
   pageName: string | null;
+  /** Zernio: accountId de la cuenta conectada. Meta directo: null. */
+  accountRef: string | null;
+  webhookSecret: string | null;
   status: "connected" | "reconnect_required";
   token: string;
 };
@@ -28,8 +32,11 @@ function toCredentials(row: Row): MessengerCredentials {
   return {
     id: row.id,
     organizationId: row.organizationId,
+    source: row.source,
     pageId: row.pageId,
     pageName: row.pageName,
+    accountRef: row.accountRef,
+    webhookSecret: row.webhookSecret,
     status: row.status,
     token: decryptSecret({
       cipher: row.tokenCipher,
@@ -62,11 +69,26 @@ export async function getMessengerCredentialsByPageId(
   return rows[0] ? toCredentials(rows[0]) : null;
 }
 
+/** Enrutado del webhook de Zernio: el evento trae `account.id`, no la página. */
+export async function getMessengerCredentialsByAccountRef(
+  accountRef: string
+): Promise<MessengerCredentials | null> {
+  const rows = await getDb()
+    .select()
+    .from(schema.messengerCredentials)
+    .where(eq(schema.messengerCredentials.accountRef, accountRef))
+    .limit(1);
+  return rows[0] ? toCredentials(rows[0]) : null;
+}
+
 export async function saveMessengerCredentials(input: {
   organizationId: string;
-  pageId: string;
+  source: "zernio" | "meta";
+  pageId: string | null;
   pageName: string | null;
+  accountRef: string | null;
   token: string;
+  webhookSecret: string | null;
 }): Promise<void> {
   const db = getDb();
   const enc = encryptSecret(input.token);
@@ -74,11 +96,14 @@ export async function saveMessengerCredentials(input: {
 
   const values = {
     organizationId: input.organizationId,
+    source: input.source,
     pageId: input.pageId,
     pageName: input.pageName,
+    accountRef: input.accountRef,
     tokenCipher: enc.cipher,
     tokenIv: enc.iv,
     tokenTag: enc.tag,
+    webhookSecret: input.webhookSecret,
     status: "connected" as const,
     updatedAt: new Date(),
   };

--- a/src/server/messenger/ingest.ts
+++ b/src/server/messenger/ingest.ts
@@ -2,36 +2,48 @@ import { and, eq } from "drizzle-orm";
 import { getDb, schema } from "@/lib/db";
 import { FB_PREFIX } from "@/server/inbox/identity";
 import { ingestInboundMessage } from "@/server/inbox/ingest";
-import { getMessengerCredentialsByPageId } from "@/server/messenger/credentials";
+import {
+  getMessengerCredentialsByAccountRef,
+  getMessengerCredentialsByPageId,
+} from "@/server/messenger/credentials";
 import { fetchMessengerProfileName } from "@/server/messenger/send";
+import { parseZernioEvent, type ZernioEvent } from "@/server/zernio";
 
 /**
- * 017 — Adaptador de entrada del canal de Messenger.
+ * 017 — Adaptadores de entrada del canal de Messenger.
  *
- * Meta manda los mensajes de la página con `object: "page"` y la misma forma
- * `entry[].messaging[]` que usa para Instagram. Aquí se normaliza a la forma
- * interna y de ahí en adelante corre el MISMO núcleo de ingesta que ya
- * resuelve contacto, conversación, idempotencia y bus de eventos (SSE).
+ * Dos fuentes con formatos que no se parecen: Meta manda los mensajes de la
+ * página con `object: "page"` y la forma `entry[].messaging[]`; Zernio manda un
+ * evento plano con `account`. Cada una se normaliza aquí y de ahí en adelante
+ * corre el MISMO núcleo de ingesta que ya resuelve contacto, conversación,
+ * idempotencia y bus de eventos (SSE).
  *
- * El normalizador es una función pura para poder probarla sin base de datos:
- * qué se ingiere y qué se descarta (echos, acuses, postbacks) es la parte que
- * más fácil se rompe cuando Meta cambia un campo.
+ * Los normalizadores son funciones puras para poder probarlos sin base de
+ * datos: qué se ingiere y qué se descarta (echos, acuses, postbacks, otra
+ * plataforma) es la parte que más fácil se rompe cuando el proveedor cambia un
+ * campo.
  */
 
 /** Un mensaje entrante ya en la forma que entiende el núcleo. */
 export type MessengerInbound = {
-  pageId: string;
+  /** Llave de enrutado: la página (Meta) o la cuenta de Zernio. */
+  routeKey: string;
   /** Page-Scoped ID del remitente: la identidad del contacto (`fb:<PSID>`). */
   psid: string;
-  mid: string;
+  /** Id del mensaje en la plataforma, para deduplicar. */
+  messageId: string;
   text: string | null;
   /** Tipo para la bandeja: text | image | video | audio | document | sticker | unsupported */
   type: string;
   /** Segundos desde epoch, como lo consume el núcleo. */
   timestamp: string;
+  /** Nombre del perfil si la fuente lo entrega (Zernio sí, Meta no). */
+  profileName: string | null;
+  /** Hilo en la plataforma de origen: hace falta para responder por Zernio. */
+  threadRef: string | null;
 };
 
-type MessengerPayload = {
+type MetaPagePayload = {
   object?: string;
   entry?: Array<{
     id?: string;
@@ -57,21 +69,24 @@ type MessengerPayload = {
 };
 
 /**
- * Tipos de adjunto de Messenger → tipo de mensaje del CRM. En la v1 el
- * adjunto no se descarga (Messenger lo entrega como URL temporal, no como id
- * de media): el mensaje entra con su tipo para que la bandeja enseñe
- * "📎 Imagen" en vez de perder el mensaje, y el operador sepa que hay algo
- * que ver en la app de la página.
+ * Tipos de adjunto → tipo de mensaje del CRM. En la v1 el adjunto no se
+ * descarga (ambas fuentes lo entregan como URL temporal, no como id de media):
+ * el mensaje entra con su tipo para que la bandeja enseñe "📎 Imagen" en vez
+ * de perder el mensaje, y el operador sepa que hay algo que ver.
  */
 const ATTACHMENT_TYPE: Record<string, string> = {
   image: "image",
   video: "video",
   audio: "audio",
   file: "document",
+  document: "document",
 };
 
-export function normalizeMessengerPayload(payload: unknown): MessengerInbound[] {
-  const body = payload as MessengerPayload | null;
+/** Plataformas con las que Zernio nombra a Messenger. */
+const ZERNIO_MESSENGER_PLATFORMS = new Set(["facebook", "messenger"]);
+
+export function normalizeMetaPagePayload(payload: unknown): MessengerInbound[] {
+  const body = payload as MetaPagePayload | null;
   if (!body || body.object !== "page") return [];
 
   const out: MessengerInbound[] = [];
@@ -94,23 +109,80 @@ export function normalizeMessengerPayload(payload: unknown): MessengerInbound[] 
 
       const text =
         typeof msg.text === "string" && msg.text.length > 0 ? msg.text : null;
-      const attachment = msg.attachments?.[0];
-      let type: string | null = text ? "text" : null;
-      if (!type && attachment) {
-        type = attachment.payload?.sticker_id
-          ? "sticker"
-          : (ATTACHMENT_TYPE[attachment.type ?? ""] ?? "unsupported");
-      }
+      const type = resolveType(text, msg.attachments?.[0]);
       if (!type) continue; // ni texto ni adjunto: no hay nada que ingerir
 
-      const seconds = m.timestamp
-        ? Math.floor(m.timestamp / 1000)
-        : Math.floor(Date.now() / 1000);
-
-      out.push({ pageId, psid, mid, text, type, timestamp: String(seconds) });
+      out.push({
+        routeKey: pageId,
+        psid,
+        messageId: mid,
+        text,
+        type,
+        timestamp: String(
+          m.timestamp ? Math.floor(m.timestamp / 1000) : Math.floor(Date.now() / 1000)
+        ),
+        // Meta no manda nombre ni usuario en el webhook: se consulta aparte.
+        profileName: null,
+        threadRef: null,
+      });
     }
   }
   return out;
+}
+
+/**
+ * Evento de Zernio. El MISMO webhook trae Instagram, WhatsApp y X si esas
+ * cuentas están conectadas: sin el filtro de plataforma acabaríamos ingiriendo
+ * otro canal como si fueran mensajes de la página.
+ */
+export function normalizeZernioEvent(payload: unknown): MessengerInbound[] {
+  const evt = payload as ZernioEvent | null;
+  if (!evt || typeof evt !== "object") return [];
+
+  const platform = (evt.account?.platform ?? "").toLowerCase();
+  if (!ZERNIO_MESSENGER_PLATFORMS.has(platform)) return [];
+  if (evt.event !== "message.received") return [];
+  if (evt.message?.direction && evt.message.direction !== "incoming") return [];
+
+  const accountRef = evt.account?.id;
+  const psid = evt.message?.sender?.id;
+  const messageId = evt.message?.id;
+  if (!accountRef || !psid || !messageId) return [];
+
+  const text =
+    typeof evt.message?.text === "string" && evt.message.text.length > 0
+      ? evt.message.text
+      : null;
+  const type = resolveType(text, evt.message?.attachments?.[0]);
+  if (!type) return [];
+
+  const sender = evt.message?.sender;
+  return [
+    {
+      routeKey: accountRef,
+      psid,
+      messageId,
+      text,
+      type,
+      timestamp: String(Math.floor(Date.now() / 1000)),
+      profileName:
+        sender?.name?.trim() ||
+        (sender?.username ? `@${sender.username}` : null),
+      // Opaco por contrato: se guarda tal cual y no se parsea. Es lo que hace
+      // falta para responder por Zernio.
+      threadRef: evt.message?.conversationId ?? null,
+    },
+  ];
+}
+
+function resolveType(
+  text: string | null,
+  attachment: { type?: string; payload?: { sticker_id?: number } } | undefined
+): string | null {
+  if (text) return "text";
+  if (!attachment) return null;
+  if (attachment.payload?.sticker_id) return "sticker";
+  return ATTACHMENT_TYPE[attachment.type ?? ""] ?? "unsupported";
 }
 
 async function contactExists(
@@ -131,24 +203,65 @@ async function contactExists(
   return rows.length > 0;
 }
 
-export async function processMessengerPayload(payload: unknown): Promise<void> {
-  for (const evt of normalizeMessengerPayload(payload)) {
-    const creds = await getMessengerCredentialsByPageId(evt.pageId);
+/** Resuelve el secreto de firma de la cuenta de Zernio ANTES de procesar. */
+export async function resolveZernioMessengerSecret(
+  rawBody: string
+): Promise<{ secret: string | null; accountRef: string | null }> {
+  const evt = parseZernioEvent(rawBody);
+  const accountRef = evt?.account?.id ?? null;
+  if (!accountRef) return { secret: null, accountRef: null };
+  const creds = await getMessengerCredentialsByAccountRef(accountRef);
+  return { secret: creds?.webhookSecret ?? null, accountRef };
+}
+
+export async function processMetaPagePayload(payload: unknown): Promise<void> {
+  await ingestAll(normalizeMetaPagePayload(payload), "meta");
+}
+
+export async function processZernioMessengerEvent(
+  payload: unknown
+): Promise<void> {
+  await ingestAll(normalizeZernioEvent(payload), "zernio");
+}
+
+async function ingestAll(
+  events: MessengerInbound[],
+  source: "zernio" | "meta"
+): Promise<void> {
+  for (const evt of events) {
+    const creds =
+      source === "meta"
+        ? await getMessengerCredentialsByPageId(evt.routeKey)
+        : await getMessengerCredentialsByAccountRef(evt.routeKey);
+
     if (!creds) {
       console.warn(
-        `[messenger] evento para una página desconocida (${evt.pageId}): ` +
+        `[messenger] evento para una cuenta desconocida (${evt.routeKey}): ` +
           "guarda la conexión en Configuración → Messenger para recibir mensajes"
+      );
+      continue;
+    }
+    if (creds.source !== source) {
+      // Defensa en profundidad: si esta instancia no habla con esa fuente, un
+      // payload con su forma no puede ser legítimo aunque llegue por la URL
+      // correcta. Sin esto, la única barrera de la forma ajena es la URL.
+      console.warn(
+        `[messenger] payload de ${source} en una instancia configurada como ` +
+          `'${creds.source}': descartado`
       );
       continue;
     }
 
     const identity = `${FB_PREFIX}${evt.psid}`;
-    // El nombre se consulta UNA vez, la primera que se ve al PSID: después el
+    // El nombre se resuelve UNA vez, la primera que se ve al PSID: después el
     // contacto ya existe y el nombre que tenga (o el que editó el operador)
-    // manda. Consultarlo en cada mensaje sería un viaje a Meta por renglón.
-    const profileName = (await contactExists(creds.organizationId, identity))
-      ? null
-      : await fetchMessengerProfileName(creds, evt.psid);
+    // manda. Consultarlo en cada mensaje sería un viaje al proveedor por
+    // renglón.
+    const profileName =
+      evt.profileName ??
+      ((await contactExists(creds.organizationId, identity))
+        ? null
+        : await fetchMessengerProfileName(creds, evt.psid));
 
     await ingestInboundMessage({
       organizationId: creds.organizationId,
@@ -161,11 +274,11 @@ export async function processMessengerPayload(payload: unknown): Promise<void> {
       },
       // Prefijado para que no colisione jamás con un id de WhatsApp ni de
       // Instagram en el índice único de mensajes.
-      waMessageId: `fb_${evt.mid}`,
+      waMessageId: `fb_${evt.messageId}`,
       type: evt.type,
       text: evt.text,
       timestamp: evt.timestamp,
-      threadRef: null,
+      threadRef: evt.threadRef,
     });
   }
 }

--- a/src/server/messenger/send.ts
+++ b/src/server/messenger/send.ts
@@ -1,23 +1,25 @@
 import { graphRequest, MetaApiError } from "@/lib/meta/client";
 import type { MessengerCredentials } from "@/server/messenger/credentials";
+import { sendZernioMessage } from "@/server/zernio";
 
 /**
  * 017 — Frontera de salida del canal de Messenger (Constitución II: todo
  * request a una plataforma pasa por un único módulo).
  *
- * Messenger habla por `graph.facebook.com`, el MISMO host que WhatsApp, así
- * que reutiliza el cliente de Graph que ya existe (`graphRequest`): misma
- * versión de API, mismo `META_GRAPH_BASE_URL` (y por tanto el mismo mock en
- * pruebas) y los mismos errores tipados que el resto del CRM ya interpreta.
+ * Dos transportes, misma firma: Zernio (API unificada) y Meta directo. El de
+ * Meta habla por `graph.facebook.com`, el MISMO host que WhatsApp, así que
+ * reutiliza el cliente de Graph que ya existe (`graphRequest`): misma versión
+ * de API, mismo `META_GRAPH_BASE_URL` (y por tanto el mismo mock en pruebas) y
+ * los mismos errores tipados que el resto del CRM ya interpreta.
  */
 
 export type MessengerSendResult = { platformMessageId: string };
 
 /**
- * Cuerpo del envío. Separado para poder afirmarlo en una prueba sin red: la
- * etiqueta de agente humano es lo único que distingue un envío dentro de la
- * ventana de uno fuera, y equivocarla no da error de compilación — da un 400
- * de Meta en producción a las 2 de la mañana.
+ * Cuerpo del envío por Meta. Separado para poder afirmarlo en una prueba sin
+ * red: la etiqueta de agente humano es lo único que distingue un envío dentro
+ * de la ventana de uno fuera, y equivocarla no da error de compilación — da un
+ * 400 de Meta en producción a las 2 de la mañana.
  */
 export function buildMessengerSendBody(input: {
   recipient: string;
@@ -36,22 +38,55 @@ export function buildMessengerSendBody(input: {
 }
 
 /**
- * Envía texto a un PSID (`recipient` viene ya sin el prefijo `fb:`).
+ * Envía texto por el transporte que corresponda.
  *
+ * `recipient` es el PSID (sin el prefijo `fb:`); `threadRef` es el
+ * conversationId opaco de Zernio, que solo hace falta en ese transporte.
+ */
+export async function sendMessengerText(input: {
+  credentials: MessengerCredentials;
+  recipient: string;
+  threadRef: string | null;
+  text: string;
+  humanAgentTag?: boolean;
+  /** Id del mensaje en Vocero: llave natural de idempotencia en Zernio. */
+  idempotencyKey?: string;
+}): Promise<MessengerSendResult> {
+  if (input.credentials.source === "zernio") {
+    return sendZernioMessage({
+      token: input.credentials.token,
+      accountId: input.credentials.accountRef,
+      conversationId: input.threadRef,
+      text: input.text,
+      humanAgentTag: input.humanAgentTag,
+      idempotencyKey: input.idempotencyKey,
+    });
+  }
+  return sendViaMeta(input);
+}
+
+/**
  * Meta responde `{ recipient_id, message_id }`; el mock de Graph del entorno
  * de pruebas responde con la forma de WhatsApp (`messages[0].id`), y se
  * aceptan las dos para que el mismo código sirva en ambos.
  */
-export async function sendMessengerText(input: {
+async function sendViaMeta(input: {
   credentials: MessengerCredentials;
   recipient: string;
   text: string;
   humanAgentTag?: boolean;
 }): Promise<MessengerSendResult> {
+  const { pageId } = input.credentials;
+  if (!pageId) {
+    throw new MetaApiError(
+      "La conexión de Messenger no tiene ID de página para enviar",
+      { status: 400 }
+    );
+  }
   const res = await graphRequest<{
     message_id?: string;
     messages?: { id: string }[];
-  }>(`${input.credentials.pageId}/messages`, {
+  }>(`${pageId}/messages`, {
     method: "POST",
     token: input.credentials.token,
     body: buildMessengerSendBody({
@@ -68,17 +103,18 @@ export async function sendMessengerText(input: {
 }
 
 /**
- * Nombre visible de quien escribe. El webhook de Messenger no trae nombre ni
- * usuario —solo el PSID—, y un contacto llamado "8371…" en la bandeja es
+ * Nombre visible de quien escribe. El webhook de Messenger de Meta no trae
+ * nombre —solo el PSID—, y un contacto llamado "8371…" en la bandeja es
  * inservible para el operador. Se consulta al perfil con el token de la
  * página; si Meta no lo da (permiso ausente, perfil restringido) se devuelve
- * null y la ingesta cae al nombre de respaldo: nunca se bloquea un mensaje
- * por un nombre.
+ * null y la ingesta cae al nombre de respaldo: nunca se bloquea un mensaje por
+ * un nombre. En modo Zernio no hace falta — el evento ya trae el nombre.
  */
 export async function fetchMessengerProfileName(
   credentials: MessengerCredentials,
   psid: string
 ): Promise<string | null> {
+  if (credentials.source !== "meta") return null;
   try {
     const res = await graphRequest<{
       first_name?: string;

--- a/src/server/zernio/index.ts
+++ b/src/server/zernio/index.ts
@@ -1,0 +1,200 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { MetaApiError } from "@/lib/meta/client";
+
+/**
+ * 017 — Transporte de Zernio, compartido por los canales que lo usan.
+ *
+ * Zernio es una API unificada: UNA cuenta y UNA llave entregan los mensajes de
+ * todas las plataformas conectadas (Instagram, Facebook/Messenger, X…) por el
+ * mismo webhook, y se responde por el mismo endpoint de conversaciones. Lo que
+ * distingue el canal es `account.platform`, y lo que enruta a la organización
+ * es `account.id`.
+ *
+ * Esto vive aparte de cada canal a propósito: la verificación de la firma es
+ * un control de seguridad, y dos implementaciones del mismo control son dos
+ * sitios donde equivocarse. El canal decide QUÉ plataforma acepta; este módulo
+ * resuelve CÓMO se habla con Zernio.
+ */
+
+export const ZERNIO_BASE = process.env.ZERNIO_BASE_URL ?? "https://zernio.com/api/v1";
+
+/** Cabeceras con las que Zernio firma sus entregas (la segunda es heredada). */
+const SIGNATURE_HEADERS = ["x-zernio-signature", "x-late-signature"] as const;
+
+export function zernioSignatureFrom(headers: Headers): string | null {
+  for (const h of SIGNATURE_HEADERS) {
+    const value = headers.get(h);
+    if (value) return value;
+  }
+  return null;
+}
+
+/**
+ * Firma de Zernio: HMAC-SHA256 en hex del cuerpo CRUDO, con el secreto de esa
+ * cuenta. Sin secreto configurado la capa queda desactivada y protege solo el
+ * segmento secreto de la URL — mismo trato que da el webhook de WhatsApp a
+ * `META_APP_SECRET`.
+ */
+export function isValidZernioSignature(
+  rawBody: string,
+  signature: string | null,
+  secret: string | null
+): boolean {
+  if (!secret) return true;
+  if (!signature) return false;
+  const expected = createHmac("sha256", secret).update(rawBody).digest("hex");
+  const a = Buffer.from(expected, "utf8");
+  const b = Buffer.from(signature.trim().toLowerCase(), "utf8");
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/** El evento de Zernio, en lo que a Vocero le importa. */
+export type ZernioEvent = {
+  id?: string;
+  event?: string;
+  message?: {
+    id?: string;
+    conversationId?: string;
+    direction?: string;
+    text?: string | null;
+    attachments?: { type?: string; url?: string }[];
+    sender?: { id?: string; name?: string | null; username?: string | null };
+  };
+  account?: { id?: string; platform?: string };
+};
+
+/** Lee el cuerpo crudo como evento de Zernio; null si no lo es. */
+export function parseZernioEvent(rawBody: string): ZernioEvent | null {
+  try {
+    const parsed = JSON.parse(rawBody) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const evt = parsed as ZernioEvent;
+    // Un payload de Meta trae `object`; uno de Zernio trae `account`. Sin
+    // `account` no hay a quién enrutar, así que no es un evento utilizable.
+    return evt.account ? evt : null;
+  } catch {
+    return null;
+  }
+}
+
+/** `true` si el cuerpo es un webhook de Meta (y por tanto NO de Zernio). */
+export function looksLikeMetaPayload(payload: unknown, object: string): boolean {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    (payload as { object?: string }).object === object
+  );
+}
+
+export type ZernioSendResult = { platformMessageId: string };
+
+/**
+ * Responde en una conversación de Zernio.
+ *
+ * `accountId` va en el cuerpo aunque la conversación ya lo implique (lo exige
+ * la API). `Idempotency-Key` evita que un reintento mande el mensaje dos
+ * veces: la llave natural es el id que Vocero ya generó para ese envío.
+ */
+export async function sendZernioMessage(input: {
+  token: string;
+  accountId: string | null;
+  conversationId: string | null;
+  text: string;
+  /** Fuera de la ventana de 24 h, la única etiqueta admitida. */
+  humanAgentTag?: boolean;
+  idempotencyKey?: string;
+}): Promise<ZernioSendResult> {
+  if (!input.conversationId) {
+    throw new MetaApiError(
+      "La conversación no tiene referencia de hilo en Zernio",
+      { status: 400 }
+    );
+  }
+
+  const body: Record<string, unknown> = {
+    accountId: input.accountId,
+    message: input.text,
+  };
+  if (input.humanAgentTag) {
+    body.messagingType = "MESSAGE_TAG";
+    body.messageTag = "HUMAN_AGENT";
+  }
+
+  const res = await zernioFetch(
+    `/inbox/conversations/${encodeURIComponent(input.conversationId)}/messages`,
+    {
+      method: "POST",
+      token: input.token,
+      body,
+      ...(input.idempotencyKey
+        ? { headers: { "Idempotency-Key": input.idempotencyKey } }
+        : {}),
+    }
+  );
+
+  const id =
+    (res as { message?: { id?: string }; id?: string }).message?.id ??
+    (res as { id?: string }).id ??
+    `zernio_${Date.now()}`;
+  return { platformMessageId: String(id) };
+}
+
+/** Comprueba que la llave sirve (se usa antes de guardar una conexión). */
+export async function verifyZernioToken(token: string): Promise<void> {
+  await zernioFetch("/inbox/conversations?limit=1", { token });
+}
+
+/**
+ * Traduce los fallos de Zernio al MetaApiError que el resto del CRM ya sabe
+ * interpretar — incluido `isAuthError`, que distingue una llave muerta de un
+ * hipo transitorio y costó un incidente aprender.
+ */
+async function zernioFetch(
+  path: string,
+  opts: {
+    method?: "GET" | "POST";
+    token: string;
+    body?: unknown;
+    headers?: Record<string, string>;
+  }
+): Promise<unknown> {
+  let res: Response;
+  try {
+    res = await fetch(`${ZERNIO_BASE}${path}`, {
+      method: opts.method ?? "GET",
+      headers: {
+        Authorization: `Bearer ${opts.token}`,
+        ...(opts.body !== undefined ? { "Content-Type": "application/json" } : {}),
+        ...(opts.headers ?? {}),
+      },
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+    });
+  } catch (cause) {
+    throw new MetaApiError("No se pudo contactar la API de Zernio", {
+      status: 0,
+      details: cause,
+    });
+  }
+
+  const text = await res.text();
+  let json: unknown = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    // respuesta no-JSON: se conserva el texto crudo en los detalles
+  }
+
+  if (!res.ok) {
+    const err = json as { error?: { message?: string } | string } | null;
+    const message =
+      typeof err?.error === "string"
+        ? err.error
+        : (err?.error?.message ?? `HTTP ${res.status}`);
+    throw new MetaApiError(message, {
+      status: res.status,
+      details: json ?? text,
+    });
+  }
+  return json;
+}

--- a/tests/unit/messenger.test.ts
+++ b/tests/unit/messenger.test.ts
@@ -4,18 +4,41 @@ import { FB_PREFIX, IG_PREFIX, BSUID_PREFIX } from "@/server/inbox/identity";
 import { capabilitiesFor, textFits, windowClosedMessage } from "@/server/channels/capabilities";
 import { parseChannels } from "@/server/channels/enabled";
 import { channelMark } from "@/components/channel-badge";
-import { normalizeMessengerPayload } from "@/server/messenger/ingest";
+import {
+  normalizeMetaPagePayload,
+  normalizeZernioEvent,
+} from "@/server/messenger/ingest";
 import { buildMessengerSendBody } from "@/server/messenger/send";
+import { isValidZernioSignature, looksLikeMetaPayload } from "@/server/zernio";
+import { createHmac } from "node:crypto";
 
 const PAGE = "1092837465";
 const PSID = "83719264018";
+const ACCOUNT = "665f1c2e8b3a4d0012345678";
 
 /** Un webhook de Meta con lo que trae de verdad: `object: "page"`. */
-function webhook(messaging: unknown[], overrides: Record<string, unknown> = {}) {
+function metaWebhook(messaging: unknown[], overrides: Record<string, unknown> = {}) {
   return {
     object: "page",
     entry: [{ id: PAGE, time: 1_770_000_000_000, messaging }],
     ...overrides,
+  };
+}
+
+/** Un evento de Zernio, con la forma de su documentación. */
+function zernioEvent(over: Record<string, unknown> = {}) {
+  return {
+    id: "5f8e2a1c-0000",
+    event: "message.received",
+    message: {
+      id: "665f0001",
+      conversationId: "664a0001",
+      direction: "incoming",
+      text: "Hola",
+      sender: { id: PSID, name: "Jane Doe", username: "jane_doe" },
+    },
+    account: { id: ACCOUNT, platform: "facebook" },
+    ...over,
   };
 }
 
@@ -52,10 +75,10 @@ describe("017 · Messenger en el catálogo de canales", () => {
   });
 });
 
-describe("017 · normalizeMessengerPayload (qué entra y qué se descarta)", () => {
+describe("017 · normalizeMetaPagePayload (qué entra y qué se descarta)", () => {
   it("un texto entra con su página, su PSID, su mid y su hora en segundos", () => {
-    const [evt, ...rest] = normalizeMessengerPayload(
-      webhook([
+    const [evt, ...rest] = normalizeMetaPagePayload(
+      metaWebhook([
         {
           sender: { id: PSID },
           recipient: { id: PAGE },
@@ -66,18 +89,20 @@ describe("017 · normalizeMessengerPayload (qué entra y qué se descarta)", () 
     );
     expect(rest).toHaveLength(0);
     expect(evt).toEqual({
-      pageId: PAGE,
+      routeKey: PAGE,
       psid: PSID,
-      mid: "m_abc",
+      messageId: "m_abc",
       text: "Hola, ¿tienen envíos?",
       type: "text",
       timestamp: "1770000123",
+      profileName: null,
+      threadRef: null,
     });
   });
 
   it("un adjunto sin texto entra con su tipo para que la bandeja enseñe qué llegó", () => {
-    const [img] = normalizeMessengerPayload(
-      webhook([
+    const [img] = normalizeMetaPagePayload(
+      metaWebhook([
         {
           sender: { id: PSID },
           message: {
@@ -90,13 +115,13 @@ describe("017 · normalizeMessengerPayload (qué entra y qué se descarta)", () 
     expect(img?.type).toBe("image");
     expect(img?.text).toBeNull();
 
-    const [doc] = normalizeMessengerPayload(
-      webhook([{ sender: { id: PSID }, message: { mid: "m_doc", attachments: [{ type: "file" }] } }])
+    const [doc] = normalizeMetaPagePayload(
+      metaWebhook([{ sender: { id: PSID }, message: { mid: "m_doc", attachments: [{ type: "file" }] } }])
     );
     expect(doc?.type).toBe("document");
 
-    const [sticker] = normalizeMessengerPayload(
-      webhook([
+    const [sticker] = normalizeMetaPagePayload(
+      metaWebhook([
         {
           sender: { id: PSID },
           message: { mid: "m_stk", attachments: [{ type: "image", payload: { sticker_id: 369239 } }] },
@@ -107,8 +132,8 @@ describe("017 · normalizeMessengerPayload (qué entra y qué se descarta)", () 
   });
 
   it("los echos (lo que mandó la página), los acuses y los postbacks NO son mensajes", () => {
-    const events = normalizeMessengerPayload(
-      webhook([
+    const events = normalizeMetaPagePayload(
+      metaWebhook([
         { sender: { id: PAGE }, recipient: { id: PSID }, message: { mid: "m_echo", text: "Gracias", is_echo: true } },
         { sender: { id: PSID }, delivery: { mids: ["m_1"], watermark: 1 } },
         { sender: { id: PSID }, read: { watermark: 1 } },
@@ -119,31 +144,138 @@ describe("017 · normalizeMessengerPayload (qué entra y qué se descarta)", () 
   });
 
   it("lo que no es un webhook de página se ignora entero", () => {
-    expect(normalizeMessengerPayload(webhook([{ sender: { id: PSID }, message: { mid: "m", text: "x" } }], { object: "instagram" }))).toEqual([]);
-    expect(normalizeMessengerPayload(null)).toEqual([]);
-    expect(normalizeMessengerPayload("basura")).toEqual([]);
-    expect(normalizeMessengerPayload({ object: "page" })).toEqual([]);
+    expect(
+      normalizeMetaPagePayload(metaWebhook([{ sender: { id: PSID }, message: { mid: "m", text: "x" } }], { object: "instagram" }))
+    ).toEqual([]);
+    expect(normalizeMetaPagePayload(null)).toEqual([]);
+    expect(normalizeMetaPagePayload("basura")).toEqual([]);
+    expect(normalizeMetaPagePayload({ object: "page" })).toEqual([]);
+    // Un evento de Zernio NO debe colarse por el normalizador de Meta.
+    expect(normalizeMetaPagePayload(zernioEvent())).toEqual([]);
   });
 
   it("sin remitente o sin mid no hay con qué identificar ni deduplicar: se descarta", () => {
     expect(
-      normalizeMessengerPayload(webhook([{ message: { mid: "m", text: "x" } }, { sender: { id: PSID }, message: { text: "x" } }]))
+      normalizeMetaPagePayload(metaWebhook([{ message: { mid: "m", text: "x" } }, { sender: { id: PSID }, message: { text: "x" } }]))
     ).toEqual([]);
   });
 
   it("varias entradas y varios mensajes se aplanan en orden", () => {
-    const events = normalizeMessengerPayload({
+    const events = normalizeMetaPagePayload({
       object: "page",
       entry: [
         { id: PAGE, messaging: [{ sender: { id: "a" }, message: { mid: "1", text: "uno" } }] },
         { id: "otra-pagina", messaging: [{ sender: { id: "b" }, message: { mid: "2", text: "dos" } }] },
       ],
     });
-    expect(events.map((e) => `${e.pageId}/${e.psid}/${e.mid}`)).toEqual([`${PAGE}/a/1`, "otra-pagina/b/2"]);
+    expect(events.map((e) => `${e.routeKey}/${e.psid}/${e.messageId}`)).toEqual([`${PAGE}/a/1`, "otra-pagina/b/2"]);
   });
 });
 
-describe("017 · buildMessengerSendBody", () => {
+describe("017 · normalizeZernioEvent (la fuente unificada)", () => {
+  it("un mensaje de Facebook entra con su cuenta, su PSID, su hilo y el nombre del perfil", () => {
+    const [evt] = normalizeZernioEvent(zernioEvent());
+    expect(evt?.routeKey).toBe(ACCOUNT);
+    expect(evt?.psid).toBe(PSID);
+    expect(evt?.messageId).toBe("665f0001");
+    expect(evt?.text).toBe("Hola");
+    expect(evt?.type).toBe("text");
+    // El conversationId es lo ÚNICO con lo que se puede responder por Zernio.
+    expect(evt?.threadRef).toBe("664a0001");
+    expect(evt?.profileName).toBe("Jane Doe");
+  });
+
+  it("sin nombre cae al usuario con arroba, que sigue siendo legible", () => {
+    const [evt] = normalizeZernioEvent(
+      zernioEvent({
+        message: {
+          id: "m1",
+          conversationId: "c1",
+          direction: "incoming",
+          text: "hola",
+          sender: { id: PSID, username: "jane_doe" },
+        },
+      })
+    );
+    expect(evt?.profileName).toBe("@jane_doe");
+  });
+
+  it("el MISMO webhook trae otras plataformas: solo se ingiere Facebook/Messenger", () => {
+    for (const platform of ["instagram", "whatsapp", "x", "tiktok", ""]) {
+      expect(
+        normalizeZernioEvent(zernioEvent({ account: { id: ACCOUNT, platform } }))
+      ).toEqual([]);
+    }
+    expect(
+      normalizeZernioEvent(zernioEvent({ account: { id: ACCOUNT, platform: "MESSENGER" } }))
+    ).toHaveLength(1);
+  });
+
+  it("solo `message.received` entrante: lo demás es ruido de la bandeja de Zernio", () => {
+    expect(normalizeZernioEvent(zernioEvent({ event: "message.sent" }))).toEqual([]);
+    expect(normalizeZernioEvent(zernioEvent({ event: "message.read" }))).toEqual([]);
+    expect(
+      normalizeZernioEvent(
+        zernioEvent({
+          message: { id: "m", conversationId: "c", direction: "outgoing", text: "x", sender: { id: PSID } },
+        })
+      )
+    ).toEqual([]);
+  });
+
+  it("sin cuenta, sin remitente o sin id de mensaje no se puede enrutar ni deduplicar", () => {
+    expect(normalizeZernioEvent(zernioEvent({ account: { platform: "facebook" } }))).toEqual([]);
+    expect(
+      normalizeZernioEvent(zernioEvent({ message: { id: "m", direction: "incoming", text: "x" } }))
+    ).toEqual([]);
+    expect(normalizeZernioEvent(null)).toEqual([]);
+    expect(normalizeZernioEvent({ object: "page" })).toEqual([]);
+  });
+
+  it("un adjunto de Zernio también entra con su tipo", () => {
+    const [evt] = normalizeZernioEvent(
+      zernioEvent({
+        message: {
+          id: "m_img",
+          conversationId: "c1",
+          direction: "incoming",
+          text: null,
+          attachments: [{ type: "image", url: "https://cdn/x.jpg" }],
+          sender: { id: PSID },
+        },
+      })
+    );
+    expect(evt?.type).toBe("image");
+    expect(evt?.text).toBeNull();
+  });
+});
+
+describe("017 · firma de Zernio (control de seguridad compartido)", () => {
+  const body = JSON.stringify(zernioEvent());
+  const secret = "s3cr3t0";
+  const good = createHmac("sha256", secret).update(body).digest("hex");
+
+  it("acepta la firma correcta y rechaza la que no lo es", () => {
+    expect(isValidZernioSignature(body, good, secret)).toBe(true);
+    expect(isValidZernioSignature(body, good.toUpperCase(), secret)).toBe(true);
+    expect(isValidZernioSignature(body, "deadbeef", secret)).toBe(false);
+    expect(isValidZernioSignature(body + " ", good, secret)).toBe(false);
+    expect(isValidZernioSignature(body, null, secret)).toBe(false);
+  });
+
+  it("sin secreto configurado la capa queda desactivada, como en WhatsApp", () => {
+    expect(isValidZernioSignature(body, null, null)).toBe(true);
+  });
+
+  it("distingue un payload de Meta de uno de Zernio", () => {
+    expect(looksLikeMetaPayload({ object: "page" }, "page")).toBe(true);
+    expect(looksLikeMetaPayload({ object: "instagram" }, "page")).toBe(false);
+    expect(looksLikeMetaPayload(zernioEvent(), "page")).toBe(false);
+    expect(looksLikeMetaPayload(null, "page")).toBe(false);
+  });
+});
+
+describe("017 · buildMessengerSendBody (transporte de Meta)", () => {
   it("dentro de la ventana es una RESPONSE normal", () => {
     expect(buildMessengerSendBody({ recipient: PSID, text: "Sí, a toda la ciudad", humanAgentTag: false })).toEqual({
       recipient: { id: PSID },


### PR DESCRIPTION
## Por qué

El canal de Messenger ([#45](https://github.com/kevinrivm/vocero-crm/pull/45)) nació hablando solo con Meta: token de página y `graph.facebook.com`. Instagram ya soportaba las dos fuentes, y una instalación que trae Instagram por **Zernio** quiere traer la página de Facebook por el mismo sitio: una llave, un webhook y una factura. Ahora Messenger admite las dos y se elige en **Configuración → Messenger**.

## Qué cambia

- **`src/server/zernio/`** — la API unificada pasa a un módulo propio: firma HMAC de las entregas, detección de payload de Meta, envío a `POST /inbox/conversations/{id}/messages` con `Idempotency-Key`, y validación de la llave. Instagram **delega ahí** su verificación de firma, así que ese control de seguridad queda con UNA implementación en vez de dos.
- **Modelo**: `messenger_credentials` gana `source` / `account_ref` / `webhook_secret`, y `page_id` pasa a opcional — en Zernio enruta la cuenta, no la página. Migración `0012` aditiva y re-ejecutable.
- **Ingesta**: el webhook acepta las dos formas por la misma URL (son inconfundibles: Meta manda `object: "page"`, Zernio un evento plano con `account`) y valida la firma que corresponda a cada una. El normalizador de Zernio **descarta lo que no sea la plataforma de Facebook**, porque el mismo webhook entrega Instagram, WhatsApp y X. El nombre del contacto sale del evento cuando la fuente lo manda, sin un viaje extra al proveedor.
- **Salida**: se enruta por fuente dentro del canal. Zernio responde en el `conversationId` opaco que guardó la ingesta (`conversation.channel_thread_ref`); sin esa referencia no habría a dónde contestar.
- **UI**: selector de fuente, campos según la elegida, y la ayuda y el bloque de webhook cambian con ella.
- **Mock**: `/api/dev/zernio-mock` con el mismo `mockGuard()` que los de Zoom y Google (404 incondicional en producción).

## Verificación

- typecheck, lint, build y **397** pruebas unitarias en verde (21 del canal: los dos normalizadores, la firma HMAC y el cuerpo de envío).
- `scripts/e2e-messenger.mjs`: **42/42** contra los mocks, cubriendo las **dos** fuentes de punta a punta — conexión validada antes de guardar, firma buena y mala, entrante, idempotencia, ruido de otras plataformas por el mismo webhook, defensa entre fuentes, y salida por cada transporte con y sin etiqueta de agente humano.

## Nota

La regresión de WhatsApp (`scripts/e2e-selftest.mjs`) quedó sin re-correr en esta rama porque Docker Desktop se cayó en la máquina local a mitad de la verificación; la rama no toca el camino de WhatsApp (solo `send.ts` en la llamada de Messenger y el helper de firma que usaba Instagram). CI corre los cuatro gates en las dos configuraciones de canales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
