### PR TITLE
fix(015): la prueba de conexión de Google pedía más scope del documentado, y el caché ignoraba la credencial

### DIFF
--- a/src/server/agenda/connectors/google.ts
+++ b/src/server/agenda/connectors/google.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { getEnv } from "@/lib/env";
 import {
   ConnectorError,
@@ -39,8 +40,36 @@ export const GOOGLE_SCOPE = "https://www.googleapis.com/auth/calendar.events";
 const CONFERENCE_POLLS = 3;
 const POLL_DELAY_MS = 400;
 
+/**
+ * La clave del caché incluye TODO lo que determina el token.
+ *
+ * Era `clientId:calendarId`. Como el refresh token y el secreto no entraban,
+ * cambiar credenciales no tenía efecto observable hasta que el token expiraba
+ * —una hora— y el operador concluía que las nuevas también estaban mal. Pasó
+ * de verdad: tras corregir el scope y regenerar el refresh token, la prueba
+ * seguía devolviendo el MISMO 403, palabra por palabra (#50, punto 3).
+ *
+ * Va como hash y no en claro porque esta clave vive en memoria del proceso y
+ * no hay motivo para tener un refresh token dando vueltas en ella.
+ */
+function claveDeToken(creds: GoogleCreds): string {
+  // `JSON.stringify` del array y no un separador a mano: los valores son
+  // opacos y una concatenación cruda podría colisionar entre credenciales
+  // distintas. Aquí la ambigüedad la resuelve el propio formato.
+  return createHash("sha256")
+    .update(
+      JSON.stringify([
+        creds.clientId,
+        creds.clientSecret,
+        creds.refreshToken,
+        creds.calendarId,
+      ])
+    )
+    .digest("hex");
+}
+
 async function getAccessToken(creds: GoogleCreds): Promise<string> {
-  const key = `${creds.clientId}:${creds.calendarId}`;
+  const key = claveDeToken(creds);
   const cached = getCachedGoogleToken(key);
   if (cached) return cached;
 
@@ -220,11 +249,25 @@ export const googleConnector: AgendaConnector<GoogleCreds> = {
 
   async testConnection(creds): Promise<TestConnectionResult> {
     try {
-      const cal = (await googleFetch(
+      /**
+       * Se listan eventos, no se lee el calendario.
+       *
+       * `GET /calendars/{id}` es `Calendars.Get`, y Google solo lo concede con
+       * `calendar.readonly` o superior. Con el scope que este conector pide de
+       * verdad —`calendar.events`, suficiente para insert/get/patch/delete— la
+       * llamada devuelve 403 ACCESS_TOKEN_SCOPE_INSUFFICIENT: la conexión
+       * funcionaba y su PROPIA prueba fallaba (#50, punto 2).
+       *
+       * Listar un evento sí entra en `calendar.events`, así que el scope
+       * documentado sigue siendo el mínimo — que es la razón de pedirlo.
+       */
+      const lista = (await googleFetch(
         creds,
-        `/calendars/${encodeURIComponent(creds.calendarId)}`
+        eventsPath(creds, "?maxResults=1")
       )) as { summary?: string } | null;
-      return { ok: true, detail: cal?.summary };
+      // `summary` del listado es el nombre del calendario: el mismo dato que
+      // se enseñaba antes, por una vía que el scope permite.
+      return { ok: true, detail: lista?.summary };
     } catch (err) {
       return {
         ok: false,

--- a/src/server/agenda/connectors/zoom.ts
+++ b/src/server/agenda/connectors/zoom.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { getEnv } from "@/lib/env";
 import {
   ConnectorError,
@@ -34,8 +35,25 @@ export const ZOOM_SCOPES = [
   "user:read:user",
 ] as const;
 
+/**
+ * La clave del caché incluye TODO lo que determina el token.
+ *
+ * Misma trampa que la de Google (#50, punto 3), que aquí nadie ha reportado
+ * todavía porque el conector se usa menos: era `accountId:clientId`, así que
+ * cambiar el SECRETO no tenía efecto observable hasta que el token expiraba y
+ * el operador concluía que las credenciales nuevas también estaban mal.
+ *
+ * Se arregla junto con la otra a propósito: dejar una de las dos copias de un
+ * mismo error es cómo vuelve.
+ */
+function claveDeToken(creds: ZoomCreds): string {
+  return createHash("sha256")
+    .update(JSON.stringify([creds.accountId, creds.clientId, creds.clientSecret]))
+    .digest("hex");
+}
+
 async function getAccessToken(creds: ZoomCreds): Promise<string> {
-  const key = `${creds.accountId}:${creds.clientId}`;
+  const key = claveDeToken(creds);
   const cached = getCachedZoomToken(key);
   if (cached) return cached;
 

--- a/tests/unit/conectores-cache-y-prueba.test.ts
+++ b/tests/unit/conectores-cache-y-prueba.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GOOGLE_SCOPE, googleConnector } from "@/server/agenda/connectors/google";
+import { clearGoogleTokenCache } from "@/server/agenda/connectors/google-credentials";
+
+/**
+ * 015 / issue #50, puntos 2 y 3 — Los dos fallos del conector de Google que
+ * hacen que conectarlo parezca roto cuando no lo está.
+ *
+ * Los dos se comprueban por la FRONTERA de red: lo que importa no es cómo se
+ * llame la función interna, sino a qué endpoint se llama y cuántas veces se
+ * pide el token. Un test acoplado a los nombres pasaría con el bug puesto en
+ * cuanto alguien renombrara algo.
+ */
+
+const CREDS = {
+  clientId: "cid",
+  clientSecret: "secreto-1",
+  refreshToken: "refresh-1",
+  calendarId: "primary",
+} as never;
+
+let llamadas: string[] = [];
+
+function responder(url: string): Response {
+  llamadas.push(url);
+  if (url.includes("/token")) {
+    return new Response(
+      JSON.stringify({ access_token: `tok-${llamadas.length}`, expires_in: 3600 }),
+      { status: 200 }
+    );
+  }
+  return new Response(JSON.stringify({ summary: "Mi calendario" }), {
+    status: 200,
+  });
+}
+
+beforeEach(() => {
+  llamadas = [];
+  clearGoogleTokenCache();
+  // `getEnv()` valida el entorno entero: sin lo mínimo, el conector falla
+  // antes de tocar la red y el test mediría otra cosa.
+  vi.stubEnv("APP_BASE_URL", "http://localhost:3000");
+  vi.stubEnv("DATABASE_URL", "postgresql://t:t@localhost:5432/t");
+  vi.stubEnv("BETTER_AUTH_SECRET", "secret-de-test-suficiente");
+  vi.stubEnv("ENCRYPTION_KEY", Buffer.alloc(32, 3).toString("base64"));
+  vi.stubEnv("META_WEBHOOK_VERIFY_TOKEN", "verify-test");
+  vi.stubEnv("GOOGLE_OAUTH_BASE_URL", "https://oauth.test");
+  vi.stubEnv("GOOGLE_CAL_BASE_URL", "https://cal.test");
+  globalThis.fetch = ((url: string) =>
+    Promise.resolve(responder(String(url)))) as typeof fetch;
+});
+
+describe("punto 2 — la prueba de conexión cabe en el scope documentado", () => {
+  /**
+   * `GET /calendars/{id}` es `Calendars.Get`, y Google solo lo concede con
+   * `calendar.readonly` o superior. Con el scope que este conector pide de
+   * verdad, esa llamada devolvía 403 ACCESS_TOKEN_SCOPE_INSUFFICIENT: la
+   * conexión funcionaba y su propia prueba fallaba.
+   */
+  it("lista eventos en vez de leer el calendario", async () => {
+    const r = await googleConnector.testConnection!(CREDS);
+    expect(r.ok).toBe(true);
+
+    const api = llamadas.filter((u) => !u.includes("/token"));
+    expect(api).toHaveLength(1);
+    expect(api[0]).toContain("/events");
+    // La llamada que exigía más permiso del documentado.
+    expect(api[0]).not.toMatch(/\/calendars\/[^/]+$/);
+  });
+
+  it("y el scope que se pide sigue siendo el mínimo", () => {
+    // Si algún día hiciera falta `readonly`, esta prueba obliga a decirlo aquí
+    // y en la guía de la pantalla, en vez de descubrirlo con un 403.
+    expect(GOOGLE_SCOPE).toBe("https://www.googleapis.com/auth/calendar.events");
+  });
+});
+
+describe("punto 3 — el caché del token distingue credenciales", () => {
+  it("las mismas credenciales reutilizan el token (el caché sirve)", async () => {
+    await googleConnector.testConnection!(CREDS);
+    await googleConnector.testConnection!(CREDS);
+    expect(llamadas.filter((u) => u.includes("/token"))).toHaveLength(1);
+  });
+
+  /**
+   * El síntoma real: tras regenerar el refresh token, la prueba seguía
+   * devolviendo el MISMO error, palabra por palabra, durante una hora. El
+   * operador concluye que el token nuevo también está mal.
+   */
+  it("un refresh token distinto pide un token NUEVO, sin esperar a que expire", async () => {
+    await googleConnector.testConnection!(CREDS);
+    await googleConnector.testConnection!({
+      ...(CREDS as object),
+      refreshToken: "refresh-2",
+    } as never);
+    expect(llamadas.filter((u) => u.includes("/token"))).toHaveLength(2);
+  });
+
+  it("y cambiar solo el secreto también cuenta", async () => {
+    await googleConnector.testConnection!(CREDS);
+    await googleConnector.testConnection!({
+      ...(CREDS as object),
+      clientSecret: "secreto-2",
+    } as never);
+    expect(llamadas.filter((u) => u.includes("/token"))).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Cierra los puntos **2 y 3** de #50. Gracias @Diony7004 — la causa venía localizada en los dos, incluida la observación de que el segundo convierte cualquier corrección en un misterio.

## Punto 2 · La conexión funciona y su propia prueba falla

`testConnection` llamaba a `GET /calendars/{id}` — `Calendars.Get`, que Google solo concede con `calendar.readonly` o superior. Pero el conector pide `calendar.events`, que basta para todo lo que hace de verdad: `insert`, `get`, `patch`, `delete`.

Resultado: **403 ACCESS_TOKEN_SCOPE_INSUFFICIENT** con credenciales correctas.

Ahora lista un evento (`/events?maxResults=1`), que sí entra en `calendar.events`. Así el scope documentado sigue siendo el mínimo, que es la razón de pedirlo. El `summary` del calendario que se enseñaba sigue saliendo, por una vía permitida.

## Punto 3 · El caché ignoraba la credencial

La clave era `clientId:calendarId`. Como el refresh token y el secreto no entraban, cambiar credenciales no tenía efecto observable hasta que el token expiraba — una hora.

Ese es el detalle que hace el fallo tan caro: tras corregir el scope y regenerar el refresh token, la prueba **seguía devolviendo el mismo 403, palabra por palabra**. Cualquiera concluiría que las credenciales nuevas también están mal.

La clave pasa a ser un hash de todo lo que determina el token.

**Por qué así y no invalidando al guardar**, que era la otra opción del issue: porque no se puede olvidar en un sitio nuevo. Si la credencial cambia, la clave cambia sola; una invalidación explícita hay que acordarse de llamarla desde cada punto que guarde credenciales, hoy y dentro de un año. Va en hash porque no hay motivo para tener un refresh token dando vueltas en la memoria del proceso.

## Zoom tenía la misma trampa

`accountId:clientId`, sin el secreto. Nadie la ha reportado —se usa menos— pero es el mismo error, y se arregla aquí también: dejar una de las dos copias de un mismo fallo es exactamente cómo vuelve.

## Las pruebas

Miran la **frontera de red**: a qué endpoint se llama y cuántas veces se pide el token. No los nombres internos — un test acoplado a los nombres pasaría con el bug puesto en cuanto alguien renombrara algo.

Una de ellas fija que `GOOGLE_SCOPE` siga siendo `calendar.events`. Si algún día hiciera falta `readonly`, obliga a decirlo ahí y en la guía de la pantalla, en vez de descubrirlo con un 403.

## Comprobado

- **407 unitarias** (5 nuevas), `typecheck` y `lint` limpios.
- **Self-test 133/133**, con base de datos recién creada.
- **Mutación**: restaurados los dos fallos, caen 3 de las 5 pruebas nuevas. La que sigue pasando es la del scope declarado, que es correcto: esa fija una decisión, no un comportamiento.

## Nota

Va aparte de #54 (el punto 1) para que cada uno se pueda revisar y revertir por separado. El punto 4 —la insignia de versión— es de build y documentación, y va en un tercero si te parece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
