### PR TITLE
fix(017): un webhook de Zernio reparte a todos sus canales

### DIFF
--- a/scripts/e2e-messenger.mjs
+++ b/scripts/e2e-messenger.mjs
@@ -20,8 +20,12 @@ const VERIFY_TOKEN = process.env.META_WEBHOOK_VERIFY_TOKEN;
 const PAGE = "page-demo-001";
 const ACCOUNT = "zernio-account-001";
 const SECRET = "secreto-del-webhook-de-zernio";
-const PSID_META = `psid-meta-${Date.now()}`;
-const PSID_ZERNIO = `psid-zernio-${Date.now()}`;
+const RUN = Date.now().toString(36);
+const PSID_META = `psid-meta-${RUN}`;
+const PSID_ZERNIO = `psid-zernio-${RUN}`;
+/** Marca de esta corrida: el arnes se puede repetir sobre la misma base. */
+const MARCA = `#${RUN}`;
+const NOMBRE_ZERNIO = `Jane Doe ${MARCA}`;
 
 let cookie = "";
 let failures = 0;
@@ -84,7 +88,7 @@ function zernioEvent(over = {}) {
       conversationId: "zconv-001",
       direction: "incoming",
       text: "Hola desde Facebook",
-      sender: { id: PSID_ZERNIO, name: "Jane Doe", username: "jane_doe" },
+      sender: { id: PSID_ZERNIO, name: NOMBRE_ZERNIO, username: "jane_doe" },
       ...(over.message ?? {}),
     },
     account: { id: ACCOUNT, platform: "facebook", ...(over.account ?? {}) },
@@ -176,12 +180,12 @@ async function main() {
         sender: { id: PSID_META },
         recipient: { id: PAGE },
         timestamp: Date.now(),
-        message: { mid: `m_${PSID_META}_1`, text: "Hola, ¿tienen envíos a Guadalajara?" },
+        message: { mid: `m_${PSID_META}_1`, text: `Hola, ¿tienen envíos a Guadalajara? ${MARCA}` },
       },
     ])
   );
   ok("el proveedor recibe 200 de inmediato", first.status === 200);
-  const convMeta = await waitForConversation((c) => c.preview?.includes("Guadalajara"));
+  const convMeta = await waitForConversation((c) => c.preview?.includes(MARCA));
   ok("la conversación aparece en la bandeja", Boolean(convMeta));
   ok("con canal messenger", convMeta?.channel === "messenger", convMeta?.channel);
   ok(
@@ -194,7 +198,7 @@ async function main() {
 
   console.log("\n== Idempotencia y ruido (Meta) ==");
   await webhook(
-    metaEvent([{ sender: { id: PSID_META }, message: { mid: `m_${PSID_META}_1`, text: "Hola, ¿tienen envíos a Guadalajara?" } }])
+    metaEvent([{ sender: { id: PSID_META }, message: { mid: `m_${PSID_META}_1`, text: `Hola, ¿tienen envíos a Guadalajara? ${MARCA}` } }])
   );
   await webhook(
     metaEvent([
@@ -213,7 +217,7 @@ async function main() {
   const inbound = (msgs.json?.messages ?? []).filter((m) => m.direction === "in");
   ok(
     "el webhook repetido NO duplica el mensaje",
-    inbound.filter((m) => m.text?.includes("Guadalajara")).length === 1,
+    inbound.filter((m) => m.text?.includes(MARCA)).length === 1,
     `in=${inbound.length}`
   );
   ok("echo, acuses y lectura no crean mensajes", inbound.every((m) => m.text !== "eco"));
@@ -295,10 +299,10 @@ async function main() {
   const evt = zernioEvent();
   const okFirma = await webhook(evt, { signature: sign(evt) });
   ok("firma válida → 200", okFirma.status === 200, String(okFirma.status));
-  const convZ = await waitForConversation((c) => c.contact?.name === "Jane Doe");
+  const convZ = await waitForConversation((c) => c.contact?.name === NOMBRE_ZERNIO);
   ok("la conversación aparece en la bandeja", Boolean(convZ));
   ok("con canal messenger", convZ?.channel === "messenger", convZ?.channel);
-  ok("el nombre viene del evento, sin consultar a nadie", convZ?.contact?.name === "Jane Doe", convZ?.contact?.name);
+  ok("el nombre viene del evento, sin consultar a nadie", convZ?.contact?.name === NOMBRE_ZERNIO, convZ?.contact?.name);
 
   console.log("\n== Zernio: ruido de otras plataformas y duplicados ==");
   const otra = zernioEvent({
@@ -339,7 +343,7 @@ async function main() {
   console.log("\n== Salida por Zernio ==");
   const replyZ = await api(`/api/conversations/${convZ?.id}/messages`, {
     method: "POST",
-    body: JSON.stringify({ text: "Claro, te mando el catálogo" }),
+    body: JSON.stringify({ text: `Claro, te mando el catálogo ${MARCA}` }),
   });
   ok("POST /messages → 200/201", replyZ.res.ok, JSON.stringify(replyZ.json));
   const sentZ = await fetch(`${BASE}/api/dev/zernio-mock/_sent`).then((r) => r.json());
@@ -350,7 +354,7 @@ async function main() {
     lastZ?.conversationId === "zconv-001" && lastZ?.accountId === ACCOUNT,
     JSON.stringify(lastZ)
   );
-  ok("con el texto que escribió el operador", lastZ?.message === "Claro, te mando el catálogo");
+  ok("con el texto que escribió el operador", lastZ?.message === `Claro, te mando el catálogo ${MARCA}`);
   ok(
     "dentro de la ventana NO va etiquetado como agente humano",
     !lastZ?.messageTag,

--- a/src/app/api/dev/zernio-mock/[...path]/route.ts
+++ b/src/app/api/dev/zernio-mock/[...path]/route.ts
@@ -1,5 +1,6 @@
 import { mockGuard } from "@/lib/dev-guard";
 import {
+  nextZernioMessageId,
   resetZernioMock,
   zernioMockState,
   zernioTokenIsBad,
@@ -63,9 +64,9 @@ export async function POST(req: Request, ctx: Ctx) {
   ) {
     const body = (await req.json().catch(() => ({}))) as Record<string, unknown>;
     const state = zernioMockState();
-    const n = ++state.seq;
+    const id = nextZernioMessageId();
     state.sent.push({
-      n,
+      n: state.seq,
       conversationId: decodeURIComponent(path[2]!),
       accountId: body.accountId ? String(body.accountId) : null,
       message: String(body.message ?? ""),
@@ -74,7 +75,7 @@ export async function POST(req: Request, ctx: Ctx) {
       idempotencyKey: req.headers.get("idempotency-key"),
       at: new Date().toISOString(),
     });
-    return Response.json({ message: { id: `zmock_${n}` } });
+    return Response.json({ message: { id } });
   }
 
   return Response.json({});

--- a/src/app/api/webhooks/ig/[webhookToken]/route.ts
+++ b/src/app/api/webhooks/ig/[webhookToken]/route.ts
@@ -1,16 +1,13 @@
 import { after } from "next/server";
 import { getEnv } from "@/lib/env";
 import { isValidSignature, isValidWebhookToken } from "@/server/inbox/webhook";
-import {
-  isValidZernioSignature,
-  processMetaInstagramPayload,
-  processZernioEvent,
-  resolveZernioSecret,
-} from "@/server/instagram/ingest";
+import { processMetaInstagramPayload } from "@/server/instagram/ingest";
 import {
   channelDisabledResponse,
   isChannelEnabled,
 } from "@/server/channels/enabled";
+import { isValidZernioSignature, zernioSignatureFrom } from "@/server/zernio";
+import { processZernioPayload, resolveZernioSecret } from "@/server/zernio/dispatch";
 
 /**
  * 014 — Webhook público del canal de Instagram.
@@ -80,10 +77,7 @@ export async function POST(req: Request, { params }: Params) {
     // Zernio: la firma se valida contra el secreto de ESTA cuenta, que hay que
     // resolver leyendo el cuerpo primero.
     const { secret } = await resolveZernioSecret(rawBody);
-    const signature =
-      req.headers.get("x-zernio-signature") ??
-      req.headers.get("x-late-signature");
-    if (!isValidZernioSignature(rawBody, signature, secret)) {
+    if (!isValidZernioSignature(rawBody, zernioSignatureFrom(req.headers), secret)) {
       return new Response(null, { status: 401 });
     }
   }
@@ -92,10 +86,13 @@ export async function POST(req: Request, { params }: Params) {
   // fuera de la ruta.
   after(async () => {
     try {
+      // Un evento de Zernio se reparte por plataforma: esa API entrega TODAS
+      // las cuentas de la llave por un solo webhook, asi que esta URL tambien
+      // puede traer mensajes de la pagina de Facebook.
       if (isMeta) {
         await processMetaInstagramPayload(payload);
       } else {
-        await processZernioEvent(payload);
+        await processZernioPayload(payload);
       }
     } catch (err) {
       console.error("[ig] error procesando payload:", err);

--- a/src/app/api/webhooks/messenger/[webhookToken]/route.ts
+++ b/src/app/api/webhooks/messenger/[webhookToken]/route.ts
@@ -1,16 +1,13 @@
 import { after } from "next/server";
 import { getEnv } from "@/lib/env";
 import { isValidSignature, isValidWebhookToken } from "@/server/inbox/webhook";
-import {
-  processMetaPagePayload,
-  processZernioMessengerEvent,
-  resolveZernioMessengerSecret,
-} from "@/server/messenger/ingest";
+import { processMetaPagePayload } from "@/server/messenger/ingest";
 import {
   channelDisabledResponse,
   isChannelEnabled,
 } from "@/server/channels/enabled";
 import { isValidZernioSignature, looksLikeMetaPayload, zernioSignatureFrom } from "@/server/zernio";
+import { processZernioPayload, resolveZernioSecret } from "@/server/zernio/dispatch";
 
 /**
  * 017 — Webhook público del canal de Messenger.
@@ -82,7 +79,7 @@ export async function POST(req: Request, { params }: Params) {
   } else {
     // Zernio: la firma se valida contra el secreto de ESTA cuenta, que hay que
     // resolver leyendo el cuerpo primero.
-    const { secret } = await resolveZernioMessengerSecret(rawBody);
+    const { secret } = await resolveZernioSecret(rawBody);
     if (!isValidZernioSignature(rawBody, zernioSignatureFrom(req.headers), secret)) {
       return new Response(null, { status: 401 });
     }
@@ -92,8 +89,10 @@ export async function POST(req: Request, { params }: Params) {
   // YA y se procesa fuera de la ruta.
   after(async () => {
     try {
+      // Un evento de Zernio se reparte por plataforma: la misma URL sirve para
+      // Instagram y para Messenger, porque Zernio entrega todo por un webhook.
       if (isMeta) await processMetaPagePayload(payload);
-      else await processZernioMessengerEvent(payload);
+      else await processZernioPayload(payload);
     } catch (err) {
       console.error("[messenger] error procesando payload:", err);
     }

--- a/src/server/dev/zernio-mock-state.ts
+++ b/src/server/dev/zernio-mock-state.ts
@@ -29,8 +29,22 @@ export function zernioMockState(): ZernioMockState {
   return g.__voceroZernioMock;
 }
 
+/** Vacía lo enviado. El contador NO se reinicia: ver `nextZernioMessageId`. */
 export function resetZernioMock(): void {
-  g.__voceroZernioMock = { seq: 0, sent: [] };
+  zernioMockState().sent = [];
+}
+
+/**
+ * Id del mensaje que el mock le devuelve al CRM.
+ *
+ * Lleva la marca de tiempo del proceso, no solo un contador: el CRM guarda ese
+ * id con un índice ÚNICO, así que dos corridas del arnés contra la misma base
+ * chocarían con `zmock_1` y el envío fallaría por una colisión del harness,
+ * que se ve igual que un bug del producto.
+ */
+export function nextZernioMessageId(): string {
+  const state = zernioMockState();
+  return `zmock_${Date.now().toString(36)}_${++state.seq}`;
 }
 
 /**

--- a/src/server/messenger/ingest.ts
+++ b/src/server/messenger/ingest.ts
@@ -7,7 +7,7 @@ import {
   getMessengerCredentialsByPageId,
 } from "@/server/messenger/credentials";
 import { fetchMessengerProfileName } from "@/server/messenger/send";
-import { parseZernioEvent, type ZernioEvent } from "@/server/zernio";
+import type { ZernioEvent } from "@/server/zernio";
 
 /**
  * 017 — Adaptadores de entrada del canal de Messenger.
@@ -201,17 +201,6 @@ async function contactExists(
     )
     .limit(1);
   return rows.length > 0;
-}
-
-/** Resuelve el secreto de firma de la cuenta de Zernio ANTES de procesar. */
-export async function resolveZernioMessengerSecret(
-  rawBody: string
-): Promise<{ secret: string | null; accountRef: string | null }> {
-  const evt = parseZernioEvent(rawBody);
-  const accountRef = evt?.account?.id ?? null;
-  if (!accountRef) return { secret: null, accountRef: null };
-  const creds = await getMessengerCredentialsByAccountRef(accountRef);
-  return { secret: creds?.webhookSecret ?? null, accountRef };
 }
 
 export async function processMetaPagePayload(payload: unknown): Promise<void> {

--- a/src/server/zernio/dispatch.ts
+++ b/src/server/zernio/dispatch.ts
@@ -1,0 +1,73 @@
+import type { Channel } from "@/lib/channels";
+import { isChannelEnabled } from "@/server/channels/enabled";
+import { getInstagramCredentialsByAccountRef } from "@/server/instagram/credentials";
+import { processZernioEvent } from "@/server/instagram/ingest";
+import { getMessengerCredentialsByAccountRef } from "@/server/messenger/credentials";
+import { processZernioMessengerEvent } from "@/server/messenger/ingest";
+import { parseZernioEvent, type ZernioEvent } from "@/server/zernio";
+
+/**
+ * 017 — Reparto de un evento de Zernio al canal que le toca.
+ *
+ * Zernio entrega TODAS las plataformas conectadas a esa llave por UN solo
+ * webhook: el que se dé de alta recibe los DMs de Instagram y los mensajes de
+ * la página de Facebook por igual. Si cada canal solo atendiera su propia URL,
+ * quien tenga el webhook apuntado a `/api/webhooks/ig/...` vería sus mensajes
+ * de Messenger descartados en silencio — el peor modo de fallo posible, porque
+ * el webhook responde 200 y no hay nada que investigar.
+ *
+ * Así que ambas rutas de Zernio reparten por `account.platform`, y da igual
+ * cuál de las dos URLs esté configurada.
+ */
+
+/** A qué canal pertenece un evento, o null si no es de ninguno nuestro. */
+export function zernioTargetChannel(payload: unknown): Channel | null {
+  const evt = payload as ZernioEvent | null;
+  if (!evt || typeof evt !== "object") return null;
+  const platform = (evt.account?.platform ?? "").toLowerCase();
+  if (platform === "instagram") return "instagram";
+  if (platform === "facebook" || platform === "messenger") return "messenger";
+  return null;
+}
+
+/**
+ * El secreto de firma de la cuenta que manda el evento, buscándolo en el canal
+ * que corresponda. Se resuelve ANTES de procesar, leyendo solo el cuerpo: la
+ * firma se valida contra el secreto de ESA cuenta, no uno global.
+ */
+export async function resolveZernioSecret(
+  rawBody: string
+): Promise<{ secret: string | null; accountRef: string | null; channel: Channel | null }> {
+  const evt = parseZernioEvent(rawBody);
+  const accountRef = evt?.account?.id ?? null;
+  const channel = zernioTargetChannel(evt);
+  if (!accountRef) return { secret: null, accountRef: null, channel };
+
+  const creds =
+    channel === "messenger"
+      ? await getMessengerCredentialsByAccountRef(accountRef)
+      : channel === "instagram"
+        ? await getInstagramCredentialsByAccountRef(accountRef)
+        : null;
+
+  return { secret: creds?.webhookSecret ?? null, accountRef, channel };
+}
+
+/**
+ * Procesa el evento por el canal al que pertenece. Un canal apagado descarta
+ * con aviso: la instancia no lo tiene, y su superficie no existe (ADR-001).
+ */
+export async function processZernioPayload(payload: unknown): Promise<void> {
+  const channel = zernioTargetChannel(payload);
+  if (!channel) return; // otra plataforma conectada a la misma llave: no es nuestra
+
+  if (!isChannelEnabled(channel)) {
+    console.warn(
+      `[zernio] evento de ${channel} con el canal apagado en esta instancia: descartado`
+    );
+    return;
+  }
+
+  if (channel === "messenger") await processZernioMessengerEvent(payload);
+  else await processZernioEvent(payload);
+}

--- a/tests/unit/messenger.test.ts
+++ b/tests/unit/messenger.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@/server/messenger/ingest";
 import { buildMessengerSendBody } from "@/server/messenger/send";
 import { isValidZernioSignature, looksLikeMetaPayload } from "@/server/zernio";
+import { zernioTargetChannel } from "@/server/zernio/dispatch";
 import { createHmac } from "node:crypto";
 
 const PAGE = "1092837465";
@@ -272,6 +273,25 @@ describe("017 · firma de Zernio (control de seguridad compartido)", () => {
     expect(looksLikeMetaPayload({ object: "instagram" }, "page")).toBe(false);
     expect(looksLikeMetaPayload(zernioEvent(), "page")).toBe(false);
     expect(looksLikeMetaPayload(null, "page")).toBe(false);
+  });
+});
+
+describe("017 · reparto de Zernio por plataforma (un webhook, varios canales)", () => {
+  it("manda cada plataforma a su canal", () => {
+    // Zernio entrega TODAS las cuentas de la llave por un solo webhook: si
+    // cada canal atendiera solo su URL, quien tenga el webhook apuntado a
+    // Instagram vería sus mensajes de Messenger descartados en silencio.
+    expect(zernioTargetChannel(zernioEvent({ account: { id: ACCOUNT, platform: "instagram" } }))).toBe("instagram");
+    expect(zernioTargetChannel(zernioEvent({ account: { id: ACCOUNT, platform: "facebook" } }))).toBe("messenger");
+    expect(zernioTargetChannel(zernioEvent({ account: { id: ACCOUNT, platform: "MESSENGER" } }))).toBe("messenger");
+  });
+
+  it("una plataforma que Vocero no atiende no es de nadie", () => {
+    for (const platform of ["whatsapp", "x", "tiktok", "linkedin", ""]) {
+      expect(zernioTargetChannel(zernioEvent({ account: { id: ACCOUNT, platform } }))).toBeNull();
+    }
+    expect(zernioTargetChannel(null)).toBeNull();
+    expect(zernioTargetChannel({ object: "page" })).toBeNull();
   });
 });
 


### PR DESCRIPTION
## El fallo que esto evita

Zernio entrega **todas** las plataformas conectadas a una llave por **un solo webhook**. Con un endpoint por canal, quien tenga su webhook apuntado a `/api/webhooks/ig/<token>` vería sus mensajes de Messenger descartados en silencio: el filtro de plataforma del normalizador de Instagram los tira, el webhook contesta `200`, y no queda nada que investigar. Es el peor modo de fallo posible —parece que funciona— y estaba a un paso de morder en producción.

## Qué cambia

- **`src/server/zernio/dispatch.ts`**: las dos rutas de Zernio reparten por `account.platform`. Da igual cuál de las dos URLs esté dada de alta en Zernio; `instagram` va al canal de Instagram y `facebook`/`messenger` al de Messenger. Una plataforma que Vocero no atiende (WhatsApp, X…) se ignora, y un canal apagado descarta con aviso en vez de ingerir a escondidas.
- El secreto de la firma se resuelve en el canal que corresponde, no solo en el propio de la ruta.
- **Mock de Zernio**: devuelve ids únicos por corrida. Con el contador que reiniciaba en 1, una segunda corrida del arnés sobre la misma base chocaba contra el índice único de mensajes y **el fallo se veía como un bug del producto**. El arnés también marca sus datos por corrida.

## Verificación

- typecheck, lint, build y **399** unit (2 nuevas, del reparto por plataforma).
- `scripts/e2e-messenger.mjs`: **42/42 dos veces seguidas** sobre la misma base — antes la segunda fallaba.
- `scripts/e2e-selftest.mjs` (regresión de WhatsApp): **103/103** en la misma instancia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
