### PR TITLE
fix(017): la hora del mensaje sale del evento de Zernio, no de la ingesta

### DIFF
--- a/src/server/instagram/ingest.ts
+++ b/src/server/instagram/ingest.ts
@@ -4,7 +4,11 @@ import {
   getInstagramCredentialsByAccountRef,
   getInstagramCredentialsByIgUserId,
 } from "@/server/instagram/credentials";
-import { parseZernioEvent, type ZernioEvent } from "@/server/zernio";
+import {
+  parseZernioEvent,
+  zernioSentAtSeconds,
+  type ZernioEvent,
+} from "@/server/zernio";
 
 /**
  * 014 — Adaptadores de entrada del canal de Instagram.
@@ -76,8 +80,10 @@ export async function processZernioEvent(payload: unknown): Promise<void> {
   }
 
   const text = evt.message?.text ?? null;
-  const platformMessageId = evt.message?.id;
-  if (!platformMessageId) {
+  // Id de Zernio, no el de la plataforma (el payload trae los dos): es el
+  // que se mantiene entre reentregas, que es lo que hay que colapsar.
+  const zernioMessageId = evt.message?.id;
+  if (!zernioMessageId) {
     console.warn(`[ig] evento ${evt.id ?? "?"} sin id de mensaje: descartado`);
     return;
   }
@@ -97,10 +103,10 @@ export async function processZernioEvent(payload: unknown): Promise<void> {
     },
     // Prefijado para que no colisione jamas con un id de WhatsApp en el
     // indice unico de mensajes.
-    waMessageId: `ig_${platformMessageId}`,
+    waMessageId: `ig_${zernioMessageId}`,
     type: "text",
     text,
-    timestamp: String(Math.floor(Date.now() / 1000)),
+    timestamp: zernioSentAtSeconds(evt.message?.sentAt),
     threadRef: evt.message?.conversationId ?? null,
   });
 }

--- a/src/server/messenger/ingest.ts
+++ b/src/server/messenger/ingest.ts
@@ -7,7 +7,7 @@ import {
   getMessengerCredentialsByPageId,
 } from "@/server/messenger/credentials";
 import { fetchMessengerProfileName } from "@/server/messenger/send";
-import type { ZernioEvent } from "@/server/zernio";
+import { zernioSentAtSeconds, type ZernioEvent } from "@/server/zernio";
 
 /**
  * 017 — Adaptadores de entrada del canal de Messenger.
@@ -164,7 +164,7 @@ export function normalizeZernioEvent(payload: unknown): MessengerInbound[] {
       messageId,
       text,
       type,
-      timestamp: String(Math.floor(Date.now() / 1000)),
+      timestamp: zernioSentAtSeconds(evt.message?.sentAt),
       profileName:
         sender?.name?.trim() ||
         (sender?.username ? `@${sender.username}` : null),

--- a/src/server/zernio/index.ts
+++ b/src/server/zernio/index.ts
@@ -54,15 +54,46 @@ export type ZernioEvent = {
   id?: string;
   event?: string;
   message?: {
+    /**
+     * Id de Zernio, NO el de la plataforma (ese viene en
+     * `platformMessageId`). Es el que dedupe: se mantiene entre reentregas
+     * del mismo mensaje, que es justo lo que hay que colapsar.
+     */
     id?: string;
+    platformMessageId?: string;
+    /**
+     * Identificador OPACO del hilo. La propia API dice «format not to be
+     * assumed»: su endpoint de respuesta lo acepta verbatim, ya venga del
+     * listado o de aquí. No se parsea ni se compara con el de la plataforma.
+     */
     conversationId?: string;
     direction?: string;
     text?: string | null;
+    /** Cuándo lo mandó la persona, ISO-8601. Ver `zernioSentAtSeconds`. */
+    sentAt?: string;
     attachments?: { type?: string; url?: string }[];
     sender?: { id?: string; name?: string | null; username?: string | null };
   };
   account?: { id?: string; platform?: string };
 };
+
+/**
+ * Hora del mensaje en segundos, la que trae el evento y no la de llegada.
+ *
+ * Importa porque `lastInboundAt` es lo que abre la ventana de 24 h: sellar con
+ * la hora de ingesta haría que una reentrega tardía —Zernio reintenta con
+ * backoff de hasta 24 h, y su panel permite reenviar a mano— pareciera un
+ * mensaje recién llegado, y el CRM ofrecería escribir libre por una ventana
+ * que en realidad ya se cerró. El envío lo rechazaría la plataforma, y el
+ * operador no tendría forma de entender por qué.
+ *
+ * Sin `sentAt` utilizable se cae a la hora actual: es lo que había antes y
+ * nunca es peor.
+ */
+export function zernioSentAtSeconds(sentAt: string | undefined): string {
+  const ms = sentAt ? Date.parse(sentAt) : NaN;
+  return String(Math.floor((Number.isFinite(ms) ? ms : Date.now()) / 1000));
+}
 
 /** Lee el cuerpo crudo como evento de Zernio; null si no lo es. */
 export function parseZernioEvent(rawBody: string): ZernioEvent | null {

--- a/tests/unit/messenger.test.ts
+++ b/tests/unit/messenger.test.ts
@@ -9,7 +9,11 @@ import {
   normalizeZernioEvent,
 } from "@/server/messenger/ingest";
 import { buildMessengerSendBody } from "@/server/messenger/send";
-import { isValidZernioSignature, looksLikeMetaPayload } from "@/server/zernio";
+import {
+  isValidZernioSignature,
+  looksLikeMetaPayload,
+  zernioSentAtSeconds,
+} from "@/server/zernio";
 import { zernioTargetChannel } from "@/server/zernio/dispatch";
 import { createHmac } from "node:crypto";
 
@@ -273,6 +277,40 @@ describe("017 · firma de Zernio (control de seguridad compartido)", () => {
     expect(looksLikeMetaPayload({ object: "instagram" }, "page")).toBe(false);
     expect(looksLikeMetaPayload(zernioEvent(), "page")).toBe(false);
     expect(looksLikeMetaPayload(null, "page")).toBe(false);
+  });
+});
+
+describe("017 · la hora del mensaje sale del evento, no de la ingesta", () => {
+  it("usa `sentAt` cuando viene", () => {
+    // Importa porque `lastInboundAt` abre la ventana de 24 h: una reentrega
+    // tardía sellada con la hora de llegada haría creer que la ventana está
+    // abierta cuando la plataforma ya la cerró.
+    expect(zernioSentAtSeconds("2026-09-02T00:56:04.336Z")).toBe("1788310564");
+  });
+
+  it("un `sentAt` ausente o ilegible cae a la hora actual, nunca a NaN", () => {
+    const ahora = Math.floor(Date.now() / 1000);
+    for (const v of [undefined, "", "ayer por la tarde"]) {
+      const s = Number(zernioSentAtSeconds(v));
+      expect(Number.isFinite(s)).toBe(true);
+      expect(Math.abs(s - ahora)).toBeLessThan(5);
+    }
+  });
+
+  it("el normalizador lo propaga", () => {
+    const [evt] = normalizeZernioEvent(
+      zernioEvent({
+        message: {
+          id: "m1",
+          conversationId: "c1",
+          direction: "incoming",
+          text: "hola",
+          sentAt: "2026-09-02T00:56:04.336Z",
+          sender: { id: PSID, name: "Jane" },
+        },
+      })
+    );
+    expect(evt?.timestamp).toBe("1788310564");
   });
 });
 


### PR DESCRIPTION
## Qué estaba mal

El payload real de Zernio trae `message.sentAt` y lo estábamos ignorando: cada mensaje se sellaba con la hora en que Vocero lo recibía.

Como `lastInboundAt` es lo que abre la **ventana de 24 h**, una reentrega tardía —Zernio reintenta con backoff de hasta 24 h, y su panel permite reenviar a mano— hacía creer que la ventana estaba abierta cuando la plataforma ya la había cerrado. El CRM ofrecía escribir libre, la plataforma rechazaba el envío, y el operador no tenía forma de entender por qué.

Se corrige en los **dos** canales que entran por Zernio (Instagram y Messenger) con un helper compartido, que cae a la hora actual si `sentAt` falta o no se puede leer: nunca es peor que antes.

## De paso

El tipo del evento ahora documenta lo que el payload **real** trae y la documentación no enseñaba:

- `message.id` es el id de **Zernio**; el de la plataforma viene aparte en `platformMessageId`. El de Zernio es el correcto para deduplicar, porque se mantiene entre reentregas.
- `message.conversationId` es **opaco**: la propia API dice *"format not to be assumed"* y su endpoint de respuesta lo acepta verbatim, venga del webhook o del listado. (Verificado: no hay que traducirlo al id de plataforma.)
- En Instagram la variable se llamaba `platformMessageId` sin serlo, lo que invitaba a "arreglarlo" mal.

## Verificación

- typecheck, lint, build y **402** unitarias (3 nuevas).
- `scripts/e2e-messenger.mjs` **42/42** y regresión de WhatsApp **103/103**, sobre base limpia.
- **Contra la instancia real**: Zernio reentregó el evento firmado, Vocero lo aceptó (200), lo enrutó a Messenger y **no lo duplicó**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
