### PR TITLE
fix(015): el modelo no podía acertar book_slot, y la conversación entraba en bucle

### DIFF
--- a/scripts/e2e-selftest.mjs
+++ b/scripts/e2e-selftest.mjs
@@ -59,6 +59,22 @@ function bot(path, opts = {}) {
 }
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Espera a que algo OCURRA, en vez de dormir un rato y confiar.
+ *
+ * Un `sleep` fijo convierte cualquier lentitud —la primera compilación de una
+ * ruta en `next dev`, por ejemplo— en un fallo que no significa nada. Y si se
+ * pone generoso, alarga el guion entero para todos.
+ */
+async function hasta(cond, ms = 15000, paso = 400) {
+  const fin = Date.now() + ms;
+  for (;;) {
+    if (await cond()) return true;
+    if (Date.now() > fin) return false;
+    await sleep(paso);
+  }
+}
 const PN = "PN-E2E-1";
 
 async function main() {
@@ -1238,6 +1254,115 @@ async function agendaChecks() {
       movida.res.status === 200,
       `status=${movida.res.status}`
     );
+  }
+
+  /**
+   * El agujero de INTEGRACIÓN del issue #50.
+   *
+   * Todo lo de arriba entra por `/api/bot/*`, donde quien llama YA tiene el
+   * ISO. El agente EMBEBIDO no lo tenía: al modelo solo le llegaban el prompt
+   * y el historial de TEXTO, con las etiquetas que leyó el cliente y sin año,
+   * zona ni fecha de hoy. Acertar el instante era suerte, el rechazo caía en
+   * `slot_not_offered` —de texto fijo— y la conversación repetía la lista
+   * para siempre.
+   *
+   * Y por eso este self-test no lo cazaba: el resto de 015 ejercita el
+   * gateway, nunca la conversación. Aquí hay que ENCENDER el agente
+   * in-process a propósito, y apagarlo después para no alterar lo que sigue.
+   */
+  console.log("\n== 015: el agente reserva desde la conversación (#50) ==");
+  {
+    await api("/api/agent/profile", {
+      method: "PUT",
+      body: JSON.stringify({ enabled: true }),
+    });
+    const encendido = await api("/api/agent/profile");
+    ok(
+      "el agente in-process queda encendido para esta prueba",
+      encendido.json?.profile?.enabled === true,
+      JSON.stringify(encendido.json?.profile?.enabled)
+    );
+
+    /**
+     * Contacto NUEVO en cada corrida.
+     *
+     * Con un teléfono fijo, la segunda ejecución arrastra la conversación y —
+     * sobre todo— las OFERTAS de la anterior: el mapa ya está ahí desde el
+     * primer mensaje y el agente reserva antes de ofrecer, así que el check
+     * mide otra cosa. El resto del guion asume base recién sembrada; esta
+     * sección no puede permitírselo porque compara ANTES y DESPUÉS.
+     */
+    const CORRIDA = Date.now().toString().slice(-6);
+    const LEAD_C = `5214627${CORRIDA}`;
+    const decir = (texto, n) =>
+      api("/api/dev/wa-mock/inbound", {
+        method: "POST",
+        body: JSON.stringify({
+          phoneNumberId: PN,
+          from: LEAD_C,
+          name: "Lead agenda C",
+          text: texto,
+          // Único por corrida: con un id fijo, la segunda ejecución lo
+          // deduplica en la ingesta y no entra NADA — el agente no llega a
+          // correr y el check falla sin que haya nada roto.
+          waMessageId: `wamid.e2e.015.c.${CORRIDA}.${n}`,
+        }),
+      });
+
+    await decir("quiero agendar una cita", 1);
+    await hasta(async () => {
+      const cs = (await api("/api/conversations")).json?.conversations ?? [];
+      return cs.some((c) => c.contact.phone === `524627${CORRIDA}`);
+    });
+
+    const convs = (await api("/api/conversations")).json?.conversations ?? [];
+    const convC = convs.find((c) => c.contact.phone === `524627${CORRIDA}`);
+    ok("el agente atendió al lead que pide cita", Boolean(convC));
+
+    if (convC) {
+      const salientesDe = async () => {
+        const msgs =
+          (await api(`/api/conversations/${convC.id}/messages`)).json
+            ?.messages ?? [];
+        return msgs.filter((m) => m.direction === "out");
+      };
+
+      // El agente tiene que RESPONDER; cuánto tarde no es asunto del check.
+      await hasta(async () => (await salientesDe()).length > 0);
+      const trasOferta = await salientesDe();
+      ok(
+        "el agente OFRECE horarios (hay respuesta, no silencio)",
+        trasOferta.length > 0 && /\d{2}:\d{2}/.test(trasOferta.at(-1)?.text ?? ""),
+        `salientes=${trasOferta.length} ultimo=${(trasOferta.at(-1)?.text ?? "").slice(0, 80)}`
+      );
+
+      const antes = (await api("/api/bookings")).json?.bookings ?? [];
+      await decir("quiero el primero", 2);
+      await hasta(async () => {
+        const bs = (await api("/api/bookings")).json?.bookings ?? [];
+        return bs.length > antes.length;
+      });
+
+      const despues = (await api("/api/bookings")).json?.bookings ?? [];
+      ok(
+        "elegir un horario CREA la cita (no repite la lista)",
+        despues.length > antes.length,
+        `citas antes=${antes.length} despues=${despues.length}`
+      );
+
+      /**
+       * Aquí había una tercera comprobación —«confirma en vez de volver a
+       * ofrecer»— y se quitó: pasaba TAMBIÉN con el bug puesto, porque bajo el
+       * fallo el agente responde cualquier otra cosa que tampoco contiene
+       * «estos horarios». Una comprobación que no distingue el fallo del
+       * acierto solo da confianza falsa. Lo que decide es la cita creada.
+       */
+    }
+
+    await api("/api/agent/profile", {
+      method: "PUT",
+      body: JSON.stringify({ enabled: false }),
+    });
   }
 
   console.log("\n== 015: el operador y el enlace pendiente (US4) ==");

--- a/src/server/agenda/offers.ts
+++ b/src/server/agenda/offers.ts
@@ -109,3 +109,38 @@ export function sameInstant(a: string, b: string): boolean {
   const y = Date.parse(b);
   return !Number.isNaN(x) && !Number.isNaN(y) && x === y;
 }
+
+/**
+ * Encabezado del bloque de huecos que ve el modelo.
+ *
+ * Es una constante y no una cadena suelta porque hay DOS lados que dependen de
+ * ella: quien la escribe (el turno del agente) y quien la lee (el mock de IA
+ * del self-test). Con dos copias, el día que cambie la frase el guion pasaría
+ * a verde sin ejercitar nada.
+ */
+export const CABECERA_HUECOS =
+  "Horarios vigentes de esta conversación. Para book_slot usa el startUtc " +
+  "EXACTO de la columna derecha, copiado tal cual:";
+
+/**
+ * Los huecos vigentes, en la forma en que el modelo puede usarlos.
+ *
+ * `book_slot` exige el `startUtc` y `findOffered` compara por epoch, sin
+ * tolerancia. Pero al modelo solo le llegan el prompt y el historial de TEXTO,
+ * donde están las etiquetas que leyó el cliente —«lun 7 sep, 11:00»— sin año,
+ * sin zona y sin la fecha de hoy. Con eso, acertar el instante era cuestión de
+ * suerte: el rechazo caía siempre en `slot_not_offered`, cuyo texto es fijo, y
+ * la conversación se quedaba en bucle repitiendo la lista.
+ *
+ * Devuelve `null` sin oferta vigente, para que el modelo siga obligado a
+ * ofrecer antes de reservar.
+ *
+ * Reportado por @Diony7004 en #50, con el diagnóstico ya hecho.
+ */
+export function mapaDeHuecosParaModelo(ofertas: OfferedSlot[]): string | null {
+  if (ofertas.length === 0) return null;
+  return [
+    CABECERA_HUECOS,
+    ...ofertas.map((o) => `- "${o.label}" → ${o.startUtc}`),
+  ].join("\n");
+}

--- a/src/server/ai/pipeline.ts
+++ b/src/server/ai/pipeline.ts
@@ -18,6 +18,7 @@ import { matchesHandoffIntent } from "@/server/ai/handoff";
 import { buildAgentSystemPrompt } from "@/server/ai/prompts";
 import { agendaEnabled } from "@/server/agenda/flag";
 import { bookSlot, offerSlots } from "@/server/agenda/agent";
+import { getOffers, mapaDeHuecosParaModelo } from "@/server/agenda/offers";
 
 /**
  * Turno del agente (FR-021..FR-025).
@@ -152,6 +153,30 @@ export async function runAgentTurn(conversationId: string): Promise<void> {
     .orderBy(asc(schema.pipelineStage.position));
 
   const agenda = agendaEnabled();
+
+  /**
+   * 015 — Los huecos vigentes, con su instante exacto.
+   *
+   * `book_slot` exige el `startUtc` y `findOffered` compara por epoch, sin
+   * tolerancia. Pero al modelo solo le llegaban el prompt y el historial de
+   * TEXTO, donde están las etiquetas que leyó el cliente —«lun 7 sep, 11:00»—
+   * sin año, sin zona y sin la fecha de hoy. Con eso, acertar el instante era
+   * cuestión de suerte: el rechazo caía siempre en `slot_not_offered`, cuyo
+   * texto es fijo, y la conversación se quedaba en bucle repitiendo la lista.
+   *
+   * Es un agujero de INTEGRACIÓN: las pruebas de contrato pasan porque
+   * inyectan el ISO correcto, que es justo lo que el modelo no tenía.
+   *
+   * Sin oferta vigente no se añade nada, así que el modelo sigue obligado a
+   * ofrecer antes de reservar. Se entrega el catálogo COMPLETO, no solo los
+   * tres que se enseñaron: si el cliente pide otro día, ese hueco ya estaba
+   * registrado como ofrecido y ahora el modelo también lo conoce.
+   *
+   * Reportado por @Diony7004 en #50, con el diagnóstico ya hecho.
+   */
+  const ofertas = agenda ? await getOffers(organizationId, conversationId) : [];
+  const mapaDeHuecos = mapaDeHuecosParaModelo(ofertas);
+
   const messages: ChatMessage[] = [
     {
       role: "system",
@@ -163,6 +188,13 @@ export async function runAgentTurn(conversationId: string): Promise<void> {
         role: m.direction === "in" ? ("user" as const) : ("assistant" as const),
         content: m.text!,
       })),
+    /**
+     * Va AL FINAL, después del historial: es el estado de AHORA, y ponerlo
+     * antes lo dejaría enterrado bajo la conversación en cuanto esta crezca.
+     */
+    ...(mapaDeHuecos
+      ? [{ role: "system" as const, content: mapaDeHuecos }]
+      : []),
   ];
 
   const result = await chatJson(agentActionSchema(agenda), messages);

--- a/src/server/dev/ai-mock.ts
+++ b/src/server/dev/ai-mock.ts
@@ -1,4 +1,5 @@
 import { JUDGE_MARKER } from "@/server/ai/prompts";
+import { CABECERA_HUECOS } from "@/server/agenda/offers";
 
 /**
  * Proveedor LLM determinista para el self-test (contrato mocks.md).
@@ -44,6 +45,37 @@ export function aiMockCompletion(messages: InMessage[]): string {
   }
 
   const text = lastUser.toLowerCase();
+
+  /**
+   * 015 — La agenda, ejercitando el camino REAL.
+   *
+   * El mock reserva copiando el `startUtc` del mapa de huecos, igual que tiene
+   * que hacer un modelo de verdad. Si ese mapa deja de llegar, aquí no hay de
+   * dónde sacar el instante y la reserva falla — que es exactamente el fallo
+   * que se vivió en producción (#50), en vez de un test que lo simula.
+   *
+   * Se buscan TODOS los mensajes `system`, no solo el primero: el mapa va al
+   * final, después del historial.
+   */
+  const huecos = messages
+    .filter((m) => m.role === "system" && m.content.includes(CABECERA_HUECOS))
+    .flatMap((m) => m.content.match(/\d{4}-\d{2}-\d{2}T[\d:.]+Z/g) ?? []);
+
+  const quiereCita = /cita|agendar|agenda|horario|reserv/.test(text);
+  if (quiereCita && huecos.length === 0) {
+    return JSON.stringify({
+      action: "offer_slots",
+      reply: "Claro, tengo estos horarios:",
+    });
+  }
+  const eligeUno = /primero|segundo|ese|esa|confirmo|quiero|me sirve/.test(text);
+  if (huecos.length > 0 && eligeUno) {
+    return JSON.stringify({
+      action: "book_slot",
+      startUtc: huecos[0],
+      reply: "¡Listo! Te agendé.",
+    });
+  }
 
   // Persona pide_humano (el regex de respaldo captura la frase canónica; esta
   // rama cubre variantes que llegan al modelo).

--- a/tests/unit/agenda-huecos-modelo.test.ts
+++ b/tests/unit/agenda-huecos-modelo.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  CABECERA_HUECOS,
+  findOffered,
+  mapaDeHuecosParaModelo,
+} from "@/server/agenda/offers";
+
+/**
+ * 015 / issue #50 — Los huecos que el modelo puede usar de verdad.
+ *
+ * `book_slot` exige el `startUtc` y `findOffered` compara por epoch exacto,
+ * sin tolerancia. Al modelo solo le llegaban el prompt y el historial de
+ * TEXTO, donde están las etiquetas que leyó el cliente —«lun 7 sep, 11:00»—
+ * sin año, sin zona y sin la fecha de hoy. Acertar el instante era cuestión de
+ * suerte, el rechazo caía siempre en `slot_not_offered`, y la conversación se
+ * quedaba en bucle repitiendo la misma lista.
+ */
+
+const OFERTAS = [
+  { startUtc: "2026-09-07T15:00:00.000Z", label: "lun 7 sep, 09:00" },
+  { startUtc: "2026-09-07T17:00:00.000Z", label: "lun 7 sep, 11:00" },
+];
+
+describe("mapaDeHuecosParaModelo", () => {
+  it("empareja cada etiqueta con su instante exacto", () => {
+    const mapa = mapaDeHuecosParaModelo(OFERTAS)!;
+    expect(mapa).toContain('- "lun 7 sep, 09:00" → 2026-09-07T15:00:00.000Z');
+    expect(mapa).toContain('- "lun 7 sep, 11:00" → 2026-09-07T17:00:00.000Z');
+  });
+
+  it("lleva la cabecera que dice qué hacer con esos valores", () => {
+    expect(mapaDeHuecosParaModelo(OFERTAS)).toContain(CABECERA_HUECOS);
+  });
+
+  /**
+   * Sin esto, el modelo podría inventarse una reserva antes de haber ofrecido
+   * nada — y el motor la rechazaría, volviendo al bucle por otro camino.
+   */
+  it("sin oferta vigente no hay bloque: hay que ofrecer antes de reservar", () => {
+    expect(mapaDeHuecosParaModelo([])).toBeNull();
+  });
+
+  /**
+   * La invariante que cierra el círculo: lo que el mapa enseña tiene que ser
+   * exactamente lo que `findOffered` acepta. Si el formato del ISO cambiara en
+   * un lado y no en el otro, volveríamos al mismo bucle sin que nada avisara.
+   */
+  it("todo instante del mapa es aceptado por findOffered", () => {
+    const mapa = mapaDeHuecosParaModelo(OFERTAS)!;
+    const instantes = mapa.match(/\d{4}-\d{2}-\d{2}T[\d:.]+Z/g) ?? [];
+    expect(instantes).toHaveLength(OFERTAS.length);
+    for (const iso of instantes) {
+      expect(findOffered(OFERTAS, iso)).not.toBeNull();
+    }
+  });
+
+  it("una etiqueta con comillas no rompe el formato de la línea", () => {
+    const mapa = mapaDeHuecosParaModelo([
+      { startUtc: "2026-09-07T15:00:00.000Z", label: 'mar 8 "temprano"' },
+    ])!;
+    expect(mapa.split("\n")).toHaveLength(2);
+    expect(mapa).toContain("→ 2026-09-07T15:00:00.000Z");
+  });
+});


### PR DESCRIPTION
Cierra el punto 1 de #50, y de paso su nota menor. Gracias @Diony7004 — el diagnóstico venía hecho y verificado; esto es básicamente su propuesta.

## Lo que pasaba

`book_slot` exige el `startUtc` y `findOffered` compara por epoch exacto, sin tolerancia. Pero al modelo solo le llegaban el system prompt y el historial de **texto**: ahí están las etiquetas que leyó el cliente —«lun 7 sep, 11:00»— sin año, sin zona y sin la fecha de hoy.

Acertar el instante era cuestión de suerte. El rechazo caía siempre en `slot_not_offered`, cuyo texto es fijo, y el turno siguiente repetía la lista entera. Para siempre.

## El arreglo

Cuando hay oferta vigente, se añade un mensaje `system` con el mapa `etiqueta → startUtc`.

- **Al final**, después del historial: es el estado de *ahora*, y arriba quedaría enterrado en cuanto la conversación crezca.
- **Sin oferta no se añade nada**, así que el modelo sigue obligado a ofrecer antes de reservar.
- Se entrega el **catálogo completo**, no solo los tres que se enseñaron. Si el cliente pide otro día, ese hueco ya estaba registrado como ofrecido y ahora el modelo también lo conoce — eso alivia la nota menor sobre `SHOWN = 3`.

La constante de cabecera se exporta porque hay **dos** lados que dependen de ella: quien escribe el mapa y quien lo lee en el self-test. Con dos copias, el día que cambie la frase el guion pasaría a verde sin ejercitar nada.

## Por qué no lo cazaba nada

Es un agujero de **integración**, como decía el issue. Las pruebas de contrato inyectan el ISO correcto —justo lo que el modelo no tenía— y **todo el resto de 015 en el self-test entra por `/api/bot/*`**, donde quien llama ya lo trae. La conversación, el único camino donde el fallo existe, no se ejercitaba.

Así que el self-test estrena una sección que va **por la conversación**: enciende el agente in-process (y lo apaga después), pide cita, elige un horario y comprueba que la cita **se crea**.

El mock de IA reserva copiando el `startUtc` del mapa, igual que tendría que hacer un modelo de verdad: si el mapa deja de llegar, no tiene de dónde sacarlo.

## Tres detalles del guion, cada uno una corrida perdida

- **Contacto nuevo por ejecución.** Con teléfono fijo, la segunda corrida arrastra las ofertas de la primera: el mapa ya está desde el primer mensaje, el agente reserva antes de ofrecer y el check mide otra cosa.
- **Sondeo en vez de `sleep` fijo.** La primera compilación de una ruta en `next dev` tardaba más que la espera, y eso no es un fallo del producto.
- **Se retiró un tercer check** que comprobaba «confirma en vez de volver a ofrecer»: pasaba **también con el bug puesto**, porque bajo el fallo el agente responde otra cosa que tampoco contiene «estos horarios». Una comprobación que no distingue el fallo del acierto solo da confianza falsa.

## Comprobado

Con base de datos **recién creada** en cada medición, porque el guion acumula estado:

| | sin el cambio | con el cambio |
|---|---|---|
| self-test | 133/133 | **137/137** |

- **407 unitarias** (5 nuevas), `typecheck` y `lint` limpios.
- **Mutación**: con `mapaDeHuecos = null` —el comportamiento de hoy— cae exactamente «elegir un horario CREA la cita». Restaurado, verde.

Una de las pruebas nuevas fija la invariante que cierra el círculo: **todo instante que el mapa enseña es aceptado por `findOffered`**. Si el formato cambiara en un lado y no en el otro, volveríamos al mismo bucle sin que nada avisara.

## Lo que NO trae este PR

Los puntos 2, 3 y 4 del issue (scope de `testConnection`, clave del caché del token de Google, y la insignia de versión). Van aparte para que se puedan revisar y revertir por separado.

Sobre el punto 1, el issue proponía además una alternativa más robusta: que `book_slot` aceptara la etiqueta o el índice y que el motor resolviera el instante, para que el modelo nunca manipule fechas. Estoy de acuerdo en que es mejor diseño, pero cambia el contrato de la herramienta; esto es la corrección mínima que devuelve el comportamiento sin tocarlo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
