### PR TITLE
fix(003): a un contacto sin teléfono se le responde por recipient, no por to

### DIFF
--- a/scripts/e2e-selftest.mjs
+++ b/scripts/e2e-selftest.mjs
@@ -142,10 +142,16 @@ async function main() {
   ok("respuesta a contacto BSUID enviable", reply.res.ok, JSON.stringify(reply.json));
 
   const outbox = (await api("/api/dev/wa-mock/outbox")).json?.outbox ?? [];
+  /**
+   * Esta comprobación fijaba el comportamiento EQUIVOCADO: afirmaba que el
+   * BSUID viaja en `to`. Y pasaba, porque el mock aceptaba cualquier cosa ahí
+   * — mientras Meta respondía 131026 en producción. Un test verde sobre un
+   * mock permisivo es peor que no tenerlo: convence de lo contrario.
+   */
   ok(
-    "el destinatario del envío es el BSUID",
-    outbox.some((o) => o.to === "bsu_e2e_1"),
-    JSON.stringify(outbox.map((o) => o.to))
+    "el destinatario del envío es el BSUID, en `recipient`",
+    outbox.some((o) => o.recipient === "bsu_e2e_1" && !o.to),
+    JSON.stringify(outbox.map((o) => ({ to: o.to, recipient: o.recipient })))
   );
 
   // Idempotencia: re-entrega del mismo wa_message_id
@@ -165,6 +171,37 @@ async function main() {
     [];
   const inCount = msgs.filter((m) => m.direction === "in").length;
   ok("webhook duplicado no duplica mensajes", inCount === 1, `in=${inCount}`);
+
+  console.log("\n== us-bsuid: a un contacto sin teléfono se le puede responder ==");
+  {
+    /**
+     * El caso de produccion que dejo mudo al agente de un miembro.
+     *
+     * Meta omite el telefono cuando coinciden TRES condiciones: el usuario
+     * activo su nombre de usuario, no hubo interaccion con ese numero de
+     * empresa en 30 dias, y no esta en la agenda. Entonces solo llega el
+     * BSUID — y hay que responderle por `recipient`, no por `to`: en `to`
+     * Meta espera un telefono y devuelve 131026, que en la bandeja se lee
+     * como si el numero del cliente no existiera.
+     */
+    const conv = bsuidConv;
+    if (!conv) {
+      ok("hay conversacion BSUID para responder", false, "no aparecio");
+    } else {
+      const envio = await api(`/api/conversations/${conv.id}/messages`, {
+        method: "POST",
+        body: JSON.stringify({ text: "respuesta a un BSUID" }),
+      });
+      ok("se le PUEDE responder (antes: Meta 131026)", envio.res.ok,
+        `status=${envio.res.status} ${JSON.stringify(envio.json)}`);
+
+      const outbox = (await api("/api/dev/wa-mock/outbox")).json?.outbox ?? [];
+      const salida = outbox[outbox.length - 1];
+      ok("y el BSUID viaja en `recipient`, nunca en `to`",
+        salida?.recipient === "bsu_e2e_1" && !salida?.to,
+        `to=${JSON.stringify(salida?.to)} recipient=${JSON.stringify(salida?.recipient)}`);
+    }
+  }
 
   console.log("\n== us-bsuid: reconciliación 521/52 ==");
   await api("/api/dev/wa-mock/inbound", {

--- a/src/app/api/dev/wa-mock/graph/[...path]/route.ts
+++ b/src/app/api/dev/wa-mock/graph/[...path]/route.ts
@@ -52,6 +52,11 @@ function invalidTokenResponse(): Response {
   );
 }
 
+/** Un teléfono de Meta es solo dígitos; un BSUID lleva prefijo y punto. */
+function esSoloDigitos(valor: string): boolean {
+  return /^[0-9]+$/.test(valor);
+}
+
 /** Quita el segmento de versión (v25.0/...) si viene en la ruta. */
 function normalizePath(path: string[]): string[] {
   return path[0] && /^v\d+/.test(path[0]) ? path.slice(1) : path;
@@ -215,6 +220,29 @@ export async function POST(req: Request, ctx: Params) {
   // POST {phoneNumberId}/messages → registra en el outbox
   if (path.length === 2 && path[1] === "messages") {
     const state = getWaMockState();
+
+    /**
+     * Meta espera un TELEFONO en `to`. Un BSUID ahi devuelve 131026 — «el
+     * destinatario no puede recibir mensajes» — y el mock lo replica.
+     *
+     * Sin esto, mandar el BSUID en el campo equivocado pasaba en verde aqui y
+     * fallaba en produccion, que es exactamente lo que ocurrio. El BSUID va
+     * en `recipient`, con `recipient_type: "individual"`.
+     */
+    const destino = body.to as string | undefined;
+    if (destino && !esSoloDigitos(destino)) {
+      return Response.json(
+        {
+          error: {
+            message:
+              "(#131026) Message undeliverable: recipient is not a valid WhatsApp user",
+            code: 131026,
+            type: "OAuthException",
+          },
+        },
+        { status: 400 }
+      );
+    }
     // Meta responde 132000 si los parámetros no cuadran con las {{n}} de la
     // plantilla aprobada. El mock lo replica para que un desfase no pase.
     if (body.type === "template") {
@@ -256,6 +284,9 @@ export async function POST(req: Request, ctx: Params) {
       waMessageId,
       phoneNumberId: path[0]!,
       to: String(body.to ?? ""),
+      // Se guarda aparte para que un self-test pueda comprobar EN QUE CAMPO
+      // viajo el destinatario, que es de lo que dependia el fallo.
+      ...(body.recipient ? { recipient: String(body.recipient) } : {}),
       type: String(body.type ?? "text"),
       body,
       at: new Date().toISOString(),

--- a/src/lib/meta/destinatario.ts
+++ b/src/lib/meta/destinatario.ts
@@ -1,0 +1,44 @@
+/**
+ * A quién va un mensaje de la Cloud API: teléfono o BSUID.
+ *
+ * Meta los pide en campos DISTINTOS, y esa es toda la historia de este módulo:
+ *
+ *   - teléfono → `{ to: "<E.164>" }`
+ *   - BSUID    → `{ recipient_type: "individual", recipient: "<BSUID>" }`
+ *
+ * Se mandaba el BSUID en `to`, donde Meta espera un número. La respuesta era
+ * un 131026 —«el destinatario no puede recibir mensajes de WhatsApp (número
+ * inexistente, sin cuenta o que no acepta mensajes de empresas)»— así que el
+ * CRM le echaba la culpa al cliente del miembro por un campo mal puesto.
+ *
+ * Cuándo llega un contacto sin teléfono, según la documentación de Meta: el
+ * usuario activó el nombre de usuario, no ha habido interacción con ese número
+ * de empresa en 30 días, y no está en la agenda. Las tres a la vez. Por eso
+ * fallaba con unos contactos y con otros no, que es justo lo que lo hacía
+ * parecer un misterio.
+ *
+ * Vive aparte porque hay CUATRO sitios que arman envíos (texto, adjuntos,
+ * ubicación/contactos y plantillas) y con una copia en cada uno bastaría con
+ * olvidar la quinta.
+ */
+export type Destinatario =
+  | { to: string }
+  | { recipient_type: "individual"; recipient: string };
+
+/**
+ * `phone` gana cuando existe: la documentación dice que si van los dos, el
+ * teléfono tiene precedencia, así que mandar ambos solo añadiría ruido.
+ */
+export function destinatarioMeta(
+  phone: string | null,
+  bsuid: string | null
+): Destinatario | null {
+  if (phone) return { to: phone };
+  if (bsuid) return { recipient_type: "individual", recipient: bsuid };
+  return null;
+}
+
+/** ¿Este destinatario es un BSUID? Para decidir qué se puede mandarle. */
+export function esBsuid(d: Destinatario): boolean {
+  return "recipient" in d;
+}

--- a/src/server/dev/wa-mock-state.ts
+++ b/src/server/dev/wa-mock-state.ts
@@ -8,6 +8,13 @@ export type OutboxEntry = {
   n: number;
   phoneNumberId: string;
   to: string;
+  /**
+   * El BSUID, cuando el destinatario iba por `recipient` en vez de `to`.
+   *
+   * Se expone para que un self-test pueda comprobar EN QUE CAMPO viajo: es la
+   * unica diferencia entre el envio que Meta acepta y el que devuelve 131026.
+   */
+  recipient?: string;
   type: string;
   body: unknown;
   at: string;

--- a/src/server/inbox/send.ts
+++ b/src/server/inbox/send.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { getDb, schema } from "@/lib/db";
 import { newId } from "@/lib/db/ids";
 import { graphRequest, MetaApiError, normalizeRecipient } from "@/lib/meta/client";
+import { destinatarioMeta, type Destinatario } from "@/lib/meta/destinatario";
 import { publish } from "@/server/events/bus";
 import {
   getCredentialsByOrg,
@@ -62,6 +63,9 @@ type SendTarget = {
   conversation: typeof schema.conversation.$inferSelect;
   /** null cuando el destino no es WhatsApp (014). */
   credentials: Credentials | null;
+  /** El destinatario en la forma que Meta espera: `to` o `recipient`. */
+  destinatario: Destinatario;
+  /** El identificador a secas, para lo que no arma un payload de Graph. */
   recipient: string;
   /** 014: presente solo en conversaciones de Instagram. */
   instagram?: InstagramCredentials;
@@ -134,6 +138,9 @@ async function prepareSend(
     return {
       conversation: row.conversation,
       credentials: null,
+      // Instagram no pasa por la Graph API de WhatsApp; el campo existe para
+      // cumplir el tipo y su camino de envío no lo mira.
+      destinatario: { to: igRecipient },
       recipient: igRecipient,
       instagram: igCreds,
     };
@@ -167,6 +174,8 @@ async function prepareSend(
     return {
       conversation: row.conversation,
       credentials: null,
+      // Messenger tampoco pasa por la Graph API de WhatsApp.
+      destinatario: { to: fbRecipient },
       recipient: fbRecipient,
       messenger: fbCreds,
     };
@@ -198,19 +207,31 @@ async function prepareSend(
     );
   }
 
-  // 003: el destinatario es el teléfono normalizado o, si el contacto llegó
-  // por BSUID sin teléfono, su Business-Scoped User ID.
-  const recipient = row.contact.phone
-    ? normalizeRecipient(row.contact.phone)
-    : row.contact.waUserId;
-  if (!recipient) {
+  /**
+   * 003 — El destinatario, en el campo que Meta espera para cada forma.
+   *
+   * Un teléfono va en `to`; un BSUID va en `recipient` con
+   * `recipient_type: "individual"`. Se mandaba el BSUID en `to` y Meta
+   * respondía 131026, que en la bandeja se lee como si el número del cliente
+   * no existiera.
+   */
+  const destinatario = destinatarioMeta(
+    row.contact.phone ? normalizeRecipient(row.contact.phone) : null,
+    row.contact.waUserId
+  );
+  const recipient = destinatario
+    ? "to" in destinatario
+      ? destinatario.to
+      : destinatario.recipient
+    : null;
+  if (!destinatario || !recipient) {
     throw new SendError(
       "meta_error",
       "El contacto no tiene teléfono ni identidad de WhatsApp utilizable"
     );
   }
 
-  return { conversation: row.conversation, credentials, recipient };
+  return { conversation: row.conversation, credentials, destinatario, recipient };
 }
 
 async function persistOutbound(input: {
@@ -277,7 +298,7 @@ export async function sendText(input: {
   aiGenerated?: boolean;
 }): Promise<SendResult> {
   const target = await prepareSend(input.conversationId, input.organizationId);
-  const { credentials, recipient } = target;
+  const { credentials } = target;
 
   const waMessageId = target.instagram
     ? await callInstagramSend(target, input.text)
@@ -285,7 +306,7 @@ export async function sendText(input: {
       ? await callMessengerSend(target, input.text)
       : await callGraphSend(credentials!, {
           messaging_product: "whatsapp",
-          to: recipient,
+          ...target.destinatario,
           type: "text",
           text: { body: input.text },
         });
@@ -325,7 +346,7 @@ export async function sendMediaMessage(input: {
   const kind = validateOutgoing(input.file.mimeType, input.file.data.byteLength);
 
   const target = await prepareSend(input.conversationId, input.organizationId);
-  const { credentials, recipient } = target;
+  const { credentials } = target;
   const sendCaps = capabilitiesFor(target.conversation.channel);
   if (!sendCaps.outboundMedia) {
     throw new SendError(
@@ -371,7 +392,7 @@ export async function sendMediaMessage(input: {
     }
     const waMessageId = await callGraphSend(credentials!, {
       messaging_product: "whatsapp",
-      to: recipient,
+      ...target.destinatario,
       type: kind,
       [kind]: mediaPayload,
     });
@@ -441,13 +462,13 @@ export async function sendStructured(
     | { kind: "contacts"; contacts: ContactInput[] }
   )
 ): Promise<SendResult> {
-  const { credentials, recipient } = await prepareSend(
+  const target = await prepareSend(
     input.conversationId,
     input.organizationId
   );
   // Ubicaciones y contactos son mensajes de WhatsApp: en los demás canales no
   // hay credenciales de WhatsApp que usar y Graph los rechazaría.
-  if (!credentials) {
+  if (!target.credentials) {
     throw new SendError(
       "meta_error",
       "Este canal no admite ubicaciones ni contactos; manda el texto"
@@ -465,9 +486,9 @@ export async function sendStructured(
           })),
         };
 
-  const waMessageId = await callGraphSend(credentials, {
+  const waMessageId = await callGraphSend(target.credentials, {
     messaging_product: "whatsapp",
-    to: recipient,
+    ...target.destinatario,
     ...payload,
   });
 

--- a/src/server/whatsapp/templates.ts
+++ b/src/server/whatsapp/templates.ts
@@ -7,6 +7,7 @@ import {
 import { getDb, schema } from "@/lib/db";
 import { newId } from "@/lib/db/ids";
 import { graphRequest, MetaApiError, normalizeRecipient } from "@/lib/meta/client";
+import { destinatarioMeta } from "@/lib/meta/destinatario";
 import { scoped } from "@/lib/db/tenant";
 import { publish } from "@/server/events/bus";
 import {
@@ -343,10 +344,13 @@ export async function sendTemplate(input: {
   }
 
   // 003: destinatario = teléfono normalizado o BSUID.
-  const templateRecipient = row.contact.phone
-    ? normalizeRecipient(row.contact.phone)
-    : row.contact.waUserId;
-  if (!templateRecipient) {
+  // 003: teléfono en `to`, BSUID en `recipient` — Meta los pide en campos
+  // distintos y mandar el BSUID en `to` devuelve 131026.
+  const destinatario = destinatarioMeta(
+    row.contact.phone ? normalizeRecipient(row.contact.phone) : null,
+    row.contact.waUserId
+  );
+  if (!destinatario) {
     throw new TemplateError(
       "meta_error",
       "El contacto no tiene teléfono ni identidad de WhatsApp utilizable"
@@ -355,7 +359,7 @@ export async function sendTemplate(input: {
 
   const waMessageId = await callGraphSend(creds, {
     messaging_product: "whatsapp",
-    to: templateRecipient,
+    ...destinatario,
     type: "template",
     template: {
       name: template.name,

--- a/tests/unit/destinatario-meta.test.ts
+++ b/tests/unit/destinatario-meta.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { destinatarioMeta, esBsuid } from "@/lib/meta/destinatario";
+
+/**
+ * A quién va un mensaje de la Cloud API.
+ *
+ * Meta pide el teléfono y el BSUID en campos DISTINTOS:
+ *
+ *   teléfono → `{ to }`
+ *   BSUID    → `{ recipient_type: "individual", recipient }`
+ *
+ * Se mandaba el BSUID en `to`, donde Meta espera un número, y respondía
+ * 131026 — «el destinatario no puede recibir mensajes de WhatsApp (número
+ * inexistente, sin cuenta o que no acepta mensajes de empresas)». O sea: el
+ * CRM le echaba la culpa al cliente del miembro por un campo mal puesto.
+ *
+ * Se veía solo con algunos contactos porque Meta omite el teléfono cuando
+ * coinciden TRES condiciones: el usuario activó su nombre de usuario, no ha
+ * habido interacción con ese número de empresa en 30 días, y no está en la
+ * agenda. Por eso parecía aleatorio.
+ */
+
+describe("destinatarioMeta", () => {
+  it("un teléfono va en `to`", () => {
+    expect(destinatarioMeta("5214627015001", null)).toEqual({
+      to: "5214627015001",
+    });
+  });
+
+  it("un BSUID va en `recipient`, con su `recipient_type`", () => {
+    expect(destinatarioMeta(null, "CO.1502852711544066")).toEqual({
+      recipient_type: "individual",
+      recipient: "CO.1502852711544066",
+    });
+  });
+
+  /**
+   * La documentación dice que si van los dos, el teléfono tiene precedencia.
+   * Mandar ambos solo añadiría un campo que Meta ignora.
+   */
+  it("con los dos, gana el teléfono y el BSUID no viaja", () => {
+    const d = destinatarioMeta("5214627015001", "CO.150285");
+    expect(d).toEqual({ to: "5214627015001" });
+    expect(JSON.stringify(d)).not.toContain("CO.150285");
+  });
+
+  it("sin ninguno de los dos no hay destinatario", () => {
+    expect(destinatarioMeta(null, null)).toBeNull();
+  });
+
+  /**
+   * La invariante que impide el fallo original: el BSUID NUNCA puede acabar
+   * en `to`. Si alguien invierte la condición, esto lo dice.
+   */
+  it("el BSUID jamás aparece en `to`", () => {
+    const d = destinatarioMeta(null, "CO.1502852711544066")!;
+    expect("to" in d).toBe(false);
+    expect(esBsuid(d)).toBe(true);
+    expect(esBsuid({ to: "521462" })).toBe(false);
+  });
+});


### PR DESCRIPTION
Portado desde el fork multitenant, donde **ya está verificado en producción** con un miembro real: escribió desde un número con nombre de usuario y recibió respuesta.

## Lo que pasaba

Meta pide el teléfono y el BSUID en **campos distintos**:

```
teléfono → { "to": "<E.164>" }
BSUID    → { "recipient_type": "individual", "recipient": "<BSUID>" }
```

Se mandaba el BSUID en `to`, donde Meta espera un número. La respuesta era **131026**:

> El destinatario no puede recibir mensajes de WhatsApp (número inexistente, sin cuenta o que no acepta mensajes de empresas).

Es decir: **el CRM le echaba la culpa al cliente por un campo mal puesto**.

## Por qué solo con algunos contactos

Meta omite el teléfono cuando coinciden **tres** condiciones: el usuario activó su nombre de usuario, no hubo interacción con ese número de empresa en 30 días, y no está en la agenda. Por eso parecía aleatorio y costó tanto de correlacionar.

Confirmado en un log de producción, con el diagnóstico que se añadió para esto:

```
[webhook] mensaje sin teléfono en ninguna parte (contactos: 1, con wa_id: 0)
```

Un contacto en el evento, **cero** con `wa_id`. No es que lo buscáramos mal: no viene.

## El arreglo

El destinatario se arma en un solo módulo. Hay **cuatro** sitios que montan envíos —texto, adjuntos, ubicación/contactos y plantillas— y con una copia en cada uno bastaría con olvidar la quinta.

Cuando van los dos, gana el teléfono: la documentación dice que tiene precedencia.

## Dos cosas del self-test que esto destapa

**1 · El mock era permisivo.** Aceptaba cualquier cosa en `to`, así que el campo equivocado pasaba en verde aquí y fallaba en producción. Ahora responde 131026 ante un `to` que no sea un número, como Meta.

**2 · Una comprobación fijaba el comportamiento equivocado.** «el destinatario del envío es el BSUID» afirmaba que el BSUID viaja en `to` — y pasaba, gracias a ese mismo mock. Ahora comprueba `recipient`.

Ese es el detalle que más me interesa de este PR: **había cobertura de BSUID y estaba verde con el bug puesto**. Un test verde sobre un mock permisivo es peor que no tenerlo, porque convence de lo contrario.

## Comprobado

Con base de datos recién creada:

- `typecheck` · `lint` · `build` · **417 unitarias**
- **self-test 139/139**
- **Mutación**: con el BSUID de vuelta en `to` caen **cuatro** comprobaciones — las dos nuevas y las dos viejas que ahora sí distinguen.

Una de las pruebas unitarias fija la invariante que impide la recaída: **el BSUID jamás aparece en `to`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
