### PR TITLE
chore: v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vocero-crm",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "CRM de WhatsApp open source y self-hosted con agente de IA y Laboratorio de auto-evaluación",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Sube la **menor** por lo que ya está en `main` y en producción:

- La interfaz con la identidad de vocerocrm.com (#44).
- El canal de **Messenger**, por app propia de Meta o por **Zernio**, con reparto por plataforma del webhook unificado y la hora real del evento (#45, #46, #47, #48).

Actualizar sigue siendo redesplegar: el canal es opcional y se enciende con `CHANNELS`. Según el README la versión debió subir en el PR que publicó el cambio; se sube ahora.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
